### PR TITLE
refactor(api): replace datetime.utcnow() with timezone-aware now

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -211,10 +211,10 @@ def debug_info():
     """Debug endpoint with detailed system information."""
     import os
     import sys
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     debug_data = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "python_version": sys.version,
         "platform": os.name,
         "env": {

--- a/api/repositories.py
+++ b/api/repositories.py
@@ -8,7 +8,7 @@ domain-specific query methods. Injected via FastAPI Depends.
 from __future__ import annotations
 
 from collections.abc import Generator
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Generic, TypeVar
 
 from fastapi import Depends
@@ -100,7 +100,7 @@ class NoteRepository(BaseRepository[Note]):
         )
 
     def get_recent(self, days: int = 7) -> list[Note]:
-        since = datetime.utcnow() - timedelta(days=days)
+        since = datetime.now(timezone.utc) - timedelta(days=days)
         return (
             self._db.query(Note)
             .filter(Note.created_at >= since)
@@ -180,7 +180,7 @@ class EmbeddingFailureRepository(BaseRepository[EmbeddingFailure]):
         )
 
     def get_retryable(self, limit: int = 20) -> list[EmbeddingFailure]:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         return (
             self._db.query(EmbeddingFailure)
             .filter(
@@ -192,7 +192,7 @@ class EmbeddingFailureRepository(BaseRepository[EmbeddingFailure]):
         )
 
     def get_dead_letters(self, limit: int = 50) -> list[EmbeddingFailure]:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         return (
             self._db.query(EmbeddingFailure)
             .filter(
@@ -204,7 +204,7 @@ class EmbeddingFailureRepository(BaseRepository[EmbeddingFailure]):
         )
 
     def count_dead_letters(self) -> int:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         return (
             self._db.query(EmbeddingFailure)
             .filter(

--- a/api/routers/goals.py
+++ b/api/routers/goals.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 
 from database import get_db
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
@@ -340,7 +340,7 @@ def complete_goal(
         raise HTTPException(status_code=404, detail="Goal not found")
     goal.is_completed = True
     goal.state = GoalState.COMPLETED
-    goal.completed_at = datetime.utcnow()
+    goal.completed_at = datetime.now(timezone.utc)
     goal.current_value = get_goal_progress(goal, db)
     gami = process_event(db, "goal_completed", {"goal_id": goal_id, "title": goal.title})
     db.commit()

--- a/api/routers/integrations/github.py
+++ b/api/routers/integrations/github.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import httpx
@@ -706,7 +706,7 @@ async def sync_repo(repo_id: int, db: Session = Depends(get_db)):
             existing.body = issue_data.get("body", "")
             existing.state = issue_data.get("state", "open")
             existing.labels = labels_str
-            existing.updated_at = datetime.utcnow()
+            existing.updated_at = datetime.now(timezone.utc)
         else:
             item = GitHubItem(
                 repo_id=repo_id,
@@ -725,12 +725,12 @@ async def sync_repo(repo_id: int, db: Session = Depends(get_db)):
                 labels=labels_str,
                 url=issue_data.get("url", ""),
                 html_url=issue_data.get("html_url", ""),
-                synced_at=datetime.utcnow(),
+                synced_at=datetime.now(timezone.utc),
             )
             db.add(item)
         synced_count += 1
 
-    repo.last_synced_at = datetime.utcnow()
+    repo.last_synced_at = datetime.now(timezone.utc)
     db.commit()
 
     return {

--- a/api/routers/planning.py
+++ b/api/routers/planning.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from database import get_db
 from fastapi import APIRouter, Depends, HTTPException
@@ -53,7 +53,7 @@ def set_assignments(data: AssignmentsIn, db: Session = Depends(get_db)):
     db.query(PlanningAssignment).filter(PlanningAssignment.date == date_obj).delete()
     # Insert new
     for gid in data.goal_ids:
-        pa = PlanningAssignment(date=date_obj, goal_id=gid, created_at=datetime.utcnow())
+        pa = PlanningAssignment(date=date_obj, goal_id=gid, created_at=datetime.now(timezone.utc))
         db.add(pa)
     db.commit()
     clear_api_caches()

--- a/api/routers/stats.py
+++ b/api/routers/stats.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from database import get_db
 from fastapi import APIRouter, Depends
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/stats", tags=["stats"])
 @router.get("/system")
 def get_system_stats(db: Session = Depends(get_db)):
     """Get system-wide statistics."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     week_ago = now - timedelta(days=7)
 
     notes_count = db.query(Note).count()
@@ -45,7 +45,7 @@ def get_activity_stats(
     db: Session = Depends(get_db)
 ):
     """Get activity statistics for the last N days."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     since = now - timedelta(days=days)
 
     daily_stats = []

--- a/api/seed_data.py
+++ b/api/seed_data.py
@@ -1,5 +1,5 @@
 import random
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from database import SessionLocal
 from models.goal import (
@@ -20,7 +20,7 @@ def seed():
     db.commit()
 
     print("Generating goals and streaks...")
-    today = datetime.utcnow()
+    today = datetime.now(timezone.utc)
 
     # 1. Past 180 days streak (Heatmap)
     for i in range(180, -1, -1):

--- a/api/services/auth_service.py
+++ b/api/services/auth_service.py
@@ -3,7 +3,7 @@ JWT Authentication Service.
 """
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import jwt
 from config import settings
@@ -23,7 +23,7 @@ def create_access_token(user_id: int, username: str = "user") -> str:
     if not settings.secret_key:
         raise ValueError("SECRET_KEY not configured")
 
-    expire = datetime.utcnow() + timedelta(hours=TOKEN_EXPIRE_HOURS)
+    expire = datetime.now(timezone.utc) + timedelta(hours=TOKEN_EXPIRE_HOURS)
     to_encode = {
         "sub": str(user_id),
         "username": username,

--- a/api/services/embedding_service.py
+++ b/api/services/embedding_service.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import httpx
 from config import settings
@@ -55,7 +55,7 @@ def record_embedding_failure(db: Session, note_id: int, error_message: str) -> N
         )
     else:
         delay = compute_retry_delay_seconds(failure.attempts, settings.embedding_retry_base_seconds)
-        failure.next_retry_at = datetime.utcnow() + timedelta(seconds=delay)
+        failure.next_retry_at = datetime.now(timezone.utc) + timedelta(seconds=delay)
         logger.info(
             "Embedding retry scheduled for note_id=%s attempt=%d delay=%ds",
             note_id, failure.attempts, delay,
@@ -70,7 +70,7 @@ def clear_embedding_failure(db: Session, note_id: int) -> None:
 
 def get_retryable_embedding_notes(db: Session, limit: int = 20) -> list[Note]:
     """Get notes whose embeddings failed but are still retryable (not dead-lettered)."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     max_attempts = settings.embedding_retry_max_attempts
     failures = (
         db.query(EmbeddingFailure)
@@ -119,7 +119,7 @@ def reset_dead_letter_entry(db: Session, note_id: int) -> bool:
     if not failure:
         return False
     failure.attempts = 0
-    failure.next_retry_at = datetime.utcnow()
+    failure.next_retry_at = datetime.now(timezone.utc)
     db.commit()
     logger.info("Dead letter entry reset for note_id=%s", note_id)
     return True

--- a/api/services/goal_service.py
+++ b/api/services/goal_service.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from models.goal import (
     Goal,
@@ -187,7 +187,7 @@ def get_bulk_goal_progress(goals: list[Goal], db: Session) -> dict[int, float]:
 
 
 def evaluate_active_goals(db: Session):
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     active_goals = GoalRepository(db).get_active()
 
     for goal in active_goals:
@@ -302,7 +302,7 @@ def get_goal_streak(db: Session) -> dict:
         return {"current_streak": 0, "best_streak": 0}
 
     # Current streak: count backwards from today
-    today = datetime.utcnow().date()
+    today = datetime.now(timezone.utc).date()
     current_streak = 0
     day = today
     while day in completion_dates:

--- a/api/services/joidy_vault_writer.py
+++ b/api/services/joidy_vault_writer.py
@@ -4,7 +4,7 @@ Joidy NEVER modifies files outside of _joidy/.
 """
 
 import os
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 from models.gamification import StreakRecord, UserStats
@@ -276,7 +276,7 @@ def write_readme(vault_path: Path) -> None:
 
 
 def _get_notes_created_today(db: Session, today: date) -> list:
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     from models.note import Note
     start = datetime.combine(today, datetime.min.time())
@@ -285,10 +285,10 @@ def _get_notes_created_today(db: Session, today: date) -> list:
 
 
 def _get_top_tags_week(db: Session) -> list:
-    from datetime import timedelta
+    from datetime import timedelta, timezone
 
     from models.note import Note, Tag
-    week_ago = datetime.utcnow() - timedelta(days=7)
+    week_ago = datetime.now(timezone.utc) - timedelta(days=7)
     results = (
         db.query(Tag.name, Tag.id)
         .join(NoteTag, NoteTag.tag_id == Tag.id)

--- a/api/services/skill_tree.py
+++ b/api/services/skill_tree.py
@@ -3,7 +3,7 @@ Skill Tree Service — derives the RPG skill tree from note/tag data.
 Skills are auto-generated from tags, no manual configuration needed.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from models.note import NoteTag, Tag
 from models.skill import Skill, compute_skill_level
@@ -36,7 +36,7 @@ def sync_skills_for_tags(db: Session, tag_ids: set[int]) -> list[dict]:
                 continue
             skill = Skill(tag_id=tag_id, note_count=count, level=new_level)
             if new_level != "locked":
-                skill.first_unlocked_at = datetime.utcnow()
+                skill.first_unlocked_at = datetime.now(timezone.utc)
             db.add(skill)
             updated.append({"tag_id": tag_id, "level": new_level, "new": True})
             continue
@@ -50,7 +50,7 @@ def sync_skills_for_tags(db: Session, tag_ids: set[int]) -> list[dict]:
         skill.level = new_level
 
         if prev_level == "locked" and new_level != "locked":
-            skill.first_unlocked_at = datetime.utcnow()
+            skill.first_unlocked_at = datetime.now(timezone.utc)
             updated.append({"tag_id": tag_id, "level": new_level, "new": False, "unlocked": True})
         else:
             updated.append({"tag_id": tag_id, "level": new_level, "new": False})
@@ -82,7 +82,7 @@ def sync_skills(db: Session) -> list[dict]:
         skill.level = new_level
 
         if prev_level == "locked" and new_level != "locked":
-            skill.first_unlocked_at = datetime.utcnow()
+            skill.first_unlocked_at = datetime.now(timezone.utc)
             updated.append({"tag_id": tag_id, "level": new_level, "new": False, "unlocked": True})
         else:
             updated.append({"tag_id": tag_id, "level": new_level, "new": False})
@@ -93,7 +93,7 @@ def sync_skills(db: Session) -> list[dict]:
         new_level = compute_skill_level(count)
         skill = Skill(tag_id=tag_id, note_count=count, level=new_level)
         if new_level != "locked":
-            skill.first_unlocked_at = datetime.utcnow()
+            skill.first_unlocked_at = datetime.now(timezone.utc)
         db.add(skill)
         updated.append({"tag_id": tag_id, "level": new_level, "new": True})
 

--- a/api/tests/test_embedding_service.py
+++ b/api/tests/test_embedding_service.py
@@ -3,7 +3,7 @@
 import sys
 import types
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from sqlalchemy import create_engine
@@ -45,7 +45,7 @@ class TestGetRetryableNotes(EmbeddingServiceTestBase):
             failure = EmbeddingFailure(
                 note_id=note.id, attempts=2,
                 last_error="timeout",
-                next_retry_at=datetime.utcnow() - timedelta(seconds=1),
+                next_retry_at=datetime.now(timezone.utc) - timedelta(seconds=1),
             )
             db.add(failure)
             db.commit()
@@ -80,7 +80,7 @@ class TestGetRetryableNotes(EmbeddingServiceTestBase):
             failure = EmbeddingFailure(
                 note_id=note.id, attempts=1,
                 last_error="temp",
-                next_retry_at=datetime.utcnow() + timedelta(hours=1),
+                next_retry_at=datetime.now(timezone.utc) + timedelta(hours=1),
             )
             db.add(failure)
             db.commit()
@@ -94,7 +94,7 @@ class TestGetRetryableNotes(EmbeddingServiceTestBase):
             failure = EmbeddingFailure(
                 note_id=99999, attempts=1,
                 last_error="orphan",
-                next_retry_at=datetime.utcnow() - timedelta(seconds=1),
+                next_retry_at=datetime.now(timezone.utc) - timedelta(seconds=1),
             )
             db.add(failure)
             db.commit()

--- a/api/tests/test_goal_service.py
+++ b/api/tests/test_goal_service.py
@@ -3,7 +3,7 @@
 import sys
 import types
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
@@ -207,7 +207,7 @@ class TestGetGoalStreak(GoalServiceTestBase):
 
     def test_consecutive_days(self) -> None:
         with self.Session() as db:
-            today = datetime.utcnow()
+            today = datetime.now(timezone.utc)
             for i in range(3):
                 g = Goal(
                     title=f"G{i}", state=GoalState.COMPLETED,


### PR DESCRIPTION
## Problem
Python 3.12 deprecates `datetime.utcnow()`. `pytest` and runtime emit deprecation warnings across the API.

## Changes
Replace all `datetime.utcnow()` calls with `datetime.now(timezone.utc)` in API services, routers, tests and seed data, and add `timezone` to the `datetime` imports.

## Verification
`make test-api` passes (90/90) and no longer shows `utcnow` deprecation warnings.

Generated with [Devin](https://devin.ai)