### PR TITLE
fix(frontend): resolve svelte-check syntax and type errors

### DIFF
--- a/frontend/src/lib/components/NoteCard.svelte
+++ b/frontend/src/lib/components/NoteCard.svelte
@@ -99,6 +99,7 @@
       {/if}
     </div>
   {/if}
+</div>
 
 <style>
   .note-card {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -277,12 +277,6 @@
 
   // Resizable panel synced with notes
   let panelWidth = 260;
-</script>
-
-<div class="dashboard" style="--panel-w: {panelWidth}px">
-
-  <!-- ── Left panel ─────────────────────────────────────────────────────────── -->
-  <section class="plant-section">
 
   function handleWidgetDrop(e: CustomEvent<{ id: WidgetId; fromPanel: 'left' | 'right'; fromIdx: number; toPanel: 'left' | 'right'; toIdx: number }>) {
     const { id, fromPanel, toPanel, toIdx } = e.detail;
@@ -292,6 +286,12 @@
       dashboardLayout.switchPanel(id, fromPanel);
     }
   }
+</script>
+
+<div class="dashboard" style="--panel-w: {panelWidth}px">
+
+  <!-- ── Left panel ─────────────────────────────────────────────────────────── -->
+  <section class="plant-section">
 
     {#each $dashboardLayout.left as wid, i (wid)}
       <Widget id={wid} panel="left" index={i} total={$dashboardLayout.left.length} layout={$dashboardLayout} on:drop={handleWidgetDrop}>

--- a/frontend/src/routes/integraciones/+page.svelte
+++ b/frontend/src/routes/integraciones/+page.svelte
@@ -25,7 +25,7 @@
     { id: 'tasks', label: 'Google Tasks', icon: 'CheckSquare', color: '#F9AB00', description: 'Tareas de Google', status: 'planned', configurable: false },
   ]);
 
-  let githubStatus = $state<{ connected: boolean; username: string } | null>(null);
+  let githubStatus = $state<{ connected: boolean; username: string | null } | null>(null);
 
   onMount(async () => {
     try {

--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -652,7 +652,7 @@
 
     {#if $bulkMode && $selectedNoteIds.size > 0}
       <div class="bulk-actions">
-        <span class="bulk-count">{$selectedNoteIds.size} nota{if $selectedNoteIds.size !== 1}s{/if}</span>
+        <span class="bulk-count">{$selectedNoteIds.size} nota{#if $selectedNoteIds.size !== 1}s{/if}</span>
         <button class="bulk-btn danger" on:click={() => { if (confirm(`¿Eliminar ${$selectedNoteIds.size} nota(s)?`)) deleteSelectedNotes(); }}>
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
           Eliminar

--- a/frontend/src/routes/skills/+page.svelte
+++ b/frontend/src/routes/skills/+page.svelte
@@ -17,17 +17,17 @@
   };
   const LEVEL_ORDER = ['locked', 'apprentice', 'journeyman', 'expert', 'master'];
 
-  $: filteredSkills = skills.filter(s => {
+  let filteredSkills = $derived(skills.filter(s => {
     if (searchQuery && !s.tag_name.toLowerCase().includes(searchQuery.toLowerCase())) return false;
     if (levelFilter && s.level !== levelFilter) return false;
     return true;
-  });
+  }));
 
-  $: topSkill = skills.sort((a, b) => b.note_count - a.note_count)[0];
-  $: totalUnlocked = skills.filter(s => s.level !== 'locked').length;
-  $: recentlyUnlocked = skills.filter(s => s.first_unlocked_at).sort((a, b) =>
+  let topSkill = $derived([...skills].sort((a, b) => b.note_count - a.note_count)[0]);
+  let totalUnlocked = $derived(skills.filter(s => s.level !== 'locked').length);
+  let recentlyUnlocked = $derived(skills.filter(s => s.first_unlocked_at).sort((a, b) =>
     new Date(b.first_unlocked_at!).getTime() - new Date(a.first_unlocked_at!).getTime()
-  ).slice(0, 3);
+  ).slice(0, 3));
 
   onMount(async () => {
     try {


### PR DESCRIPTION
## Problem
`npm run check` reported 9 type/template errors across the frontend.

## Changes
- `NoteCard.svelte`: close unclosed `<div>`.
- `routes/+page.svelte`: move `handleWidgetDrop` back inside `<script>` and add the missing `</script>` tag.
- `routes/notes/+page.svelte`: fix malformed `{#if}` block in bulk selection count.
- `routes/skills/+page.svelte`: replace `$:` with `$derived` for runes-mode compatibility.
- `routes/integraciones/+page.svelte`: widen `githubStatus.username` to `string | null`.

## Notes
`NoteEditor.svelte` still raises `mixed_event_handler_syntaxes` because it uses legacy `on:click` while Svelte 5 expects `onclick` in this component. A separate PR will migrate the event handlers.

## How to test
1. `make test-frontend-check` (or `cd frontend && npm run check`)
2. Errors should drop from 9 to 1 (the NoteEditor handler migration).

Refs #147

Generated with [Devin](https://devin.ai)