### PR TITLE
fix(frontend,api): implement real GitHub OAuth device flow in SettingsPanel

### DIFF
--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -118,7 +118,12 @@ def update_config(update: ConfigUpdate):
 
     write_env(env_vars)
 
-    return {"status": "ok", "message": "Configuration updated. Some changes may require a restart."}
+    # Update in-memory settings so services see the new values immediately
+    for short_key, value in update_data.items():
+        if value is not None and hasattr(settings, short_key):
+            setattr(settings, short_key, value)
+
+    return {"status": "ok", "message": "Configuration updated."}
 
 
 @router.get("/keys", dependencies=[Depends(get_current_user)])

--- a/api/routers/integrations/github.py
+++ b/api/routers/integrations/github.py
@@ -865,11 +865,15 @@ async def poll_device_code(
 
 @router.post("/oauth/revoke")
 async def revoke_token(
-    token: str = Query(..., description="Token to revoke"),
+    token: str | None = Query(None, description="Token to revoke; defaults to the configured token"),
 ):
     """
-    Revoca un token de acceso GitHub.
+    Revoca el token de acceso GitHub configurado.
     """
+    token = token or settings.github_token
+    if not token:
+        raise HTTPException(status_code=400, detail="No GitHub token to revoke")
+
     revoke_url = "https://github.com/login/oauth/revoke"
 
     async with httpx.AsyncClient(timeout=30.0) as client:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -310,6 +310,9 @@ github: {
     issues: (filter: string = 'all') => req<{ issues: { id: number; number: number; title: string; repo: string; url: string; state: string; updated_at: string; author?: string }[]; stats: { total: number; open: number; closed: number }; filter: string }>('GET', `/integrations/github/issues?filter=${filter}`),
     pulls: (filter: string = 'all') => req<{ pulls: { id: number; number: number; title: string; repo: string; url: string; state: string; draft: boolean; updated_at: string; author?: string }[]; stats: { total: number; open: number; closed: number; draft: number }; filter: string }>('GET', `/integrations/github/pulls?filter=${filter}`),
     repos: () => req<{ repos: { id: number; name: string; full_name: string; color: string }[] }>('GET', '/integrations/github/repos'),
+    startDeviceAuth: () => req<{ device_code: string; user_code: string; verification_uri: string; verification_uri_secondary?: string; expires_in: number; interval: number }>('GET', '/integrations/github/oauth/device/start'),
+    pollDeviceCode: (device_code: string) => req<{ status: 'authorized'; access_token: string; token_type: string; scope: string } | { status: 'pending' | 'slowdown' | 'expired' | 'denied'; message: string }>('POST', `/integrations/github/oauth/device/polling?device_code=${encodeURIComponent(device_code)}`),
+    revoke: () => req<{ status: string }>('POST', '/integrations/github/oauth/revoke'),
   },
 
   config: {

--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { createEventDispatcher, onMount, onDestroy } from 'svelte';
-  import { goto } from '$app/navigation';
   import { browser } from '$app/environment';
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
   import { accentColors, activeIconPack, showFrontmatter, showTrash, showHiddenFiles, writeInObsidian, use24HourClock, hideTagsLine, darkMode, devMode, type IconPack, MAX_COLORS } from '$lib/stores/settings';
   import { api } from '$lib/api';
   import { logger } from '$lib/utils/logger';
   import { deferredPrompt, isAppInstalled, showInstallBanner } from '$lib/stores/pwa';
+  import { showNotification } from '$lib/stores/notifications';
 
   export let open = false;
 
@@ -20,6 +20,14 @@
 
   let githubConnected = false;
   let githubUsername = '';
+  let githubAuthLoading = false;
+  let githubAuthError = '';
+  let githubUserCode = '';
+  let githubVerificationUri = '';
+  let githubDeviceCode = '';
+  let githubPollInterval = 5;
+  let githubExpiresAt = 0;
+  let githubPollTimer: ReturnType<typeof setTimeout> | null = null;
 
   let googleCalendarConnected = false;
   let googleCalendarEmail = '';
@@ -106,8 +114,88 @@
     }
   }
 
-  async function openGithubLink() {
-    goto('/integraciones');
+  function clearGithubAuth() {
+    githubAuthLoading = false;
+    githubAuthError = '';
+    githubUserCode = '';
+    githubVerificationUri = '';
+    githubDeviceCode = '';
+    githubPollInterval = 5;
+    githubExpiresAt = 0;
+    if (githubPollTimer) {
+      clearTimeout(githubPollTimer);
+      githubPollTimer = null;
+    }
+  }
+
+  async function startGithubAuth() {
+    githubAuthLoading = true;
+    githubAuthError = '';
+    try {
+      const data = await api.github.startDeviceAuth();
+      githubDeviceCode = data.device_code;
+      githubUserCode = data.user_code;
+      githubVerificationUri = data.verification_uri;
+      githubPollInterval = data.interval || 5;
+      githubExpiresAt = Date.now() + (data.expires_in || 900) * 1000;
+      if (githubVerificationUri) {
+        window.open(githubVerificationUri, '_blank');
+      }
+      await pollGithubDeviceCode();
+    } catch (e: any) {
+      githubAuthError = e.message || 'Error iniciando autenticación con GitHub';
+      githubAuthLoading = false;
+    }
+  }
+
+  async function pollGithubDeviceCode() {
+    if (!githubDeviceCode) {
+      clearGithubAuth();
+      return;
+    }
+    if (Date.now() >= githubExpiresAt) {
+      githubAuthError = 'El código de verificación expiró. Intenta de nuevo.';
+      githubAuthLoading = false;
+      return;
+    }
+    try {
+      const result = await api.github.pollDeviceCode(githubDeviceCode);
+      if (result.status === 'authorized') {
+        await api.config.update({ github_token: result.access_token, github_username: '' });
+        await checkGithubStatus();
+        clearGithubAuth();
+        showNotification('GitHub conectado correctamente', 'success');
+        return;
+      }
+      if (result.status === 'denied') {
+        githubAuthError = 'Acceso denegado. No se concedieron permisos.';
+        githubAuthLoading = false;
+        return;
+      }
+      if (result.status === 'expired') {
+        githubAuthError = 'El código expiró. Intenta de nuevo.';
+        githubAuthLoading = false;
+        return;
+      }
+      if (result.status === 'slowdown') {
+        githubPollInterval += 5;
+      }
+      githubPollTimer = setTimeout(pollGithubDeviceCode, githubPollInterval * 1000);
+    } catch (e: any) {
+      githubAuthError = e.message || 'Error verificando autorización de GitHub';
+      githubAuthLoading = false;
+    }
+  }
+
+  async function disconnectGithub() {
+    try {
+      await api.github.revoke();
+    } catch (e) {
+      // Ignorar errores de revoke; de todos modos borramos el token
+    }
+    await api.config.update({ github_token: '', github_username: '' });
+    await checkGithubStatus();
+    showNotification('GitHub desconectado', 'info');
   }
 
   async function openGoogleCalendarLink() { window.open('https://calendar.google.com', '_blank'); }
@@ -120,10 +208,13 @@
     configSaving = true;
     configMessage = '';
     try {
-      const result = await api.config.update(systemConfig);
+      // No enviamos github_token ni github_username desde el formulario general;
+      // esos se manejan con el flujo OAuth dedicado.
+      const { github_token, github_username, ...configToSave } = systemConfig;
+      const result = await api.config.update(configToSave);
       configMessage = result.message;
-      configuredKeys = Object.entries(systemConfig)
-        .filter(([k, v]) => v && k !== 'github_token' && k !== 'telegram_bot_token' && k !== 'telegram_allowed_user_id')
+      configuredKeys = Object.entries(configToSave)
+        .filter(([k, v]) => v && k !== 'telegram_bot_token' && k !== 'telegram_allowed_user_id')
         .map(([k, v]) => k);
       setTimeout(() => configMessage = '', 3000);
     } catch (e: any) {
@@ -447,12 +538,33 @@
               <span>GitHub</span>
               {#if githubConnected}<span class="configured-badge">✓</span>{/if}
             </div>
-            {#if githubConnected}
-              <span class="mono" style="font-size:12px; color: var(--xp);">{githubUsername}</span>
+            {#if githubAuthLoading}
+              <span class="mono" style="font-size:12px; color: var(--text-muted);">
+                {#if githubUserCode}
+                  Código: <code style="margin-left:4px;">{githubUserCode}</code>
+                {:else}
+                  Conectando…
+                {/if}
+              </span>
+            {:else if githubConnected}
+              <div style="display:flex; align-items:center; gap:8px;">
+                <span class="mono" style="font-size:12px; color: var(--xp);">{githubUsername}</span>
+                <button class="link-btn" on:click={disconnectGithub} style="background:var(--border); color:var(--text-secondary);">Desconectar</button>
+              </div>
             {:else}
-              <button class="link-btn" on:click={openGithubLink}>Enlazar</button>
+              <button class="link-btn" on:click={startGithubAuth} disabled={githubAuthLoading}>Enlazar</button>
             {/if}
           </div>
+          {#if githubAuthLoading && githubUserCode}
+            <p class="hint">
+              Abre <a href={githubVerificationUri} target="_blank">{githubVerificationUri}</a> e introduce el código <code>{githubUserCode}</code> para autorizar a Joidy.
+              {#if githubAuthError}
+                <br /><span style="color:var(--danger)">{githubAuthError}</span>
+              {/if}
+            </p>
+          {:else if githubAuthError && !githubAuthLoading}
+            <p class="hint" style="color:var(--danger)">{githubAuthError}</p>
+          {/if}
           <div class="row">
             <div class="row-label disabled">
               <span>Google Contacts</span>


### PR DESCRIPTION
## Summary
- Conecta el flujo real de OAuth device de GitHub desde `SettingsPanel` (antes solo redirigía a la página de integraciones).
- El backend ya tenía `/integrations/github/oauth/device/start` y `/polling`; ahora el frontend los consume.
- Cambios clave:
  - `frontend/src/lib/api.ts`: nuevos métodos `startDeviceAuth`, `pollDeviceCode` y `revoke`.
  - `api/routers/config.py`: actualiza `settings` en memoria después de escribir `.env`, para que el token recién guardado se use sin reiniciar.
  - `api/routers/integrations/github.py`: el revoke ahora puede usar el token configurado si no se pasa explícitamente.
  - `frontend/src/lib/components/SettingsPanel.svelte`: inicia el device flow, abre la URI de verificación, hace polling, persiste el token y muestra botón de desconectar.

Closes #46

## Test plan
- [x] `cd frontend && npm run check` → 0 errores
- [x] `python -m compileall api ai-service worker` → OK
- [x] `make test-api` → 90 passed

Generated with [Devin](https://devin.ai)