### PR TITLE
fix(frontend/skills): declare reactive state with 

### DIFF
--- a/frontend/src/routes/skills/+page.svelte
+++ b/frontend/src/routes/skills/+page.svelte
@@ -6,9 +6,9 @@
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
   import { Search, X } from 'lucide-svelte';
 
-  let skills: Skill[] = [];
-  let treeData: SkillTreeData = { nodes: [], edges: [] };
-  let loading = true;
+  let skills: Skill[] = $state([]);
+  let treeData: SkillTreeData = $state({ nodes: [], edges: [] });
+  let loading = $state(true);
   let searchQuery = $state('');
   let levelFilter = $state<string | null>(null);
 


### PR DESCRIPTION
## Problem
`skills/+page.svelte` uses runes (`$state`/`$derived`) but `skills`, `treeData` and `loading` were declared with plain `let`, causing `non_reactive_update` warnings.

## Changes
Convert those variables to `$state(...)` so derived values and the template update correctly.

Generated with [Devin](https://devin.ai)