### PR TITLE
fix(frontend/card): avoid a11y tabIndex warning

### DIFF
--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -10,7 +10,7 @@
   class:clickable
   on:click
   role={clickable ? 'button' : undefined}
-  tabindex={clickable ? 0 : undefined}
+  tabindex={clickable ? 0 : -1}
   on:keydown={(e) => clickable && e.key === 'Enter' && e.currentTarget.click()}
 >
   <slot />


### PR DESCRIPTION
## Problem
Svelte a11y warns about `noninteractive element cannot have nonnegative tabIndex value` in `Card.svelte`.

## Changes
Set `tabindex={clickable ? 0 : -1}` so non-clickable cards are not focusable and the warning disappears.

Generated with [Devin](https://devin.ai)