### PR TITLE
fix(frontend/goal-editor): add role to dblclick target

### DIFF
--- a/frontend/src/lib/components/GoalEditor.svelte
+++ b/frontend/src/lib/components/GoalEditor.svelte
@@ -202,7 +202,7 @@
 
   <div class="content-area">
     {#if previewMode}
-      <div class="preview" on:dblclick={() => previewMode = false}>
+      <div class="preview" on:dblclick={() => previewMode = false} role="button" tabindex="-1">
         {@html renderedHtml}
       </div>
     {:else}


### PR DESCRIPTION
Add `role="button"` and `tabindex="-1"` to the preview div with `on:dblclick` to satisfy Svelte a11y checks.

Generated with [Devin](https://devin.ai)