### PR TITLE
feat: make graph and skills pages publicly accessible (#48)

### DIFF
--- a/frontend/src/routes/graph/+page.svelte
+++ b/frontend/src/routes/graph/+page.svelte
@@ -2,7 +2,6 @@
   import { onMount } from 'svelte';
   import KnowledgeGraphForce from '$lib/components/KnowledgeGraphForce.svelte';
   import { graphData, graphLoading, loadGraph, selectedTag } from '$lib/stores/graph';
-  import { devMode } from '$lib/stores/settings';
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
   import type { GraphNode, GraphEdge } from '$lib/api';
 
@@ -30,39 +29,6 @@
   });
 </script>
 
-{#if !$devMode}
-  <div class="integration-page">
-    <div class="page-header">
-      <div class="header-icon">
-        <DynamicIcon name="Network" size={28} />
-      </div>
-      <div class="header-text">
-        <h2>Grafo de Notas</h2>
-        <span class="caption">Visualización de conexiones entre notas</span>
-      </div>
-    </div>
-
-    <div class="content">
-      <div class="construction-box">
-        <DynamicIcon name="Construction" size={48} />
-        <h3>En Construcción</h3>
-        <p>Esta sección está en desarrollo. Activa el Modo Desarrollo en Ajustes para ver la implementación actual.</p>
-      </div>
-    </div>
-  </div>
-
-  <style>
-    .integration-page { padding: 24px; max-width: 800px; margin: 0 auto; }
-    .page-header { display: flex; align-items: center; gap: 16px; margin-bottom: 32px; padding-bottom: 16px; border-bottom: 1px solid var(--border); }
-    .header-icon { width: 56px; height: 56px; display: flex; align-items: center; justify-content: center; background: var(--elevated); border: 1px solid var(--border); border-radius: var(--r); color: var(--accent); }
-    .header-text h2 { font-size: 20px; font-weight: 600; margin: 0; color: var(--text-primary); }
-    .header-text .caption { font-size: 13px; color: var(--text-muted); }
-    .construction-box { display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding: 48px 24px; background: var(--elevated); border: 2px dashed var(--border); border-radius: var(--r-lg); color: var(--text-muted); }
-    .construction-box :global(svg) { margin-bottom: 16px; opacity: 0.6; }
-    .construction-box h3 { font-size: 18px; font-weight: 600; margin: 0 0 8px 0; color: var(--text-secondary); }
-    .construction-box p { font-size: 14px; max-width: 400px; margin: 0; line-height: 1.5; }
-  </style>
-{:else}
 
 <div class="graph-page">
   <div class="graph-header">
@@ -205,4 +171,3 @@
     opacity: 0.7;
   }
 </style>
-{/if}

--- a/frontend/src/routes/skills/+page.svelte
+++ b/frontend/src/routes/skills/+page.svelte
@@ -3,7 +3,6 @@
   import SkillTree from '$lib/components/SkillTree.svelte';
   import { api, type Skill, type SkillTree as SkillTreeData } from '$lib/api';
   import { logger } from '$lib/utils/logger';
-  import { devMode } from '$lib/stores/settings';
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
 
   let skills: Skill[] = [];
@@ -31,39 +30,6 @@
   });
 </script>
 
-{#if !$devMode}
-  <div class="integration-page">
-    <div class="page-header">
-      <div class="header-icon">
-        <DynamicIcon name="Zap" size={28} />
-      </div>
-      <div class="header-text">
-        <h2>Habilidades</h2>
-        <span class="caption">Árbol de habilidades y progresión</span>
-      </div>
-    </div>
-
-    <div class="content">
-      <div class="construction-box">
-        <DynamicIcon name="Construction" size={48} />
-        <h3>En Construcción</h3>
-        <p>Esta sección está en desarrollo. Activa el Modo Desarrollo en Ajustes para ver la implementación actual.</p>
-      </div>
-    </div>
-  </div>
-
-  <style>
-    .integration-page { padding: 24px; max-width: 800px; margin: 0 auto; }
-    .page-header { display: flex; align-items: center; gap: 16px; margin-bottom: 32px; padding-bottom: 16px; border-bottom: 1px solid var(--border); }
-    .header-icon { width: 56px; height: 56px; display: flex; align-items: center; justify-content: center; background: var(--elevated); border: 1px solid var(--border); border-radius: var(--r); color: var(--accent); }
-    .header-text h2 { font-size: 20px; font-weight: 600; margin: 0; color: var(--text-primary); }
-    .header-text .caption { font-size: 13px; color: var(--text-muted); }
-    .construction-box { display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding: 48px 24px; background: var(--elevated); border: 2px dashed var(--border); border-radius: var(--r-lg); color: var(--text-muted); }
-    .construction-box :global(svg) { margin-bottom: 16px; opacity: 0.6; }
-    .construction-box h3 { font-size: 18px; font-weight: 600; margin: 0 0 8px 0; color: var(--text-secondary); }
-    .construction-box p { font-size: 14px; max-width: 400px; margin: 0; line-height: 1.5; }
-  </style>
-{:else}
 
 <div class="skills-page">
   <div class="skills-header">
@@ -266,4 +232,3 @@
   .legend-dot[data-level='expert']     { border-color: var(--accent); }
   .legend-dot[data-level='master']     { background: var(--accent); border-color: var(--accent); }
 </style>
-{/if}


### PR DESCRIPTION
Closes #48

Removes the dev-mode gating wrapper from graph and skills pages, making them accessible to all users by default.