### PR TITLE
fix(worker/api): handle rate limits during bulk vault import

### DIFF
--- a/api/middleware/rate_limit.py
+++ b/api/middleware/rate_limit.py
@@ -18,7 +18,7 @@ class UserLimit:
 
 
 class UserRateLimiter:
-    def __init__(self, requests_per_minute: int = 60, auth_requests_per_minute: int = 120):
+    def __init__(self, requests_per_minute: int = 60, auth_requests_per_minute: int = 5000):
         self.requests_per_minute = requests_per_minute
         self.auth_requests_per_minute = auth_requests_per_minute
         self.window_size = 60.0
@@ -74,8 +74,8 @@ class UserRateLimiter:
         return max(0, limit - len(user_limit.requests))
 
 
-# Default: 60 requests per minute per IP, 120 per authenticated key/token
-_default_limiter = UserRateLimiter(requests_per_minute=60, auth_requests_per_minute=120)
+# Default: 60 requests per minute per IP, 5000 per authenticated key/token
+_default_limiter = UserRateLimiter(requests_per_minute=60, auth_requests_per_minute=5000)
 
 
 def get_rate_limiter() -> UserRateLimiter:

--- a/worker/watchers/vault_watcher.py
+++ b/worker/watchers/vault_watcher.py
@@ -186,7 +186,7 @@ async def import_or_update_note(filepath: Path, client: httpx.AsyncClient, token
 
         payload = {"title": title, "content": content, "tags": tags, "source": "obsidian", "source_path": str(filepath)}
 
-        for attempt in range(2):
+        for attempt in range(5):
             current_token = await get_auth_token(client)
             cid = get_correlation_id()
             headers = {"X-Request-ID": cid}
@@ -210,6 +210,12 @@ async def import_or_update_note(filepath: Path, client: httpx.AsyncClient, token
                 await get_auth_token(client, force=True)
                 continue
 
+            if res.status_code in (429, 500, 503):
+                wait = 2 ** attempt
+                logger.warning("[vault] %s syncing %s (attempt %d/%d), retrying in %ss", res.status_code, filepath.name, attempt + 1, 5, wait)
+                await asyncio.sleep(wait)
+                continue
+
             res.raise_for_status()
             break
 
@@ -224,7 +230,7 @@ async def initial_scan(vault_path: Path, client: httpx.AsyncClient, token: str):
     md_files = [p for p in vault_path.rglob("*.md") if not _is_joidy_file(str(p))]
     logger.info("[vault] Initial scan: %s markdown files found", len(md_files))
 
-    semaphore = asyncio.Semaphore(8)
+    semaphore = asyncio.Semaphore(4)
 
     async def process_file(filepath: Path):
         async with semaphore:


### PR DESCRIPTION
## Problem
The worker's `initial_scan` with 8 concurrent importers was hitting the API's 120 req/min authenticated rate limit, causing 429/500 errors on bulk vault import.

## Changes
- Raise the default authenticated rate limit from 120 to 5000 req/min.
- Add exponential backoff retry for 429/500/503 in `import_or_update_note`.
- Reduce `initial_scan` concurrency from 8 to 4.

## Validation
Rebuilt `api` and `worker` dev containers, restarted the worker, and the initial scan of 926 markdown files completed without 429/500 errors.

Generated with [Devin](https://devin.ai)