### PR TITLE
test: Add frontend unit tests with vitest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,13 @@ db-health: ## Verify migration head and required core tables
 test-api: ## Run all API unit tests via pytest
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm api sh -c "PYTHONPATH=/app pytest --cov=api --cov-report=term-missing"
 
-test-frontend: ## Run frontend typechecking (svelte-check) inside Docker
+test-frontend: ## Run frontend tests (vitest) inside Docker
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm frontend npm run test
+
+test-frontend-check: ## Run frontend typechecking (svelte-check) inside Docker
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm frontend npm run check
 
-test: test-api test-frontend ## Run all test suites (API + Frontend)
+test: test-api test-frontend test-frontend-check ## Run all test suites (API + Frontend + typecheck)
 
 lint-api: ## Check syntax of all Python services using ruff
 	ruff check .

--- a/frontend/src/lib/utils/fileTree.test.ts
+++ b/frontend/src/lib/utils/fileTree.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { extractFrontmatter, getFileIcon } from './fileTree';
+
+describe('extractFrontmatter', () => {
+  it('returns null fields for empty content', () => {
+    expect(extractFrontmatter('')).toEqual({ icon: null, color: null, pack: null });
+  });
+
+  it('returns null fields for content without frontmatter', () => {
+    expect(extractFrontmatter('# Hello\n\nJust a note')).toEqual({ icon: null, color: null, pack: null });
+  });
+
+  it('parses icon from frontmatter', () => {
+    const result = extractFrontmatter('---\nicon: Star\niconColor: "#ff0000"\n---\n\nContent');
+    expect(result).toMatchObject({ icon: 'Star', color: '"#ff0000"' });
+  });
+
+  it('parses iconPack from frontmatter', () => {
+    const result = extractFrontmatter('---\nicon: Home\niconPack: phosphor\n---\n\nBody');
+    expect(result).toMatchObject({ icon: 'Home', pack: 'phosphor' });
+  });
+
+  it('handles missing closing ---', () => {
+    expect(extractFrontmatter('---\nicon: Star\n\nContent')).toEqual({ icon: null, color: null, pack: null });
+  });
+
+  it('handles empty frontmatter', () => {
+    expect(extractFrontmatter('---\n---\n\nContent')).toEqual({ icon: null, color: null, pack: null });
+  });
+});
+
+describe('getFileIcon', () => {
+  it('returns File as default fallback', () => {
+    expect(getFileIcon('Random Note', '')).toBe('File');
+  });
+
+  it('returns icon from frontmatter icon field in content', () => {
+    expect(getFileIcon('Any', '---\nicon: Star\n---\n\nBody')).toBe('Star');
+  });
+
+  it('returns FileCode for content with code blocks', () => {
+    expect(getFileIcon('Code', 'Some text\n```\ncode here\n```\nmore')).toBe('FileCode');
+  });
+});


### PR DESCRIPTION
## Cambios

- Primer test suite frontend: `fileTree.test.ts` — 9 tests para `extractFrontmatter` y `getFileIcon`
- `Makefile`: `test-frontend` ahora ejecuta vitest (`npm run test`); se añade `test-frontend-check` para svelte-check
- `test` target incluye ambos: vitest + typecheck
- Infraestructura lista para añadir más tests (`src/**/*.test.ts`)

Closes #7