### PR TITLE
test: add E2E API tests for notes, tags, goals, gamification (#11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run tests
         working-directory: api
-        run: python -m unittest discover -s tests
+        run: python -m pytest tests/ -v
 
   frontend-check:
     name: Frontend Typecheck

--- a/api/tests/test_e2e_gamification.py
+++ b/api/tests/test_e2e_gamification.py
@@ -1,0 +1,29 @@
+"""E2E tests for gamification endpoints via HTTP."""
+
+from fastapi.testclient import TestClient
+from models.gamification import XPEvent
+from models.note import Note
+
+
+def test_get_gamification_stats(client: TestClient):
+    resp = client.get("/gamification/stats")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "total_xp" in data
+
+
+def test_get_recent_events_empty(client: TestClient):
+    resp = client.get("/gamification/recent-events")
+    assert resp.status_code == 200
+
+
+def test_ping_event_returns_ok(client: TestClient):
+    resp = client.post("/gamification/ping")
+    assert resp.status_code == 200
+
+
+def test_creating_note_awards_xp(client: TestClient):
+    stats_before = client.get("/gamification/stats").json()
+    client.post("/notes/", json={"title": "XP Note", "content": "Test", "tags": []})
+    stats_after = client.get("/gamification/stats").json()
+    assert stats_after["total_xp"] >= stats_before["total_xp"] + 10

--- a/api/tests/test_e2e_goals.py
+++ b/api/tests/test_e2e_goals.py
@@ -1,0 +1,43 @@
+"""E2E tests for goal CRUD lifecycle via HTTP."""
+
+from fastapi.testclient import TestClient
+
+
+def test_create_goal(client: TestClient):
+    payload = {"title": "E2E Goal", "description": "Test", "temporality": "DAILY", "target_value": 1}
+    resp = client.post("/goals/", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["title"] == "E2E Goal"
+
+
+def test_list_goals(client: TestClient):
+    client.post("/goals/", json={"title": "List Goal", "temporality": "DAILY", "target_value": 1})
+    resp = client.get("/goals/")
+    assert resp.status_code == 200
+    goals = resp.json()
+    assert any(g["title"] == "List Goal" for g in goals)
+
+
+def test_get_goal_by_id(client: TestClient):
+    create = client.post("/goals/", json={"title": "Get Goal", "temporality": "DAILY", "target_value": 1}).json()
+    resp = client.get(f"/goals/{create['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Get Goal"
+
+
+def test_get_nonexistent_goal_returns_404(client: TestClient):
+    resp = client.get("/goals/999999")
+    assert resp.status_code == 404
+
+
+def test_complete_goal(client: TestClient):
+    create = client.post("/goals/", json={"title": "Complete Me", "temporality": "DAILY", "target_value": 1}).json()
+    resp = client.post(f"/goals/{create['id']}/complete")
+    assert resp.status_code == 200
+
+
+def test_delete_goal(client: TestClient):
+    create = client.post("/goals/", json={"title": "Delete Me", "temporality": "DAILY", "target_value": 1}).json()
+    resp = client.delete(f"/goals/{create['id']}")
+    assert resp.status_code == 204

--- a/api/tests/test_e2e_notes.py
+++ b/api/tests/test_e2e_notes.py
@@ -1,0 +1,75 @@
+"""E2E tests for note CRUD lifecycle via HTTP."""
+
+from fastapi.testclient import TestClient
+
+
+def test_create_note_minimal(client: TestClient):
+    payload = {"title": "Minimal Note", "content": "Hello", "tags": []}
+    resp = client.post("/notes/", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["title"] == "Minimal Note"
+    assert "id" in data
+
+
+def test_create_note_with_tags(client: TestClient):
+    payload = {"title": "Tagged Note", "content": "Has tags", "tags": ["e2e", "test"]}
+    resp = client.post("/notes/", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "test" in data["tags"]
+    assert "e2e" in data["tags"]
+
+
+def test_list_notes_includes_new(client: TestClient):
+    client.post("/notes/", json={"title": "List Test", "content": "X", "tags": []})
+    resp = client.get("/notes/")
+    assert resp.status_code == 200
+    notes = resp.json()
+    assert any(n["title"] == "List Test" for n in notes)
+
+
+def test_get_note_by_id(client: TestClient):
+    create = client.post("/notes/", json={"title": "Get Me", "content": "Find", "tags": []}).json()
+    resp = client.get(f"/notes/{create['id']}")
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Get Me"
+
+
+def test_get_nonexistent_note_returns_404(client: TestClient):
+    resp = client.get("/notes/999999")
+    assert resp.status_code == 404
+
+
+def test_update_note_title(client: TestClient):
+    create = client.post("/notes/", json={"title": "Old", "content": "X", "tags": []}).json()
+    resp = client.put(f"/notes/{create['id']}", json={"title": "New"})
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "New"
+
+
+def test_update_note_content_and_tags(client: TestClient):
+    create = client.post("/notes/", json={"title": "Upd", "content": "Old", "tags": ["a"]}).json()
+    resp = client.put(f"/notes/{create['id']}", json={"content": "New", "tags": ["b"]})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "b" in data["tags"]
+    assert "a" not in data["tags"]
+
+
+def test_delete_note(client: TestClient):
+    create = client.post("/notes/", json={"title": "Del", "content": "X", "tags": []}).json()
+    resp = client.delete(f"/notes/{create['id']}")
+    assert resp.status_code == 204
+    get_resp = client.get(f"/notes/{create['id']}")
+    assert get_resp.status_code == 404
+
+
+def test_note_create_invalid_title_returns_422(client: TestClient):
+    resp = client.post("/notes/", json={"content": "No title", "tags": []})
+    assert resp.status_code == 422
+
+
+def test_note_rebuild_derived(client: TestClient):
+    resp = client.post("/notes/rebuild-derived")
+    assert resp.status_code == 202

--- a/api/tests/test_e2e_tags.py
+++ b/api/tests/test_e2e_tags.py
@@ -1,0 +1,43 @@
+"""E2E tests for tag CRUD via HTTP."""
+
+from fastapi.testclient import TestClient
+
+
+def test_create_tag(client: TestClient):
+    resp = client.post("/tags/", json={"name": "e2e-tag"})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "e2e-tag"
+    assert "id" in data
+
+
+def test_create_duplicate_tag_returns_409(client: TestClient):
+    client.post("/tags/", json={"name": "dup-tag"})
+    resp = client.post("/tags/", json={"name": "dup-tag"})
+    assert resp.status_code == 409
+
+
+def test_list_tags(client: TestClient):
+    client.post("/tags/", json={"name": "list-tag"})
+    resp = client.get("/tags/")
+    assert resp.status_code == 200
+    tags = resp.json()
+    assert any(t["name"] == "list-tag" for t in tags)
+
+
+def test_set_tag_parent(client: TestClient):
+    parent = client.post("/tags/", json={"name": "parent-tag"}).json()
+    child = client.post("/tags/", json={"name": "child-tag"}).json()
+    resp = client.put(f"/tags/{child['id']}/parent?parent_id={parent['id']}")
+    assert resp.status_code == 200
+
+
+def test_cannot_set_self_as_parent(client: TestClient):
+    tag = client.post("/tags/", json={"name": "self-tag"}).json()
+    resp = client.put(f"/tags/{tag['id']}/parent?parent_id={tag['id']}")
+    assert resp.status_code == 400
+
+
+def test_tag_graph_endpoint(client: TestClient):
+    resp = client.get("/tags/graph")
+    assert resp.status_code == 200


### PR DESCRIPTION
## E2E API Tests (#11)

### Changes
- **`api/tests/test_e2e_notes.py`** (NEW) — Note CRUD lifecycle (create, read, update, delete, 422 validation, rebuild-derived)
- **`api/tests/test_e2e_tags.py`** (NEW) — Tag CRUD (create, list, set parent, self-parent prevention, graph endpoint)
- **`api/tests/test_e2e_goals.py`** (NEW) — Goal CRUD (create, list, get by id, 404, complete, delete)
- **`api/tests/test_e2e_gamification.py`** (NEW) — Gamification endpoints (stats, recent events, ping, XP award on note creation)
- **`.github/workflows/ci.yml`** — Switch test runner from `unittest discover` to `pytest` (required for fixture-based tests)

### Stacking
Branch base: `feat/38-structured-logging` (needs middleware for app fixture)

Closes #11