### PR TITLE
fix: Streaks hover-only action buttons now work on mobile

### DIFF
--- a/frontend/src/routes/streaks/+page.svelte
+++ b/frontend/src/routes/streaks/+page.svelte
@@ -941,13 +941,26 @@
   .item-actions {
     display: flex; flex-direction: column; gap: 3px;
     position: absolute; top: 6px; right: 6px;
-    opacity: 0; pointer-events: none;
     transition: opacity 0.15s;
   }
 
-  .streak-item:hover .item-actions {
-    opacity: 1;
-    pointer-events: auto;
+  @media (hover: hover) {
+    .item-actions {
+      opacity: 0; pointer-events: none;
+    }
+    .streak-item:hover .item-actions {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
+
+  @media (hover: none) {
+    .item-actions {
+      opacity: 0.5;
+    }
+    .item-action-btn {
+      width: 24px; height: 24px;
+    }
   }
 
   .item-action-btn {


### PR DESCRIPTION
## Cambios

- Envuelve el comportamiento hover de los botones de acción (editar/eliminar racha) en `@media (hover: hover)` para escritorio
- Agrega `@media (hover: none)` para dispositivos táctiles: los botones se muestran siempre con opacidad reducida
- Aumenta ligeramente el tamaño de los botones en táctil (24px vs 20px) para mejor ergonomía

Closes #118