### PR TITLE
docs(AGENTS): update JWT enforcement status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Two concurrent asyncio tasks: `watch_vault()` (watches `/vault/*.md`, 2s debounc
 
 ## Known Issues (from TODO.md / code audit)
 1. CORS allows `*` in non-production — needs config
-2. Auth JWT implemented but not enforced on any endpoint
+2. Auth JWT is now enforced on all data/mutation endpoints (except `/auth/*`, `/config`, and `/ws`)
 3. Embedding retry has edge cases (`EmbeddingFailure` table)
 4. Skill tree can have cycles if circular parent created manually
 5. Response cache is a placeholder


### PR DESCRIPTION
## Problem
`AGENTS.md` still listed "Auth JWT implemented but not enforced on any endpoint" as a known issue, but after the merge the API now requires authentication on most routers.

## Changes
Update the known-issues entry to indicate that JWT is now enforced on all data/mutation endpoints, with the expected exceptions of `/auth/*`, `/config`, and `/ws`.

Refs #151

Generated with [Devin](https://devin.ai)