### PR TITLE
feat: Bulk operations on notes

### DIFF
--- a/api/routers/notes.py
+++ b/api/routers/notes.py
@@ -21,6 +21,9 @@ from services.note_service import (
     delete_note as delete_note_service,
 )
 from services.note_service import (
+    get_or_create_tag,
+)
+from services.note_service import (
     list_backlinks as list_backlinks_service,
 )
 from services.note_service import (
@@ -32,6 +35,8 @@ from services.note_service import (
 from services.note_service import (
     update_note as update_note_service,
 )
+from services.skill_tree import sync_skills_for_tags
+from services.tag_graph import sync_tag_cooccurrences_for_tags
 from sqlalchemy.orm import Session, selectinload
 
 router = APIRouter(prefix="/notes", tags=["notes"])
@@ -146,6 +151,15 @@ class NoteResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class BulkIds(BaseModel):
+    ids: list[int]
+
+
+class BulkTagRequest(BaseModel):
+    ids: list[int]
+    tags: list[str]
+
+
 def _is_truthy_header(value: str | None) -> bool:
     return value is not None and value.lower() in {"1", "true", "yes", "on"}
 
@@ -230,6 +244,60 @@ def update_note(
 def rebuild_derived(db: Session = Depends(get_db)):
     rebuild_note_derived_data(db)
     return {"status": "ok"}
+
+
+@router.post("/bulk-delete", status_code=200)
+def bulk_delete(data: BulkIds, db: Session = Depends(get_db)):
+    deleted = 0
+    for nid in data.ids:
+        if delete_note_service(db, nid):
+            deleted += 1
+    return {"deleted": deleted, "total": len(data.ids)}
+
+
+@router.post("/bulk-tag", status_code=200)
+def bulk_tag(data: BulkTagRequest, db: Session = Depends(get_db)):
+    touched_tags: set[int] = set()
+    added = 0
+    for nid in data.ids:
+        note = db.query(Note).filter(Note.id == nid).first()
+        if not note:
+            continue
+        existing = {nt.tag_id for nt in note.tags}
+        for tag_name in data.tags:
+            tag = get_or_create_tag(db, tag_name)
+            if tag.id not in existing:
+                db.add(NoteTag(note_id=nid, tag_id=tag.id))
+                touched_tags.add(tag.id)
+                added += 1
+    if touched_tags:
+        sync_tag_cooccurrences_for_tags(db, touched_tags)
+        sync_skills_for_tags(db, touched_tags)
+    db.commit()
+    return {"added": added, "notes": len(data.ids), "tags": data.tags}
+
+
+@router.post("/bulk-untag", status_code=200)
+def bulk_untag(data: BulkTagRequest, db: Session = Depends(get_db)):
+    removed = 0
+    touched_tags: set[int] = set()
+    for nid in data.ids:
+        for tag_name in data.tags:
+            tag = db.query(Tag).filter(Tag.name == tag_name.lower().strip()).first()
+            if not tag:
+                continue
+            nt = db.query(NoteTag).filter(
+                NoteTag.note_id == nid, NoteTag.tag_id == tag.id
+            ).first()
+            if nt:
+                db.delete(nt)
+                touched_tags.add(tag.id)
+                removed += 1
+    if touched_tags:
+        sync_tag_cooccurrences_for_tags(db, touched_tags)
+        sync_skills_for_tags(db, touched_tags)
+    db.commit()
+    return {"removed": removed, "notes": len(data.ids), "tags": data.tags}
 
 
 @router.delete("/{note_id}", status_code=204)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -210,6 +210,9 @@ export const api = {
     update: (id: number, data: Partial<{ title: string; content: string; tags: string[] }>) =>
       req<Note & { gamification: GamificationResult }>('PUT', `/notes/${id}`, data),
     delete: (id: number)   => req<void>('DELETE', `/notes/${id}`),
+    bulkDelete: (ids: number[]) => req<{ deleted: number; total: number }>('POST', '/notes/bulk-delete', { ids }),
+    bulkTag: (ids: number[], tags: string[]) => req<{ added: number; notes: number; tags: string[] }>('POST', '/notes/bulk-tag', { ids, tags }),
+    bulkUntag: (ids: number[], tags: string[]) => req<{ removed: number; notes: number; tags: string[] }>('POST', '/notes/bulk-untag', { ids, tags }),
     acceptTag: (noteId: number, tag: string) =>
       req<{ tag: string; gamification: GamificationResult }>('POST', `/notes/${noteId}/accept-tag?tag_name=${encodeURIComponent(tag)}`),
     backlinks: (id: number) => req<Note[]>('GET', `/notes/${id}/backlinks`),

--- a/frontend/src/lib/components/NoteCard.svelte
+++ b/frontend/src/lib/components/NoteCard.svelte
@@ -13,8 +13,10 @@
   export let note: Note;
   export let active = false;
   export let showTags = true;
+  export let selected = false;
+  export let bulkMode = false;
 
-  const dispatch = createEventDispatcher<{ select: Note; delete: number; customize: { path: string; icon: string | null; color: string | null; note?: Note } }>();
+  const dispatch = createEventDispatcher<{ select: Note; delete: number; customize: { path: string; icon: string | null; color: string | null; note?: Note }; toggleSelect: number }>();
 
   function formatDate(iso: string): string {
     const d = new Date(iso);
@@ -57,14 +59,30 @@
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
-<div class="note-card" class:active on:click={() => dispatch('select', note)}>
+<div
+  class="note-card"
+  class:active
+  class:bulk-selected={selected}
+  on:click={() => bulkMode ? dispatch('toggleSelect', note.id) : dispatch('select', note)}
+>
   <div class="note-header">
+    {#if bulkMode}
+      <input
+        type="checkbox"
+        class="note-checkbox"
+        checked={selected}
+        on:click|stopPropagation
+        on:change={() => dispatch('toggleSelect', note.id)}
+      />
+    {/if}
     <div class="note-icon"><DynamicIcon name={meta.icon} size={12} color={meta.color} pack={meta.pack} /></div>
     <span class="note-title truncate">{note.title}</span>
     <span class="note-date caption">{formatDate(note.created_at)}</span>
-    <button type="button" class="note-settings-btn" title="Personalizar" on:click={onCustomize}>
-      <Settings size={10} />
-    </button>
+    {#if !bulkMode}
+      <button type="button" class="note-settings-btn" title="Personalizar" on:click={onCustomize}>
+        <Settings size={10} />
+      </button>
+    {/if}
   </div>
   {#if showTags && note.tags.length > 0}
     <div class="note-tags">
@@ -82,8 +100,6 @@
     </div>
   {/if}
 
-  </div>
-
 <style>
   .note-card {
     padding: var(--s3) var(--s4);
@@ -95,30 +111,11 @@
 
   .note-card:hover { background: var(--elevated); }
   .note-card.active { background: var(--elevated); border-left: 2px solid var(--text-secondary); }
-
-  .note-settings-btn {
-    display: none;
-    padding: 2px;
-    background: transparent;
-    border: none;
-    color: var(--text-muted);
-    cursor: pointer;
-    border-radius: 3px;
-    margin-left: auto;
-  }
-
-  .note-card:hover .note-settings-btn {
-    display: flex;
-  }
-
-  .note-settings-btn:hover {
-    color: var(--accent);
-    background: var(--border-light);
-  }
+  .note-card.bulk-selected { background: var(--elevated); border-left: 2px solid var(--accent); }
 
   .note-header {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: var(--s3);
     margin-bottom: 4px;
   }
@@ -127,6 +124,7 @@
     font-size: 13px;
     color: var(--text-primary);
     font-weight: 400;
+    flex: 1;
   }
 
   .note-date {
@@ -138,11 +136,16 @@
     margin-right: 4px;
   }
 
+  .note-checkbox {
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+    accent-color: var(--accent);
+    cursor: pointer;
+  }
+
   .note-settings-btn {
-    position: absolute;
-    right: 8px;
-    top: 50%;
-    transform: translateY(-50%);
+    flex-shrink: 0;
     display: none;
     padding: 2px;
     background: transparent;

--- a/frontend/src/lib/stores/notes.ts
+++ b/frontend/src/lib/stores/notes.ts
@@ -9,6 +9,8 @@ export const currentNote  = writable<Note | null>(null);
 export const aiSuggestions = writable<AISuggestion[]>([]);
 export const notesLoading  = writable(false);
 export const notesLoadedOnce = writable(false);
+export const selectedNoteIds = writable<Set<number>>(new Set());
+export const bulkMode = writable(false);
 
 let notesLoaded = false;
 let lastTag: string | undefined = undefined;
@@ -99,6 +101,59 @@ export async function deleteNote(id: number): Promise<void> {
     currentNote.update(n => (n?.id === id ? null : n));
   } catch (e) {
     logger.error('[notes] Failed to delete:', e);
+  }
+}
+
+export function toggleNoteSelection(id: number) {
+  selectedNoteIds.update(s => {
+    const next = new Set(s);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    return next;
+  });
+}
+
+export function selectAllNotes() {
+  selectedNoteIds.update(() => new Set(get(notes).map(n => n.id)));
+}
+
+export function clearNoteSelection() {
+  selectedNoteIds.update(() => new Set());
+}
+
+export async function deleteSelectedNotes(): Promise<void> {
+  const ids = Array.from(get(selectedNoteIds));
+  if (ids.length === 0) return;
+  try {
+    await api.notes.bulkDelete(ids);
+    notes.update(ns => ns.filter(n => !ids.includes(n.id)));
+    currentNote.update(n => (n && ids.includes(n.id)) ? null : n);
+    clearNoteSelection();
+  } catch (e) {
+    logger.error('[notes] Failed to bulk delete:', e);
+  }
+}
+
+export async function tagSelectedNotes(tags: string[]): Promise<void> {
+  const ids = Array.from(get(selectedNoteIds));
+  if (ids.length === 0 || tags.length === 0) return;
+  try {
+    await api.notes.bulkTag(ids, tags);
+    notes.update(ns => ns.map(n => ids.includes(n.id) ? { ...n, tags: [...new Set([...n.tags, ...tags])] } : n));
+  } catch (e) {
+    logger.error('[notes] Failed to bulk tag:', e);
+  }
+}
+
+export async function untagSelectedNotes(tags: string[]): Promise<void> {
+  const ids = Array.from(get(selectedNoteIds));
+  if (ids.length === 0 || tags.length === 0) return;
+  try {
+    await api.notes.bulkUntag(ids, tags);
+    const tagSet = new Set(tags.map(t => t.toLowerCase().trim()));
+    notes.update(ns => ns.map(n => ids.includes(n.id) ? { ...n, tags: n.tags.filter(t => !tagSet.has(t.toLowerCase().trim())) } : n));
+  } catch (e) {
+    logger.error('[notes] Failed to bulk untag:', e);
   }
 }
 

--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -8,7 +8,7 @@
   import NoteCard from '$lib/components/NoteCard.svelte';
   import IconPicker from '$lib/components/IconPicker.svelte';
   import VirtualList from '$lib/components/VirtualList.svelte';
-  import { notes, notesLoading, loadNotes, createNote, updateNote, deleteNote, aiSuggestions, notesLoadedOnce } from '$lib/stores/notes';
+  import { notes, notesLoading, loadNotes, createNote, updateNote, deleteNote, aiSuggestions, notesLoadedOnce, selectedNoteIds, bulkMode, toggleNoteSelection, selectAllNotes, clearNoteSelection, deleteSelectedNotes, tagSelectedNotes, untagSelectedNotes } from '$lib/stores/notes';
   import { buildTree, flattenTree, extractFrontmatter, getFileIcon, type SortMode } from '$lib/utils/fileTree';
   import { showHiddenFiles, showTrash, folderMetaStore, updateFolderMeta } from '$lib/stores/settings';
   import { loadUserSettings, patchUserSettings } from '$lib/utils/userSettings';
@@ -616,12 +616,41 @@
           </button>
         {/if}
       </div>
+      <button class="toolbar-btn bulk-toggle" class:active={$bulkMode} on:click={() => { bulkMode.set(!$bulkMode); clearNoteSelection(); }}>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/></svg>
+      </button>
     </div>
 
     <div class="list-meta">
-      <span>{$notes.length} notas</span>
+      <span>{ $bulkMode ? `${$selectedNoteIds.size} seleccionadas` : `${$notes.length} notas` }</span>
       {#if search}<span class="sep">·</span><span>{filtered.length} resultados</span>{/if}
+      {#if $bulkMode}
+        <button class="toolbar-btn select-all" on:click={$selectedNoteIds.size === filtered.length ? clearNoteSelection : selectAllNotes}>
+          {$selectedNoteIds.size === filtered.length ? 'Deseleccionar todo' : 'Seleccionar todo'}
+        </button>
+      {/if}
     </div>
+
+    {#if $bulkMode && $selectedNoteIds.size > 0}
+      <div class="bulk-actions">
+        <span class="bulk-count">{$selectedNoteIds.size} nota{if $selectedNoteIds.size !== 1}s{/if}</span>
+        <button class="bulk-btn danger" on:click={() => { if (confirm(`¿Eliminar ${$selectedNoteIds.size} nota(s)?`)) deleteSelectedNotes(); }}>
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+          Eliminar
+        </button>
+        <button class="bulk-btn" on:click={() => { const t = prompt('Tags a añadir (separadas por coma):'); if (t) tagSelectedNotes(t.split(',').map(s => s.trim()).filter(Boolean)); }}>
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
+          Etiquetar
+        </button>
+        <button class="bulk-btn" on:click={() => { const t = prompt('Tags a quitar (separadas por coma):'); if (t) untagSelectedNotes(t.split(',').map(s => s.trim()).filter(Boolean)); }}>
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
+          Desetiquetar
+        </button>
+        <button class="bulk-btn" on:click={() => clearNoteSelection()}>
+          Cancelar
+        </button>
+      </div>
+    {/if}
 
     <div class="list-scroll" bind:this={listScrollEl} on:scroll={onListScroll}>
       {#if $notesLoading}
@@ -709,11 +738,11 @@
           <div class="empty-msg">{search ? 'Sin resultados.' : 'Sin notas.'}</div>
         {:else if filtered.length > 50}
           <VirtualList items={filtered} itemHeight={52} let:item let:index>
-            <NoteCard note={item} active={selectedNote?.id === item.id} on:select={(e) => openNote(e.detail)} on:customize={(e) => openFolderCustomizer(e.detail)} />
+            <NoteCard note={item} active={selectedNote?.id === item.id} selected={$selectedNoteIds.has(item.id)} bulkMode={$bulkMode} on:select={(e) => openNote(e.detail)} on:toggleSelect={(e) => toggleNoteSelection(e.detail)} on:customize={(e) => openFolderCustomizer(e.detail)} />
           </VirtualList>
         {:else}
           {#each filtered as note}
-            <NoteCard {note} active={selectedNote?.id === note.id} on:select={(e) => openNote(e.detail)} on:customize={(e) => openFolderCustomizer(e.detail)} />
+            <NoteCard {note} active={selectedNote?.id === note.id} selected={$selectedNoteIds.has(note.id)} bulkMode={$bulkMode} on:select={(e) => openNote(e.detail)} on:toggleSelect={(e) => toggleNoteSelection(e.detail)} on:customize={(e) => openFolderCustomizer(e.detail)} />
           {/each}
         {/if}
       {/if}
@@ -1099,6 +1128,40 @@
     color: var(--accent-contrast-text, var(--bg)); cursor: pointer;
   }
   .new-btn:hover { opacity: 0.8; }
+
+  .toolbar-btn {
+    display: flex; align-items: center; gap: 4px;
+    padding: 4px 8px;
+    background: none; border: 1px solid var(--border); border-radius: var(--r);
+    color: var(--text-muted); cursor: pointer; font-size: 11px; font-family: var(--font-sans);
+    transition: all var(--t-fast); flex-shrink: 0;
+  }
+  .toolbar-btn:hover { color: var(--text-primary); border-color: var(--text-muted); }
+  .toolbar-btn.active { color: var(--accent); border-color: var(--accent); background: color-mix(in srgb, var(--accent) 10%, transparent); }
+
+  .bulk-actions {
+    display: flex; align-items: center; gap: 6px;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border);
+    background: var(--elevated);
+    flex-shrink: 0;
+  }
+
+  .bulk-count {
+    font-size: 11px; font-family: var(--font-mono); color: var(--text-primary);
+    margin-right: auto;
+  }
+
+  .bulk-btn {
+    display: flex; align-items: center; gap: 4px;
+    padding: 4px 8px;
+    background: none; border: 1px solid var(--border); border-radius: var(--r);
+    color: var(--text-muted); cursor: pointer; font-size: 11px;
+    transition: all var(--t-fast);
+  }
+  .bulk-btn:hover { color: var(--text-primary); border-color: var(--text-muted); }
+  .bulk-btn.danger { color: #f85149; border-color: #f8514940; }
+  .bulk-btn.danger:hover { border-color: #f85149; background: #f8514910; }
 
   .list-meta {
     display: flex; align-items: center; gap: 6px;


### PR DESCRIPTION
## Cambios

### Backend
- `POST /notes/bulk-delete` — acepta `{ ids: int[] }`
- `POST /notes/bulk-tag` — acepta `{ ids: int[], tags: string[] }`
- `POST /notes/bulk-untag` — acepta `{ ids: int[], tags: string[] }`

### Frontend
- Nuevos stores: `selectedNoteIds`, `bulkMode`
- Funciones: `deleteSelectedNotes()`, `tagSelectedNotes()`, `untagSelectedNotes()`, `selectAllNotes()`, `clearNoteSelection()`
- `NoteCard`: checkbox visible en bulk mode, borde lateral cuando seleccionada
- Página de notas: botón toggle de bulk mode, barra de acciones (eliminar, etiquetar, desetiquetar), conteo de selección

Closes #68