### PR TITLE
infra(docker): mount .env into ai-service container

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,6 +35,7 @@ services:
     volumes:
       - ./ai-service:/app
       - ./data/db:/data/db
+      - ./.env:/app/.env:ro
     command: uvicorn main:app --host 0.0.0.0 --port 8002 --reload
 
   worker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - "${AI_SERVICE_PORT:-8002}:8002"
     volumes:
       - ./data/db:/data/db
+      - ./.env:/app/.env:ro
     environment:
       - DATABASE_URL=postgresql://joidy:joidy@postgres:5432/joidy
       - APP_ENV=${APP_ENV:-production}


### PR DESCRIPTION
## Problem
`ai-service` relies on `GEMINI_API_KEY` (and other settings) from `.env`, but neither `docker-compose.yml` nor `docker-compose.dev.yml` mounted the file into the container.

## Changes
Add a read-only `.env` bind mount to the `ai-service` service in both compose files.

Generated with [Devin](https://devin.ai)