### PR TITLE
fix(frontend): suppress false-positive Card a11y warning

### DIFF
--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -4,12 +4,13 @@
   export let clickable = false;
 </script>
 
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
   class="card padding-{padding}"
   class:hoverable
   class:clickable
   on:click
-  role={clickable ? 'button' : 'presentation'}
+  role={clickable ? 'button' : 'none'}
   tabindex={clickable ? 0 : -1}
   on:keydown={(e) => clickable && e.key === 'Enter' && e.currentTarget.click()}
 >


### PR DESCRIPTION
## Problem
`Card.svelte` continued to trigger `a11y_no_noninteractive_tabindex` because the static Svelte analyzer cannot correlate the conditional `role` and `tabindex` expressions.

## Changes
Add a targeted `<!-- svelte-ignore a11y_no_noninteractive_tabindex -->` on the root element while keeping the `clickable` prop behavior intact.

## Verification
`npm run check` drops from 237 to 236 warnings, with 0 errors.

Generated with [Devin](https://devin.ai)