### PR TITLE
feat: Notes file tree reorganization via context menu

### DIFF
--- a/api/routers/notes.py
+++ b/api/routers/notes.py
@@ -277,7 +277,13 @@ def retry_failed_embeddings(
 @router.get("/embeddings/dead-letters")
 def list_dead_letters(limit: int = 50, db: Session = Depends(get_db)):
     """List embedding failures that exceeded max retry attempts."""
-    return get_dead_letter_entries(db, limit=limit)
+    from models.note import Note
+    entries = get_dead_letter_entries(db, limit=limit)
+    note_ids = [e["note_id"] for e in entries]
+    notes = {n.id: n.title for n in db.query(Note.id, Note.title).filter(Note.id.in_(note_ids)).all()} if note_ids else {}
+    for e in entries:
+        e["note_title"] = notes.get(e["note_id"])
+    return entries
 
 
 @router.post("/embeddings/dead-letters/{note_id}/reset")

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -182,6 +182,14 @@ export interface PersonalStreak {
   created_at: string;
 }
 
+export interface EmbeddingFailure {
+  note_id: number;
+  attempts: number;
+  last_error: string;
+  updated_at: string | null;
+  note_title?: string | null;
+}
+
 export interface StreakStats {
   total_active: number;
   total_archived: number;
@@ -354,6 +362,12 @@ github: {
     zipUrl: () => `${BASE}/export/notes/zip`
   },
   
+  embeddings: {
+    deadLetters: (limit = 50) => req<EmbeddingFailure[]>('GET', `/notes/embeddings/dead-letters?limit=${limit}`),
+    resetDeadLetter: (noteId: number) => req<{ status: string; note_id: number }>('POST', `/notes/embeddings/dead-letters/${noteId}/reset`),
+    purgeDeadLetters: () => req<{ purged: number }>('DELETE', '/notes/embeddings/dead-letters'),
+  },
+
   folders: {
     create: async (path: string) => {
       return req('POST', '/folders/', { path });

--- a/frontend/src/lib/components/DeadLetterQueue.svelte
+++ b/frontend/src/lib/components/DeadLetterQueue.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { api, type EmbeddingFailure } from '$lib/api';
+  import Card from './Card.svelte';
+  import DynamicIcon from './DynamicIcon.svelte';
+
+  let failures = $state<EmbeddingFailure[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let purging = $state(false);
+
+  onMount(() => load());
+
+  async function load() {
+    loading = true;
+    error = null;
+    try {
+      failures = await api.embeddings.deadLetters();
+    } catch (e) {
+      error = 'No se pudieron cargar los embeddings fallidos.';
+      failures = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function reset(noteId: number) {
+    try {
+      await api.embeddings.resetDeadLetter(noteId);
+      failures = failures.filter(f => f.note_id !== noteId);
+    } catch {
+      // notification already shown by api.ts
+    }
+  }
+
+  async function purgeAll() {
+    purging = true;
+    try {
+      await api.embeddings.purgeDeadLetters();
+      failures = [];
+    } catch {
+      // notification already shown by api.ts
+    } finally {
+      purging = false;
+    }
+  }
+
+  function formatDate(iso: string | null): string {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    const now = new Date();
+    const diff = now.getTime() - d.getTime();
+    if (diff < 60000) return 'hace momentos';
+    if (diff < 3600000) return `hace ${Math.floor(diff / 60000)} min`;
+    if (diff < 86400000) return `hace ${Math.floor(diff / 3600000)} h`;
+    return d.toLocaleDateString('es');
+  }
+</script>
+
+<Card padding="md">
+  <div class="dlq-header">
+    <h3><DynamicIcon icon="AlertTriangle" /> Embeddings fallidos</h3>
+    {#if failures.length > 0}
+      <button class="btn-sm btn-danger" onclick={purgeAll} disabled={purging}>
+        {purging ? 'Purgando...' : 'Purgar todos'}
+      </button>
+    {/if}
+  </div>
+
+  {#if loading}
+    <p class="muted">Cargando...</p>
+  {:else if error}
+    <p class="muted">{error}</p>
+  {:else if failures.length === 0}
+    <p class="muted">No hay embeddings fallidos.</p>
+  {:else}
+    <div class="dlq-list">
+      {#each failures as failure (failure.note_id)}
+        <div class="dlq-item">
+          <div class="dlq-info">
+            <span class="dlq-title">{failure.note_title || `Nota #${failure.note_id}`}</span>
+            <span class="dlq-meta">
+              {failure.attempts} intentos · {formatDate(failure.updated_at)}
+            </span>
+            {#if failure.last_error}
+              <span class="dlq-error">{failure.last_error}</span>
+            {/if}
+          </div>
+          <button class="btn-sm" onclick={() => reset(failure.note_id)}>
+            Reintentar
+          </button>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</Card>
+
+<style>
+  .dlq-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+  }
+  .dlq-header h3 {
+    margin: 0;
+    font-size: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .muted {
+    color: var(--color-muted, #888);
+    font-size: 0.85rem;
+    text-align: center;
+    padding: 24px 0;
+  }
+  .dlq-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .dlq-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 8px;
+    border-radius: 6px;
+    background: var(--color-surface, #f5f5f5);
+  }
+  .dlq-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .dlq-title {
+    font-weight: 600;
+    font-size: 0.875rem;
+  }
+  .dlq-meta {
+    font-size: 0.75rem;
+    color: var(--color-muted, #888);
+  }
+  .dlq-error {
+    font-size: 0.75rem;
+    color: var(--color-error, #e53e3e);
+    font-family: monospace;
+    word-break: break-word;
+    max-height: 40px;
+    overflow: hidden;
+  }
+  .btn-sm {
+    padding: 4px 10px;
+    font-size: 0.8rem;
+    border: 1px solid var(--color-border, #ddd);
+    border-radius: 4px;
+    background: var(--color-bg, #fff);
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .btn-sm:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .btn-danger {
+    color: var(--color-error, #e53e3e);
+    border-color: var(--color-error, #e53e3e);
+  }
+</style>

--- a/frontend/src/lib/components/FolderPicker.svelte
+++ b/frontend/src/lib/components/FolderPicker.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import type { FlatNode } from '$lib/utils/fileTree';
+  import DynamicIcon from './DynamicIcon.svelte';
+
+  export let flatNodes: FlatNode[] = [];
+
+  const dispatch = createEventDispatcher<{
+    close: void;
+    select: string;
+  }>();
+
+  let selectedPath = '';
+  let search = '';
+
+  $: folders = flatNodes.filter(n => n.type === 'folder' && (!search || n.path.toLowerCase().includes(search.toLowerCase())));
+</script>
+
+<div class="folder-picker-backdrop" on:click={() => dispatch('close')}>
+  <div class="folder-picker" on:click|stopPropagation>
+    <h3 class="folder-modal-title">Mover nota a carpeta</h3>
+
+    <input type="text" class="input mono" bind:value={search} placeholder="Buscar carpeta..." style="width:100%; box-sizing:border-box; margin-bottom:8px;" />
+
+    <div class="folder-list">
+      <button
+        class="folder-opt"
+        class:selected={selectedPath === ''}
+        on:click={() => selectedPath = ''}
+      >
+        <DynamicIcon name="FolderRoot" size={12} />
+        (Raíz)
+      </button>
+      {#each folders as f}
+        <button
+          class="folder-opt"
+          class:selected={selectedPath === f.path}
+          on:click={() => selectedPath = f.path}
+        >
+          <span class="folder-opt-indent" style="width: {f.depth * 14}px"></span>
+          <DynamicIcon name={f.icon || 'Folder'} size={12} color={f.color} />
+          <span>{f.name}</span>
+        </button>
+      {/each}
+      {#if folders.length === 0}
+        <p class="muted">Sin resultados</p>
+      {/if}
+    </div>
+
+    <div class="folder-modal-btns">
+      <button on:click={() => dispatch('close')}>Cancelar</button>
+      <button class="primary" on:click={() => dispatch('select', selectedPath)}>Mover aquí</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .folder-picker-backdrop {
+    position: fixed; inset: 0; z-index: 200;
+    background: rgba(0,0,0,0.3);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .folder-picker {
+    background: var(--surface, #fff);
+    border: 1px solid var(--border, #ddd);
+    border-radius: var(--r, 8px);
+    padding: 20px;
+    min-width: 300px;
+    max-width: 420px;
+    max-height: 70vh;
+    display: flex;
+    flex-direction: column;
+  }
+  .folder-list {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-bottom: 12px;
+    min-height: 100px;
+  }
+  .folder-opt {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: left;
+    font-size: 0.85rem;
+    color: var(--text-primary, #222);
+    width: 100%;
+  }
+  .folder-opt:hover { background: var(--hover, #f0f0f0); }
+  .folder-opt.selected { background: var(--elevated, #e8e8e8); }
+  .folder-opt-indent { flex-shrink: 0; }
+  .muted {
+    color: var(--color-muted, #888);
+    font-size: 0.8rem;
+    text-align: center;
+    padding: 24px 0;
+  }
+  .folder-modal-btns {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+  .folder-modal-title {
+    margin: 0 0 12px;
+    font-size: 1rem;
+  }
+  .input {
+    padding: 6px 10px;
+    border: 1px solid var(--border, #ddd);
+    border-radius: 4px;
+    background: var(--bg, #fff);
+    color: var(--text-primary, #222);
+    font-size: 0.85rem;
+    outline: none;
+  }
+  .mono { font-family: var(--font-mono, monospace); }
+  .primary {
+    background: var(--accent, #4a90d9);
+    color: var(--accent-contrast-text, #fff);
+    border: 1px solid var(--accent, #4a90d9);
+    padding: 6px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+  button:not(.primary) {
+    padding: 6px 16px;
+    border: 1px solid var(--border, #ddd);
+    border-radius: 4px;
+    background: var(--bg, #fff);
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: var(--text-primary, #222);
+  }
+</style>

--- a/frontend/src/lib/components/TreeContextMenu.svelte
+++ b/frontend/src/lib/components/TreeContextMenu.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import { createEventDispatcher, onMount } from 'svelte';
+  import type { FlatNode } from '$lib/utils/fileTree';
+  import DynamicIcon from './DynamicIcon.svelte';
+
+  export let x: number;
+  export let y: number;
+  export let node: FlatNode;
+
+  const dispatch = createEventDispatcher<{
+    close: void;
+    rename: { node: FlatNode };
+    move: { node: FlatNode };
+    deleteNote: { node: FlatNode };
+    newNoteInFolder: { node: FlatNode };
+    deleteFolder: { node: FlatNode };
+  }>();
+
+  function handleItem(action: string) {
+    return () => {
+      switch (action) {
+        case 'rename': dispatch('rename', { node }); break;
+        case 'move': dispatch('move', { node }); break;
+        case 'deleteNote': dispatch('deleteNote', { node }); break;
+        case 'newNoteInFolder': dispatch('newNoteInFolder', { node }); break;
+        case 'deleteFolder': dispatch('deleteFolder', { node }); break;
+      }
+      dispatch('close');
+    };
+  }
+
+  function adjustPos() {
+    const w = menuEl?.offsetWidth ?? 160;
+    const h = menuEl?.offsetHeight ?? 120;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let cx = x;
+    let cy = y;
+    if (cx + w > vw - 8) cx = vw - w - 8;
+    if (cy + h > vh - 8) cy = vh - h - 8;
+    if (cx < 8) cx = 8;
+    if (cy < 8) cy = 8;
+    style = `left:${cx}px;top:${cy}px;`;
+  }
+
+  let style = '';
+  let menuEl: HTMLDivElement;
+
+  onMount(() => {
+    adjustPos();
+    const close = () => dispatch('close');
+    window.addEventListener('click', close, { once: true });
+    window.addEventListener('contextmenu', close, { once: true });
+    return () => {
+      window.removeEventListener('click', close);
+      window.removeEventListener('contextmenu', close);
+    };
+  });
+</script>
+
+<div class="ctx-menu" bind:this={menuEl} style={style} on:click|stopPropagation on:contextmenu|stopPropagation>
+  {#if node.type === 'file'}
+    <button class="ctx-item" on:click={handleItem('rename')}>
+      <DynamicIcon name="Edit" size={12} /> Renombrar
+    </button>
+    <button class="ctx-item" on:click={handleItem('move')}>
+      <DynamicIcon name="MoveRight" size={12} /> Mover a...
+    </button>
+    <div class="ctx-divider"></div>
+    <button class="ctx-item ctx-danger" on:click={handleItem('deleteNote')}>
+      <DynamicIcon name="Trash2" size={12} /> Eliminar
+    </button>
+  {:else}
+    <button class="ctx-item" on:click={handleItem('newNoteInFolder')}>
+      <DynamicIcon name="FilePlus" size={12} /> Nueva nota aquí
+    </button>
+    <button class="ctx-item" on:click={handleItem('rename')}>
+      <DynamicIcon name="Edit" size={12} /> Renombrar
+    </button>
+    <button class="ctx-item ctx-danger" on:click={handleItem('deleteFolder')}>
+      <DynamicIcon name="FolderX" size={12} /> Eliminar carpeta
+    </button>
+  {/if}
+</div>
+
+<style>
+  .ctx-menu {
+    position: fixed;
+    z-index: 1000;
+    min-width: 160px;
+    background: var(--surface, #fff);
+    border: 1px solid var(--border, #ddd);
+    border-radius: 6px;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.18);
+    padding: 4px 0;
+    display: flex;
+    flex-direction: column;
+  }
+  .ctx-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 14px;
+    font-size: 0.8rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-primary, #222);
+    text-align: left;
+    width: 100%;
+  }
+  .ctx-item:hover {
+    background: var(--hover, #f0f0f0);
+  }
+  .ctx-danger {
+    color: var(--color-error, #e53e3e);
+  }
+  .ctx-divider {
+    height: 1px;
+    background: var(--border-light, #eee);
+    margin: 4px 0;
+  }
+</style>

--- a/frontend/src/routes/ai/+page.svelte
+++ b/frontend/src/routes/ai/+page.svelte
@@ -1,5 +1,96 @@
 <script lang="ts">
-  import IntegrationPlaceholder from '$lib/components/IntegrationPlaceholder.svelte';
+  import { onMount } from 'svelte';
+  import { api } from '$lib/api';
+  import Card from '$lib/components/Card.svelte';
+  import DynamicIcon from '$lib/components/DynamicIcon.svelte';
+  import DeadLetterQueue from '$lib/components/DeadLetterQueue.svelte';
+  import { devMode } from '$lib/stores/settings';
+
+  let usage = $state<{ ai_enabled: boolean; estimated_cost_usd: number } | null>(null);
+  let loadingUsage = $state(true);
+
+  onMount(async () => {
+    try {
+      usage = await api.ai.usage();
+    } catch {
+      usage = null;
+    } finally {
+      loadingUsage = false;
+    }
+  });
 </script>
 
-<IntegrationPlaceholder icon="Brain" title="Inteligencia Artificial" caption="Asistentes y modelos de lenguaje" />
+<div class="ai-page">
+  <h2><DynamicIcon icon="Brain" /> Inteligencia Artificial</h2>
+
+  <div class="ai-grid">
+    <Card padding="md">
+      <h3><DynamicIcon icon="Activity" /> Estado del servicio</h3>
+      {#if loadingUsage}
+        <p class="muted">Verificando...</p>
+      {:else if usage}
+        <p class="stat">
+          <span class="stat-label">API Key configurada:</span>
+          <span class="stat-value" class:enabled={usage.ai_enabled} class:disabled={!usage.ai_enabled}>
+            {usage.ai_enabled ? 'Sí' : 'No'}
+          </span>
+        </p>
+        <p class="stat">
+          <span class="stat-label">Costo estimado:</span>
+          <span class="stat-value">${usage.estimated_cost_usd.toFixed(4)} USD</span>
+        </p>
+      {:else}
+        <p class="muted">No se pudo obtener el estado.</p>
+      {/if}
+    </Card>
+
+    {#if $devMode}
+      <DeadLetterQueue />
+    {/if}
+  </div>
+</div>
+
+<style>
+  .ai-page {
+    padding: 24px;
+    max-width: 800px;
+    margin: 0 auto;
+  }
+  .ai-page h2 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0 0 20px;
+  }
+  .ai-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  :global(.ai-grid) h3 {
+    margin: 0 0 12px;
+    font-size: 0.95rem;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .muted {
+    color: var(--color-muted, #888);
+    font-size: 0.85rem;
+    text-align: center;
+    padding: 16px 0;
+  }
+  .stat {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 6px 0;
+    margin: 0;
+    font-size: 0.875rem;
+  }
+  .stat-label {
+    color: var(--color-muted, #888);
+  }
+  .stat-value.enabled { color: var(--color-success, #38a169); }
+  .stat-value.disabled { color: var(--color-error, #e53e3e); }
+</style>

--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -9,7 +9,9 @@
   import IconPicker from '$lib/components/IconPicker.svelte';
   import VirtualList from '$lib/components/VirtualList.svelte';
   import { notes, notesLoading, loadNotes, createNote, updateNote, deleteNote, aiSuggestions, notesLoadedOnce } from '$lib/stores/notes';
-  import { buildTree, flattenTree, extractFrontmatter, getFileIcon, type SortMode } from '$lib/utils/fileTree';
+  import { buildTree, flattenTree, extractFrontmatter, getFileIcon, type SortMode, type FlatNode } from '$lib/utils/fileTree';
+  import TreeContextMenu from '$lib/components/TreeContextMenu.svelte';
+  import FolderPicker from '$lib/components/FolderPicker.svelte';
   import { showHiddenFiles, showTrash, folderMetaStore, updateFolderMeta } from '$lib/stores/settings';
   import { loadUserSettings, patchUserSettings } from '$lib/utils/userSettings';
   import { captureSnapshot, getSnapshot } from '$lib/stores/pageSnapshots';
@@ -33,6 +35,78 @@
 
   let editingFolderNote: Note | null = null;
   let creatingFolder = false;
+
+  // ── Context menu ─────────────────────────────────────────────────────────────
+  let ctxMenu: { x: number; y: number; node: import('$lib/utils/fileTree').FlatNode } | null = null;
+  let renamingNode: import('$lib/utils/fileTree').FlatNode | null = null;
+  let renameValue = '';
+  let movingNode: import('$lib/utils/fileTree').FlatNode | null = null;
+
+  function handleContextMenu(e: MouseEvent, node: import('$lib/utils/fileTree').FlatNode) {
+    e.preventDefault();
+    e.stopPropagation();
+    ctxMenu = { x: e.clientX, y: e.clientY, node };
+  }
+
+  function handleRename() {
+    if (!ctxMenu) return;
+    renamingNode = ctxMenu.node;
+    renameValue = ctxMenu.node.name;
+    ctxMenu = null;
+  }
+
+  async function confirmRename() {
+    if (!renamingNode || !renameValue.trim()) { renamingNode = null; return; }
+    const node = renamingNode;
+    renamingNode = null;
+    if (node.type === 'file' && node.note) {
+      await updateNote(node.note.id, { title: renameValue.trim() });
+    }
+  }
+
+  function handleMove() {
+    if (!ctxMenu) return;
+    movingNode = ctxMenu.node;
+    ctxMenu = null;
+  }
+
+  async function confirmMove(targetPath: string) {
+    const node = movingNode;
+    if (!node || !node.note) { movingNode = null; return; }
+    const note = node.note;
+    movingNode = null;
+    const newPath = targetPath ? `${targetPath}/${node.name}` : node.name;
+    await api.notes.update(note.id, { source_path: newPath });
+    await loadNotes();
+  }
+
+  function handleDeleteNote() {
+    if (!ctxMenu || !ctxMenu.node.note) { ctxMenu = null; return; }
+    const note = ctxMenu.node.note;
+    ctxMenu = null;
+    if (confirm(`¿Eliminar "${note.title}"?`)) {
+      deleteNote(note.id);
+    }
+  }
+
+  function handleNewNoteInFolder() {
+    if (!ctxMenu) return;
+    ctxMenu = null;
+    openNew();
+  }
+
+  function handleDeleteFolder() {
+    if (!ctxMenu) return;
+    const menu = ctxMenu;
+    const path = menu.node.path;
+    ctxMenu = null;
+    if (confirm(`¿Eliminar carpeta "${menu.node.name}" y todas sus notas?`)) {
+      // Delete notes in this folder
+      const ids = $notes.filter(n => n.source_path && n.source_path.includes(path)).map(n => n.id);
+      Promise.all(ids.map(id => deleteNote(id))).then(() => loadNotes());
+    }
+  }
+
   let newFolderName = "";
   let newFolderParent = "";
   let newFolderIcon = "Folder";
@@ -631,40 +705,42 @@
         {#if flatNodes.length === 0}
           <div class="empty-msg">{search ? 'Sin resultados.' : 'Sin notas.'}</div>
         {:else if flatNodes.length > 50}
-          <VirtualList items={flatNodes} itemHeight={26} getKey={(n, i) => n.path ?? i} let:item let:index>
-            {#if item.type === 'folder'}
-              <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-              <div
-                class="tree-row folder-row"
-                style="padding-left: {8 + item.depth * 14}px"
-                on:click={() => toggleFolder(item.path)}
-              >
-                <span class="chevron" class:open={!collapsed.has(item.path)}>
-                  <ChevronRight size={11} />
-                </span>
-                <div class="t-icon"><DynamicIcon name={item.icon} size={13} color={item.color} pack={item.pack} /></div>
-                <span class="t-name folder-name">{item.name}</span>
-                <button class="folder-settings-btn" title="Personalizar carpeta" on:click|stopPropagation={() => openFolderCustomizer(item)}>
-                  <Settings size={10} />
-                </button>
-                <span class="t-count">{item.childCount}</span>
-              </div>
-            {:else}
-              <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-              <div
-                class="tree-row file-row"
-                class:active={item.note?.id === selectedNote?.id}
-                style="padding-left: {20 + item.depth * 14}px"
-                on:click={() => item.note && openNote(item.note)}
-              >
-                <div class="t-icon file-icon"><DynamicIcon name={item.icon} size={11} color={item.color} pack={item.pack} /></div>
-                <span class="t-name file-name">{item.name}</span>
-                <button class="folder-settings-btn" title="Personalizar nota" on:click|stopPropagation={() => openFolderCustomizer({ path: item.note?.source_path || item.path, icon: item.icon, color: item.color, note: item.note })}>
-                  <Settings size={10} />
-                </button>
-              </div>
-            {/if}
-          </VirtualList>
+            <VirtualList items={flatNodes} itemHeight={26} getKey={(n, i) => n.path ?? i} let:item let:index>
+              {#if item.type === 'folder'}
+                <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+                <div
+                  class="tree-row folder-row"
+                  style="padding-left: {8 + item.depth * 14}px"
+                  on:click={() => toggleFolder(item.path)}
+                  on:contextmenu={(e) => handleContextMenu(e, item)}
+                >
+                  <span class="chevron" class:open={!collapsed.has(item.path)}>
+                    <ChevronRight size={11} />
+                  </span>
+                  <div class="t-icon"><DynamicIcon name={item.icon} size={13} color={item.color} pack={item.pack} /></div>
+                  <span class="t-name folder-name">{item.name}</span>
+                  <button class="folder-settings-btn" title="Personalizar carpeta" on:click|stopPropagation={() => openFolderCustomizer(item)}>
+                    <Settings size={10} />
+                  </button>
+                  <span class="t-count">{item.childCount}</span>
+                </div>
+              {:else}
+                <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+                <div
+                  class="tree-row file-row"
+                  class:active={item.note?.id === selectedNote?.id}
+                  style="padding-left: {20 + item.depth * 14}px"
+                  on:click={() => item.note && openNote(item.note)}
+                  on:contextmenu={(e) => handleContextMenu(e, item)}
+                >
+                  <div class="t-icon file-icon"><DynamicIcon name={item.icon} size={11} color={item.color} pack={item.pack} /></div>
+                  <span class="t-name file-name">{item.name}</span>
+                  <button class="folder-settings-btn" title="Personalizar nota" on:click|stopPropagation={() => openFolderCustomizer({ path: item.note?.source_path || item.path, icon: item.icon, color: item.color, note: item.note })}>
+                    <Settings size={10} />
+                  </button>
+                </div>
+              {/if}
+            </VirtualList>
         {:else}
           <div class="tree-wrap">
             {#each flatNodes as node (node.path)}
@@ -674,6 +750,7 @@
                   class="tree-row folder-row"
                   style="padding-left: {8 + node.depth * 14}px"
                   on:click={() => toggleFolder(node.path)}
+                  on:contextmenu={(e) => handleContextMenu(e, node)}
                 >
                   <span class="chevron" class:open={!collapsed.has(node.path)}>
                     <ChevronRight size={11} />
@@ -692,6 +769,7 @@
                   class:active={node.note?.id === selectedNote?.id}
                   style="padding-left: {20 + node.depth * 14}px"
                   on:click={() => node.note && openNote(node.note)}
+                  on:contextmenu={(e) => handleContextMenu(e, node)}
                 >
                   <div class="t-icon file-icon"><DynamicIcon name={node.icon} size={11} color={node.color} pack={node.pack} /></div>
                   <span class="t-name file-name">{node.name}</span>
@@ -772,6 +850,40 @@
         </div>
       </div>
     </div>
+  {/if}
+
+  {#key ctxMenu}
+    {#if ctxMenu}
+      <TreeContextMenu x={ctxMenu.x} y={ctxMenu.y} node={ctxMenu.node}
+        on:close={() => ctxMenu = null}
+        on:rename={handleRename}
+        on:move={handleMove}
+        on:deleteNote={handleDeleteNote}
+        on:newNoteInFolder={handleNewNoteInFolder}
+        on:deleteFolder={handleDeleteFolder}
+      />
+    {/if}
+  {/key}
+
+  {#if renamingNode}
+    <div class="folder-modal-backdrop" on:click={() => renamingNode = null}>
+      <div class="folder-modal" on:click|stopPropagation>
+        <h3 class="folder-modal-title">Renombrar</h3>
+        <input type="text" class="input mono" bind:value={renameValue} style="width:100%; box-sizing:border-box; margin-bottom:12px;" on:keydown={(e) => e.key === 'Enter' && confirmRename()} />
+        <div class="folder-modal-btns">
+          <button on:click={() => renamingNode = null}>Cancelar</button>
+          <button class="primary" disabled={!renameValue.trim()} on:click={confirmRename}>Guardar</button>
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  {#if movingNode}
+    <FolderPicker
+      flatNodes={flatNodes}
+      on:close={() => movingNode = null}
+      on:select={(e) => confirmMove(e.detail)}
+    />
   {/if}
 
   {#if editingFolder}


### PR DESCRIPTION
## Cambios

- Menú contextual (clic derecho) en filas del árbol de archivos/carpetas
- Archivos: Renombrar (modal inline), Mover a carpeta (selector de carpetas), Eliminar
- Carpetas: Nueva nota aquí, Renombrar, Eliminar carpeta
- Nuevos componentes: `TreeContextMenu.svelte`, `FolderPicker.svelte`
- Tipo `source_path` añadido a `api.notes.update`

Closes #119