### PR TITLE
feat: add syntax highlighting to code blocks in markdown (#62)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "d3": "^7.9.0",
         "force-graph": "^1.47.0",
+        "highlight.js": "^11.11.1",
         "lucide-svelte": "^0.468.0",
         "marked": "^12.0.0"
       },
@@ -2656,6 +2657,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-encoding-sniffer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "d3": "^7.9.0",
     "force-graph": "^1.47.0",
+    "highlight.js": "^11.11.1",
     "lucide-svelte": "^0.468.0",
     "marked": "^12.0.0"
   },

--- a/frontend/src/lib/components/GoalEditor.svelte
+++ b/frontend/src/lib/components/GoalEditor.svelte
@@ -2,9 +2,25 @@
   import { createEventDispatcher } from 'svelte';
   import { Eye, EyeOff, Save, Trash2, X, Maximize, ChevronLeft, ChevronRight, Settings } from 'lucide-svelte';
   import { marked } from 'marked';
+  import hljs from 'highlight.js';
+  import 'highlight.js/styles/github-dark.css';
   import { api, type Goal } from '$lib/api';
 
-  marked.use({ gfm: true, breaks: true });
+  const renderer = new marked.Renderer();
+  renderer.code = (code: string, infostring: string | undefined, _escaped: boolean) => {
+    const lang = infostring || '';
+    const language = lang && hljs.getLanguage(lang) ? lang : '';
+    let highlighted: string;
+    try {
+      highlighted = language
+        ? hljs.highlight(code, { language }).value
+        : hljs.highlightAuto(code).value;
+    } catch {
+      highlighted = code;
+    }
+    return `<pre><code class="hljs language-${language || 'auto'}">${highlighted}</code></pre>`;
+  };
+  marked.use({ gfm: true, breaks: true, renderer });
 
   export let goal: Goal | null = null;
   export let content: string = '';

--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -5,6 +5,8 @@
   import DynamicIcon from './DynamicIcon.svelte';
   import IconPicker from './IconPicker.svelte';
   import { marked } from 'marked';
+  import hljs from 'highlight.js';
+  import 'highlight.js/styles/github-dark.css';
   import TagChip from './TagChip.svelte';
   import { aiSuggestions, fetchAISuggestions, findNoteByTitle } from '$lib/stores/notes';
   import { activeIconPack, showFrontmatter, hideTagsLine } from '$lib/stores/settings';
@@ -15,8 +17,22 @@
   import { downloadMarkdown, downloadHTML, copyNoteAsMarkdown } from '$lib/utils/export';
   import { showNotification } from '$lib/stores/gamification';
 
-  // Configure marked once — GFM enables tables, strikethrough, autolinks
-  marked.use({ gfm: true, breaks: true });
+  // Configure marked with GFM and syntax highlighting via highlight.js
+  const renderer = new marked.Renderer();
+  renderer.code = (code: string, infostring: string | undefined, _escaped: boolean) => {
+    const lang = infostring || '';
+    const language = lang && hljs.getLanguage(lang) ? lang : '';
+    let highlighted: string;
+    try {
+      highlighted = language
+        ? hljs.highlight(code, { language }).value
+        : hljs.highlightAuto(code).value;
+    } catch {
+      highlighted = code;
+    }
+    return `<pre><code class="hljs language-${language || 'auto'}">${highlighted}</code></pre>`;
+  };
+  marked.use({ gfm: true, breaks: true, renderer });
 
   export let note: Note | null = null;
   export let momentary = false;


### PR DESCRIPTION
## Summary
Fixes #62 — Code blocks in notes and goals were rendered as plain text.
Added highlight.js with github-dark theme for syntax-colored code blocks.

## Changes
- Added highlight.js dependency
- Configured marked with custom code renderer
- Applied to NoteEditor.svelte and GoalEditor.svelte
- Supports 190+ languages (Python, JS, TS, Bash, JSON, YAML, SQL, etc.)

## Testing
- Verified Python, JS, Bash, JSON code blocks render with colors
- Verified auto-language detection for unspecified blocks
- Works in both edit preview and goal editor