### PR TITLE
fix(frontend/tag-chip): add keyboard handler for a11y

### DIFF
--- a/frontend/src/lib/components/TagChip.svelte
+++ b/frontend/src/lib/components/TagChip.svelte
@@ -11,6 +11,7 @@
   class="tag-chip" 
   class:ai={isAI} 
   on:click|stopPropagation={() => dispatch('click', tag)}
+  on:keydown={(e) => e.key === 'Enter' && dispatch('click', tag)}
   role="button"
   tabindex="0"
 >


### PR DESCRIPTION
The `<span role=\"button\">` in TagChip needs a keyboard handler. Add `on:keydown` to activate on Enter and satisfy a11y rules.

Generated with [Devin](https://devin.ai)