### PR TITLE
feat(api): make CORS origins configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,10 @@ TELEGRAM_ALLOWED_USER_ID=
 SECRET_KEY=change_this_to_a_random_secret_key
 APP_ENV=development
 
+# Comma-separated allowed CORS origins (e.g. http://localhost:3000,https://joidy.app).
+# In development, leave empty to allow all origins with credentials disabled.
+CORS_ALLOWED_ORIGINS=
+
 # ── Ports (change if conflicts with existing services) ──
 FRONTEND_PORT=3000
 API_PORT=8000

--- a/api/main.py
+++ b/api/main.py
@@ -114,10 +114,11 @@ app.add_middleware(RateLimitMiddleware)
 
 def _get_cors_origins() -> list[str]:
     """Return allowed CORS origins based on environment."""
+    if settings.cors_allowed_origins:
+        return [o.strip() for o in settings.cors_allowed_origins.split(",") if o.strip()]
     if settings.app_env == "production":
-        origins = settings.cors_allowed_origins
-        return [o.strip() for o in origins.split(",") if o.strip()] if origins else []
-    return ["*"]  # Development: allow all
+        return []
+    return ["*"]  # Development fallback: allow all
 
 
 _cors_origins = _get_cors_origins()


### PR DESCRIPTION
## Problem
CORS in development was hardcoded to `*`, and production relied solely on `APP_ENV`. This made it hard to restrict origins in development or test with explicit origins.

## Changes
- Add `CORS_ALLOWED_ORIGINS` to `.env.example`.
- `_get_cors_origins()` now uses `CORS_ALLOWED_ORIGINS` when set, regardless of environment.
- Falls back to `*` only in development when no explicit origins are configured.

Generated with [Devin](https://devin.ai)