### PR TITLE
infra(docker): prevent root-owned __pycache__ in dev bind mounts

### DIFF
--- a/ai-service/Dockerfile
+++ b/ai-service/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.12-slim
 
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
 WORKDIR /app
 
 COPY requirements.txt .

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.12-slim
 
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
 WORKDIR /app
 
 # Install system dependencies for sqlite-vec and curl (healthcheck)

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.12-slim
 
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Problem
Running `make dev` with bind mounts leaves `__pycache__` directories owned by root in `api/`, `ai-service/`, and `worker/`, which later causes permission errors for local tools.

## Changes
Set `PYTHONDONTWRITEBYTECODE=1` in the three Python service Dockerfiles so that no `.pyc`/`__pycache__` files are produced at runtime.

Refs #150

Generated with [Devin](https://devin.ai)