### PR TITLE
fix(infra): improve fix-permissions.sh to clean root-owned artifacts

### DIFF
--- a/scripts/fix-permissions.sh
+++ b/scripts/fix-permissions.sh
@@ -8,7 +8,7 @@ PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 echo "Project root: $PROJECT_ROOT"
 cd "$PROJECT_ROOT"
 
-echo "Fixing permissions for Joidy project..."
+echo "Fixing permissions and cleaning Docker-generated artifacts for Joidy..."
 
 # Detect original user (not root)
 if [ -n "$SUDO_USER" ]; then
@@ -27,6 +27,15 @@ CURRENT_GROUP=$(id -gn "$CURRENT_USER" 2>/dev/null || echo "d4mag3")
 
 echo "Target user: $CURRENT_USER, group: $CURRENT_GROUP"
 
+# Remove Python caches that may have been generated as root by Docker containers
+echo "Removing __pycache__ directories..."
+find "$PROJECT_ROOT" -type d -name "__pycache__" -prune -exec rm -rf {} + 2>/dev/null || true
+
+# Remove coverage data files
+echo "Removing coverage data..."
+find "$PROJECT_ROOT" -name ".coverage" -delete 2>/dev/null || true
+find "$PROJECT_ROOT" -type d -name ".pytest_cache" -prune -exec rm -rf {} + 2>/dev/null || true
+
 # Remove and recreate .svelte-kit directory with correct ownership
 if [ -d "$PROJECT_ROOT/frontend/.svelte-kit" ]; then
     echo "Removing and recreating .svelte-kit..."
@@ -42,16 +51,17 @@ fi
 # Create fresh directories
 mkdir -p "$PROJECT_ROOT/frontend/.svelte-kit"
 
-# Fix ownership
+# Fix ownership of project Python/Node directories that may have root-owned files
 echo "Setting ownership to $CURRENT_USER:$CURRENT_GROUP..."
-chown -R $CURRENT_USER:$CURRENT_GROUP "$PROJECT_ROOT/frontend/.svelte-kit"
-chown -R $CURRENT_USER:$CURRENT_GROUP "$PROJECT_ROOT/frontend/build" 2>/dev/null || true
-chown -R $CURRENT_USER:$CURRENT_GROUP "$PROJECT_ROOT/frontend/node_modules/.cache" 2>/dev/null || true
-chown -R $CURRENT_USER:$CURRENT_GROUP "$PROJECT_ROOT/api/__pycache__" 2>/dev/null || true
+for dir in api worker ai-service frontend; do
+    if [ -d "$PROJECT_ROOT/$dir" ]; then
+        chown -R $CURRENT_USER:$CURRENT_GROUP "$PROJECT_ROOT/$dir" 2>/dev/null || true
+    fi
+done
 
-# Set proper permissions
-chmod -R 755 "$PROJECT_ROOT/frontend/.svelte-kit"
+# Set proper permissions for SvelteKit generated directory
+chmod -R 755 "$PROJECT_ROOT/frontend/.svelte-kit" 2>/dev/null || true
 chmod -R 755 "$PROJECT_ROOT/frontend/build" 2>/dev/null || true
 
-echo "✓ Permissions fixed for user: $CURRENT_USER"
-echo "Now run: cd frontend && npm run build"
+echo "✓ Permissions and artifacts cleaned for user: $CURRENT_USER"
+echo "Now run: make dev"


### PR DESCRIPTION
## Summary
Improve `scripts/fix-permissions.sh` so it actually removes root-owned `__pycache__` and other Docker-generated artifacts instead of only touching a few paths.

## Changes
- Remove all `__pycache__` directories across the project.
- Remove `.coverage`, `.pytest_cache`, and the frontend `.svelte-kit`/build dirs.
- Restore ownership on `api/`, `worker/`, `ai-service/`, and `frontend/`.
- Remove the stale "Now run: cd frontend && npm run build" hint; suggest `make dev`.

## Verification
- Cleaned existing root-owned `__pycache__` and `.svelte-kit` from the host using the updated logic.
- Confirmed no root-owned files remain in the project tree.

Closes #150.

Generated with [Devin](https://devin.ai)