### PR TITLE
fix: add delete confirmation for notes and goals to prevent data loss (#55)

### DIFF
--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -23,6 +23,7 @@
   let goalSearchQuery = $state('');
   let goalFilterState = $state<string | null>(null);
   let pinnedGoals = $state<Set<number>>(new Set());
+  let deleteConfirm = $state<number | null>(null);
 
   function filteredGoals(goals: Goal[], query: string, filter: string | null, pinned: Set<number>) {
     let result = goals;
@@ -274,8 +275,13 @@
   }
 
   async function deleteGoal(id: number) {
+    if (deleteConfirm !== id) {
+      deleteConfirm = id;
+      return;
+    }
     await api.goals.delete(id);
     goals = goals.filter(g => g.id !== id);
+    deleteConfirm = null;
   }
 
   function formatFailConfig(config: string) {
@@ -853,6 +859,7 @@
 
 <svelte:window onkeydown={(e) => {
   if (e.key === 'Escape') {
+    if (deleteConfirm !== null) { deleteConfirm = null; return; }
     showAddForm = false;
     editingGoal = null;
   }
@@ -982,7 +989,12 @@
                   <Ban size={14} />
                 </button>
               {/if}
-              <button class="btn btn-ghost text-muted" title="Eliminar" onclick={() => deleteGoal(goal.id)}>×</button>
+              {#if deleteConfirm === goal.id}
+                <button class="btn btn-ghost text-danger" onclick={() => deleteGoal(goal.id)}>¿Eliminar?</button>
+                <button class="btn btn-ghost text-muted" onclick={() => deleteConfirm = null}>Cancelar</button>
+              {:else}
+                <button class="btn btn-ghost text-muted" title="Eliminar" onclick={() => deleteGoal(goal.id)}>×</button>
+              {/if}
               <button class="btn btn-ghost text-muted" title="Editar" onclick={() => openGoalEditor(goal)}>
                 <Pencil size={13} />
               </button>

--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -24,6 +24,7 @@
   let dailySourcePath: string | null = null;
   let dailyInitialTitle = '';
   let dailyNotesConfigured = false;
+  let deleteConfirm = false;
 
   // Folder customization
   let editingFolder: string | null = null;
@@ -481,8 +482,13 @@
   }
 
   async function handleDelete() {
+    if (!deleteConfirm) {
+      deleteConfirm = true;
+      return;
+    }
     if (selectedNote) {
       await deleteNote(selectedNote.id);
+      deleteConfirm = false;
       closeEditor();
     }
   }
@@ -554,7 +560,7 @@
   }
 </script>
 
-<svelte:window on:click={() => { if (showSortMenu) showSortMenu = false; }} />
+<svelte:window on:click={() => { if (showSortMenu) showSortMenu = false; }} on:keydown={(e) => e.key === 'Escape' && (deleteConfirm = false)} />
 
 <div
   class="notes-page"
@@ -765,6 +771,16 @@
 
   <!-- ── Editor panel ──────────────────────────────────────────────────────── -->
   <div class="editor-panel">
+    {#if deleteConfirm}
+      <div class="delete-confirm-bar">
+        <span class="delete-confirm-text">¿Eliminar esta nota?</span>
+        <span class="delete-confirm-hint">Esta acción no se puede deshacer.</span>
+        <div class="delete-confirm-actions">
+          <button class="btn-cancel" on:click={() => deleteConfirm = false}>Cancelar</button>
+          <button class="btn-danger" on:click={handleDelete}>Eliminar</button>
+        </div>
+      </div>
+    {/if}
     {#if showEditor}
       {#key editingNew ? (isMomentary ? 'momentary' : 'new') : selectedNote?.id}
         <NoteEditor
@@ -1414,6 +1430,57 @@
     color: var(--xp-contrast-text, var(--bg));
   }
   .folder-modal-btns button:last-child:hover {
+    opacity: 0.85;
+  }
+
+  /* ── Delete confirmation bar ── */
+  .delete-confirm-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .delete-confirm-text {
+    font-size: 13px;
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+  .delete-confirm-hint {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    flex: 1;
+  }
+  .delete-confirm-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+  .delete-confirm-actions .btn-cancel,
+  .delete-confirm-actions .btn-danger {
+    padding: 6px 14px;
+    border-radius: var(--r);
+    font-size: 12px;
+    cursor: pointer;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text-secondary);
+    font-family: var(--font-sans);
+    transition: all var(--t-fast);
+  }
+  .delete-confirm-actions .btn-cancel:hover {
+    border-color: var(--text-muted);
+    color: var(--text-primary);
+  }
+  .delete-confirm-actions .btn-danger {
+    background: var(--error, #ef4444);
+    border-color: var(--error, #ef4444);
+    color: #fff;
+  }
+  .delete-confirm-actions .btn-danger:hover {
     opacity: 0.85;
   }
 </style>


### PR DESCRIPTION
## Summary
Fixes #55 — Notes and goals were deleted without confirmation.
Added a two-click confirmation pattern (matching what streaks already use).

## Changes
- First click on delete button shows confirmation state
- Second click executes the deletion
- Cancel button to abort
- Applied to both notes (+page.svelte) and goals (+page.svelte)

## Testing
- Verified delete requires two clicks
- Verified cancel resets state
- Tested with single and rapid double-clicks