### PR TITLE
fix(frontend/modal): address a11y warnings

### DIFF
--- a/frontend/src/lib/components/Modal.svelte
+++ b/frontend/src/lib/components/Modal.svelte
@@ -22,8 +22,10 @@
     role="dialog"
     aria-modal="true"
     aria-label={title || 'Diálogo'}
+    tabindex="-1"
     transition:fade={{ duration: 150 }}
     on:click|self={closeModal}
+    on:keydown={(e) => e.key === 'Escape' && closeModal()}
   >
     <div
       class="modal modal-{size}"
@@ -32,7 +34,7 @@
     >
       <div class="modal-header">
         <h3 class="modal-title">{title}</h3>
-        <button class="modal-close" autofocus on:click={closeModal}>
+        <button class="modal-close" on:click={closeModal}>
           <DynamicIcon name="X" size={18} />
         </button>
       </div>


### PR DESCRIPTION
Add `tabindex` and `on:keydown` to the modal overlay and remove the deprecated `autofocus` attribute from the close button.

Generated with [Devin](https://devin.ai)