### PR TITLE
fix(api/tests): resolve router test 500s from rate-limit middleware

### DIFF
--- a/api/middleware/rate_limit.py
+++ b/api/middleware/rate_limit.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 from fastapi import HTTPException, Request
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 
 
 @dataclass

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -14,6 +14,7 @@ if "sqlite_vec" not in sys.modules:
 from database import Base, get_db
 from main import app
 from fastapi.testclient import TestClient
+from middleware.rate_limit import _default_limiter
 from services.auth_service import get_current_user
 
 @pytest.fixture
@@ -39,6 +40,12 @@ def db_session():
     session.close()
     engine.dispose()
 
+@pytest.fixture(autouse=True, scope="session")
+def _disable_rate_limits():
+    _default_limiter.requests_per_minute = 10_000
+    _default_limiter.auth_requests_per_minute = 10_000
+
+
 @pytest.fixture
 def client(db_session):
     def override_get_db():
@@ -47,6 +54,7 @@ def client(db_session):
     def override_get_current_user():
         return 1  # Fake user ID for tests
 
+    original_overrides = dict(app.dependency_overrides)
     app.dependency_overrides[get_db] = override_get_db
     app.dependency_overrides[get_current_user] = override_get_current_user
 
@@ -54,3 +62,4 @@ def client(db_session):
         yield test_client
 
     app.dependency_overrides.clear()
+    app.dependency_overrides.update(original_overrides)


### PR DESCRIPTION
## Problem
`make test-api` failed with 500/429 errors on `test_routers_notes.py` and `test_routers_tags.py` when running the full suite.

## Root cause
The `RateLimitMiddleware` returned a `JSONResponse` when the limit was exceeded, but `JSONResponse` was not imported, causing a `NameError`. That `NameError` propagated through `CorsSafetyMiddleware` and was returned as 500.

When the missing import was fixed, the tests then failed with 429 because the default 60 req/min limit is exceeded by the full suite.

## Changes
- Add missing `JSONResponse` import to `middleware/rate_limit.py`.
- Disable rate limiting during the pytest session in `tests/conftest.py`.
- Save/restore `app.dependency_overrides` in the `client` fixture for cleaner isolation.

## How to test
1. `make test-api` or `docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm api sh -c "PYTHONPATH=/app pytest"`
2. All 90 tests should pass.

Refs #148

Generated with [Devin](https://devin.ai)