### PR TITLE
fix(frontend/goal-card): add standard line-clamp property

### DIFF
--- a/frontend/src/lib/components/GoalCard.svelte
+++ b/frontend/src/lib/components/GoalCard.svelte
@@ -225,6 +225,7 @@
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
+    line-clamp: 2;
     overflow: hidden;
   }
 
@@ -235,6 +236,7 @@
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
+    line-clamp: 2;
     overflow: hidden;
   }
 


### PR DESCRIPTION
Svelte CSS warns about missing standard `line-clamp` property. Add it alongside `-webkit-line-clamp` in GoalCard.

Generated with [Devin](https://devin.ai)