### PR TITLE
feat: Undo/redo history in note editor

### DIFF
--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -94,6 +94,49 @@
   let saved = false;
   let previewMode = false;
   let aiTimeout: ReturnType<typeof setTimeout>;
+
+  let historyStack: string[] = [content];
+  let historyIndex = 0;
+  let historyLock = false;
+  let saveTimeout: ReturnType<typeof setTimeout>;
+
+  function pushSnapshot() {
+    if (historyLock) return;
+    const cur = content;
+    if (historyStack[historyIndex] === cur) return;
+    historyStack = historyStack.slice(0, historyIndex + 1);
+    historyStack.push(cur);
+    if (historyStack.length > 100) historyStack.shift();
+    historyIndex = historyStack.length - 1;
+  }
+
+  function scheduleSnapshot() {
+    clearTimeout(saveTimeout);
+    saveTimeout = setTimeout(pushSnapshot, 600);
+  }
+
+  function handleUndo() {
+    if (historyIndex <= 0) return;
+    historyIndex--;
+    historyLock = true;
+    content = historyStack[historyIndex];
+    tags = extractTagsFromContent(content) || note?.tags?.slice() || [];
+    historyLock = false;
+  }
+
+  function handleRedo() {
+    if (historyIndex >= historyStack.length - 1) return;
+    historyIndex++;
+    historyLock = true;
+    content = historyStack[historyIndex];
+    tags = extractTagsFromContent(content) || note?.tags?.slice() || [];
+    historyLock = false;
+  }
+
+  $: if (note) {
+    historyStack = [note.content || ''];
+    historyIndex = 0;
+  }
   
   let showIconSettings = false;
   let customColor = '#ffffff';
@@ -188,6 +231,7 @@
 
   function updateVisibleContent(e: Event) {
     const val = (e.currentTarget as HTMLTextAreaElement).value;
+    scheduleSnapshot();
     let nextContent = val;
 
     if ($hideTagsLine && tags.length > 0 && currentTagsLine) {
@@ -292,7 +336,10 @@
     aiSuggestions.update(s => s.filter(x => x.tag !== tag));
   }
 
-  onDestroy(() => clearTimeout(aiTimeout));
+  onDestroy(() => {
+    clearTimeout(aiTimeout);
+    clearTimeout(saveTimeout);
+  });
 
   async function handleSave() {
     if (!title.trim()) return;
@@ -335,6 +382,19 @@
     if ((e.ctrlKey || e.metaKey) && e.key === 'p') {
       e.preventDefault();
       previewMode = !previewMode;
+    }
+    if ((e.ctrlKey || e.metaKey) && e.key === 'z') {
+      if (e.shiftKey) {
+        e.preventDefault();
+        handleRedo();
+      } else {
+        e.preventDefault();
+        handleUndo();
+      }
+    }
+    if ((e.ctrlKey || e.metaKey) && e.key === 'y') {
+      e.preventDefault();
+      handleRedo();
     }
     if (e.key === 'Escape' && zenMode) {
       e.preventDefault();


### PR DESCRIPTION
## Cambios

- Historial de deshacer/rehacer en NoteEditor
- Captura de snapshot cada 600ms tras la última escritura
- Ctrl+Z: deshacer, Ctrl+Shift+Z o Ctrl+Y: rehacer
- Historial limitado a 100 entradas, se reinicia al cambiar de nota
- Tags se re-extraen del contenido al navegar el historial

Closes #71