### PR TITLE
feat: Weekly activity progress bar in dashboard

### DIFF
--- a/frontend/src/lib/components/ActivityProgress.svelte
+++ b/frontend/src/lib/components/ActivityProgress.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { api } from '$lib/api';
+
+  let weeklyData: { date: string; notes_created: number; xp_events: number }[] = [];
+  let xpEventsWeek = 0;
+  let loading = true;
+
+  function getWeekBounds(): { start: Date; end: Date } {
+    const now = new Date();
+    const day = now.getDay();
+    const diff = day === 0 ? 6 : day - 1;
+    const monday = new Date(now);
+    monday.setDate(now.getDate() - diff);
+    monday.setHours(0, 0, 0, 0);
+    const sunday = new Date(monday);
+    sunday.setDate(monday.getDate() + 6);
+    sunday.setHours(23, 59, 59, 999);
+    return { start: monday, end: sunday };
+  }
+
+  function isSameDay(a: Date, b: Date): boolean {
+    return a.getFullYear() === b.getFullYear()
+      && a.getMonth() === b.getMonth()
+      && a.getDate() === b.getDate();
+  }
+
+  $: dayLabels = ['L', 'M', 'X', 'J', 'V', 'S', 'D'];
+
+  $: weekDays = (() => {
+    const { start } = getWeekBounds();
+    const days: { label: string; active: boolean; date: Date }[] = [];
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(start);
+      d.setDate(start.getDate() + i);
+      const active = weeklyData.some(w => {
+        const wd = new Date(w.date + 'T00:00:00');
+        return isSameDay(wd, d) && (w.notes_created > 0 || w.xp_events > 0);
+      });
+      days.push({ label: dayLabels[i], active, date: d });
+    }
+    return days;
+  })();
+
+  $: notesThisWeek = weeklyData
+    .filter(w => {
+      const wd = new Date(w.date + 'T00:00:00');
+      const { start, end } = getWeekBounds();
+      return wd >= start && wd <= end;
+    })
+    .reduce((sum, d) => sum + d.notes_created, 0);
+
+  $: activeDays = weekDays.filter(d => d.active).length;
+
+  onMount(async () => {
+    try {
+      const [activity, system] = await Promise.all([
+        api.stats.activity(30),
+        api.stats.system(),
+      ]);
+      weeklyData = activity.days;
+      xpEventsWeek = system.xp_events_week;
+    } catch {
+      weeklyData = [];
+    } finally {
+      loading = false;
+    }
+  });
+</script>
+
+<div class="activity-progress">
+  {#if loading}
+    <div class="loading-pulse" />
+  {:else}
+    <div class="week-strip">
+      {#each weekDays as day}
+        <div
+          class="day-cell"
+          class:active={day.active}
+          title={day.date.toLocaleDateString('es-ES', { weekday: 'long', day: 'numeric', month: 'short' })}
+        >
+          <span class="day-label">{day.label}</span>
+        </div>
+      {/each}
+    </div>
+
+    <div class="week-stats">
+      <div class="stat-item">
+        <span class="stat-value">{activeDays}/7</span>
+        <span class="stat-label">días activos</span>
+      </div>
+      <div class="stat-item">
+        <span class="stat-value">{notesThisWeek}</span>
+        <span class="stat-label">notas</span>
+      </div>
+      <div class="stat-item">
+        <span class="stat-value">{xpEventsWeek}</span>
+        <span class="stat-label">eventos XP</span>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .activity-progress {
+    width: 100%;
+    padding: 8px 0;
+  }
+
+  .loading-pulse {
+    height: 48px;
+    background: var(--border-light);
+    border-radius: var(--r);
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 0.8; }
+  }
+
+  .week-strip {
+    display: flex;
+    gap: 4px;
+    justify-content: center;
+    margin-bottom: 10px;
+  }
+
+  .day-cell {
+    width: 28px;
+    height: 32px;
+    border-radius: 4px;
+    background: var(--border-light);
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    transition: background var(--t-fast);
+  }
+
+  .day-cell.active {
+    background: var(--accent);
+  }
+
+  .day-label {
+    font-size: 9px;
+    color: var(--text-muted);
+    padding-bottom: 3px;
+  }
+
+  .day-cell.active .day-label {
+    color: var(--bg);
+  }
+
+  .week-stats {
+    display: flex;
+    justify-content: space-around;
+  }
+
+  .stat-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1px;
+  }
+
+  .stat-value {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .stat-label {
+    font-size: 9px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+</style>

--- a/frontend/src/lib/stores/layout.ts
+++ b/frontend/src/lib/stores/layout.ts
@@ -4,6 +4,7 @@ import { writable } from 'svelte/store';
 export type WidgetId =
   | 'plant-carousel'
   | 'stats-xp'
+  | 'activity-progress'
   | 'time-widget'
   | 'weather-widget'
   | 'pomodoro'
@@ -17,9 +18,10 @@ export interface WidgetMeta {
 }
 
 export const WIDGET_REGISTRY: Record<WidgetId, WidgetMeta> = {
-  'plant-carousel': { id: 'plant-carousel', label: 'Módulo visual', panel: 'left'  },
-  'stats-xp':       { id: 'stats-xp',       label: 'Estadísticas y XP',   panel: 'left'  },
-  'time-widget':    { id: 'time-widget',    label: 'Reloj',        panel: 'left'  },
+  'plant-carousel':    { id: 'plant-carousel',    label: 'Módulo visual',          panel: 'left'  },
+  'stats-xp':          { id: 'stats-xp',          label: 'Estadísticas y XP',      panel: 'left'  },
+  'activity-progress': { id: 'activity-progress', label: 'Actividad semanal',      panel: 'left'  },
+  'time-widget':       { id: 'time-widget',       label: 'Reloj',                  panel: 'left'  },
   'weather-widget': { id: 'weather-widget', label: 'Clima',         panel: 'left'  },
   'pomodoro':       { id: 'pomodoro',        label: 'Pomodoro',     panel: 'left'  },
   'recent-notes':   { id: 'recent-notes',    label: 'Notas',        panel: 'right' },
@@ -33,7 +35,7 @@ export interface DashboardLayout {
 }
 
 const DEFAULT: DashboardLayout = {
-  left:  ['plant-carousel', 'stats-xp', 'time-widget', 'pomodoro'],
+  left:  ['plant-carousel', 'stats-xp', 'activity-progress', 'time-widget', 'pomodoro'],
   right: ['recent-notes', 'github-issues'],
 };
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -18,6 +18,7 @@
   import Widget         from '$lib/components/Widget.svelte';
   import GithubWidget from '$lib/components/GithubWidget.svelte';
   import { totalXP, currentStreak, lastActivity, nextStageXP } from '$lib/stores/gamification';
+  import ActivityProgress from '$lib/components/ActivityProgress.svelte';
   import { notes, loadNotes, notesLoadedOnce } from '$lib/stores/notes';
   import { dashboardLayout } from '$lib/stores/layout';
   import { accentColors } from '$lib/stores/settings';
@@ -330,7 +331,6 @@
 
         {:else if wid === 'stats-xp'}
           <div class="widget-centered">
-            <!-- XPBar moved to footer -->
             <div class="stats-row">
               <div class="stat">
                 <span class="stat-value mono">{$currentStreak}</span>
@@ -353,6 +353,9 @@
               </div>
             </div>
           </div>
+
+        {:else if wid === 'activity-progress'}
+          <ActivityProgress />
 
         {:else if wid === 'time-widget'}
           <TimeWidget />
@@ -480,6 +483,9 @@
 
         {:else if wid === 'pomodoro'}
           <PomodoroWidget />
+
+        {:else if wid === 'activity-progress'}
+          <ActivityProgress />
         {/if}
 
       </Widget>


### PR DESCRIPTION
## Cambios

- Nuevo componente `ActivityProgress.svelte`: muestra un heat strip de 7 días (L-D) con actividad de notas/XP, más contadores de días activos, notas creadas y eventos XP esta semana
- Registrado como widget `activity-progress` en el layout del dashboard
- Agregado al layout por defecto (panel izquierdo, después de stats-xp)
- Datos de `/stats/activity` y `/stats/system`

Closes #76