### PR TITLE
feat: Modal focus trapping and ARIA attributes (a11y)

### DIFF
--- a/frontend/src/lib/actions/focusTrap.ts
+++ b/frontend/src/lib/actions/focusTrap.ts
@@ -1,0 +1,52 @@
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+let previousActiveElement: Element | null = null;
+
+export function focusTrap(node: HTMLElement) {
+  previousActiveElement = document.activeElement;
+
+  function getFocusable(): HTMLElement[] {
+    return Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE));
+  }
+
+  function trapFocus(e: KeyboardEvent) {
+    if (e.key !== 'Tab') return;
+    const focusable = getFocusable();
+    if (focusable.length === 0) {
+      e.preventDefault();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  function focusFirst() {
+    const focusable = getFocusable();
+    if (focusable.length > 0) {
+      focusable[0].focus();
+    } else {
+      node.focus();
+    }
+  }
+
+  focusFirst();
+  node.addEventListener('keydown', trapFocus);
+
+  return {
+    destroy() {
+      node.removeEventListener('keydown', trapFocus);
+      if (previousActiveElement instanceof HTMLElement) {
+        previousActiveElement.focus();
+      }
+    }
+  };
+}

--- a/frontend/src/lib/components/Modal.svelte
+++ b/frontend/src/lib/components/Modal.svelte
@@ -2,6 +2,7 @@
   import { fade, scale } from 'svelte/transition';
   import { uiModal, closeModal } from '$lib/stores/ui';
   import DynamicIcon from './DynamicIcon.svelte';
+  import { focusTrap } from '$lib/actions/focusTrap';
 
   export let title = '';
   export let size: 'sm' | 'md' | 'lg' = 'md';
@@ -16,14 +17,22 @@
 <svelte:window on:keydown={handleKeydown} />
 
 {#if $uiModal.isOpen}
-  <div class="modal-overlay" transition:fade={{ duration: 150 }} on:click|self={closeModal}>
+  <div
+    class="modal-overlay"
+    role="dialog"
+    aria-modal="true"
+    aria-label={title || 'Diálogo'}
+    transition:fade={{ duration: 150 }}
+    on:click|self={closeModal}
+  >
     <div
       class="modal modal-{size}"
       transition:scale={{ duration: 200, start: 0.95 }}
+      use:focusTrap
     >
       <div class="modal-header">
         <h3 class="modal-title">{title}</h3>
-        <button class="modal-close" on:click={closeModal}>
+        <button class="modal-close" autofocus on:click={closeModal}>
           <DynamicIcon name="X" size={18} />
         </button>
       </div>


### PR DESCRIPTION
## Cambios

- Crea `focusTrap.ts` action: atrapa el foco Tab dentro del modal, cicla entre primer/último elemento
- Restaura el foco al elemento activo anterior al cerrar el modal
- Agrega `role="dialog"`, `aria-modal="true"`, `aria-label` al overlay del modal
- `autofocus` en botón de cierre para foco inicial

Closes #9