### PR TITLE
feat: Dashboard widgets reorderable via drag & drop

### DIFF
--- a/frontend/src/lib/components/Widget.svelte
+++ b/frontend/src/lib/components/Widget.svelte
@@ -1,14 +1,77 @@
 <script lang="ts">
-  import type { WidgetId } from '$lib/stores/layout';
+  import { createEventDispatcher } from 'svelte';
+  import type { WidgetId, DashboardLayout } from '$lib/stores/layout';
+  import DynamicIcon from './DynamicIcon.svelte';
+  import { WIDGET_REGISTRY } from '$lib/stores/layout';
 
   export let id:    WidgetId;
   export let panel: 'left' | 'right';
   export let index: number;
   export let total: number;
+  export let layout: DashboardLayout;
+
+  let dragOver = false;
+
+  const dispatch = createEventDispatcher<{
+    drop: { id: WidgetId; fromPanel: 'left' | 'right'; fromIdx: number; toPanel: 'left' | 'right'; toIdx: number };
+  }>();
+
+  function handleDragStart(e: DragEvent) {
+    if (!e.dataTransfer) return;
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', JSON.stringify({ id, panel, index }));
+    e.dataTransfer.setData('application/x-widget', '');
+  }
+
+  function handleDragOver(e: DragEvent) {
+    e.preventDefault();
+    if (!e.dataTransfer) return;
+    e.dataTransfer.dropEffect = 'move';
+    dragOver = true;
+  }
+
+  function handleDragLeave() {
+    dragOver = false;
+  }
+
+  function handleDrop(e: DragEvent) {
+    e.preventDefault();
+    dragOver = false;
+    if (!e.dataTransfer) return;
+    try {
+      const src = JSON.parse(e.dataTransfer.getData('text/plain'));
+      if (src.id === id && src.panel === panel) return;
+      dispatch('drop', {
+        id: src.id as WidgetId,
+        fromPanel: src.panel,
+        fromIdx: src.index,
+        toPanel: panel,
+        toIdx: index,
+      });
+    } catch {}
+  }
+
+  $: label = WIDGET_REGISTRY[id]?.label ?? id;
 </script>
 
-<div class="widget">
-  <slot />
+<div
+  class="widget"
+  class:drag-over={dragOver}
+  draggable="true"
+  on:dragstart={handleDragStart}
+  on:dragover={handleDragOver}
+  on:dragleave={handleDragLeave}
+  on:drop={handleDrop}
+  on:dragend={() => { dragOver = false; }}
+  role="listitem"
+  aria-label={label}
+>
+  <div class="widget-handle">
+    <DynamicIcon name="GripVertical" size={10} />
+  </div>
+  <div class="widget-content">
+    <slot />
+  </div>
 </div>
 
 <style>
@@ -18,6 +81,46 @@
     background: transparent;
     overflow: hidden;
     box-shadow: none;
+    transition: opacity var(--t-fast), border-color var(--t-fast);
+  }
+
+  .widget[draggable="true"] {
+    cursor: grab;
+  }
+
+  .widget[draggable="true"]:active {
+    cursor: grabbing;
+    opacity: 0.6;
+  }
+
+  .widget.drag-over {
+    border: 1px dashed var(--accent);
+    border-radius: var(--r);
+    opacity: 0.8;
+  }
+
+  .widget-handle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 0;
+    color: var(--text-muted);
+    opacity: 0;
+    transition: opacity var(--t-fast);
+    cursor: grab;
+    height: 12px;
+  }
+
+  .widget:hover .widget-handle {
+    opacity: 0.5;
+  }
+
+  .widget-handle:hover {
+    opacity: 1 !important;
+  }
+
+  .widget-content {
+    width: 100%;
   }
 
   /* Force-neutral container even if older accent styles remain in cache/builds. */

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -19,7 +19,7 @@
   import GithubWidget from '$lib/components/GithubWidget.svelte';
   import { totalXP, currentStreak, lastActivity, nextStageXP } from '$lib/stores/gamification';
   import { notes, loadNotes, notesLoadedOnce } from '$lib/stores/notes';
-  import { dashboardLayout } from '$lib/stores/layout';
+  import { dashboardLayout, type WidgetId } from '$lib/stores/layout';
   import { accentColors } from '$lib/stores/settings';
   import { api } from '$lib/api';
   import { loadUserSettings, patchUserSettings } from '$lib/utils/userSettings';
@@ -283,8 +283,17 @@
   <!-- ── Left panel ─────────────────────────────────────────────────────────── -->
   <section class="plant-section">
 
+  function handleWidgetDrop(e: CustomEvent<{ id: WidgetId; fromPanel: 'left' | 'right'; fromIdx: number; toPanel: 'left' | 'right'; toIdx: number }>) {
+    const { id, fromPanel, toPanel, toIdx } = e.detail;
+    if (fromPanel === toPanel) {
+      dashboardLayout.move(fromPanel, e.detail.fromIdx, toIdx);
+    } else {
+      dashboardLayout.switchPanel(id, fromPanel);
+    }
+  }
+
     {#each $dashboardLayout.left as wid, i (wid)}
-      <Widget id={wid} panel="left" index={i} total={$dashboardLayout.left.length}>
+      <Widget id={wid} panel="left" index={i} total={$dashboardLayout.left.length} layout={$dashboardLayout} on:drop={handleWidgetDrop}>
 
         {#if wid === 'plant-carousel'}
           <div class="widget-centered">
@@ -408,7 +417,7 @@
   <section class="activity-section">
 
     {#each $dashboardLayout.right as wid, i (wid)}
-      <Widget id={wid} panel="right" index={i} total={$dashboardLayout.right.length}>
+      <Widget id={wid} panel="right" index={i} total={$dashboardLayout.right.length} layout={$dashboardLayout} on:drop={handleWidgetDrop}>
 
         {#if wid === 'recent-notes'}
           <div class="section-header">


### PR DESCRIPTION
## Cambios

- `Widget.svelte`: draggable con HTML5 Drag & Drop, manija de agarre visible al hover, estado drag-over con borde punteado
- Botón `GripVertical` en `Widget.svelte` para indicar que es arrastrable
- Página de dashboard: maneja evento `drop` para llamar `dashboardLayout.move()` (mismo panel) o `dashboardLayout.switchPanel()` (entre paneles)
- Cambios persistentes en localStorage

Closes #78