### PR TITLE
fix(frontend): responsive base layout and streak actions on mobile (#109 part 1)

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -497,6 +497,84 @@ textarea.input {
 .text-success { color: var(--success); }
 .text-error { color: var(--error); }
 
+/* ── Responsive (mobile) ─────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+    grid-template-rows: var(--header-h) 1fr auto;
+    grid-template-areas:
+      "header"
+      "main"
+      "sidebar";
+  }
+
+  .app-sidebar {
+    flex-direction: row;
+    justify-content: space-around;
+    align-items: center;
+    border-right: none;
+    border-top: 1px solid var(--border);
+    padding: var(--s2) 0;
+    gap: 0;
+    overflow: visible;
+  }
+
+  .app-main {
+    overflow: auto;
+  }
+
+  .app-statusbar {
+    display: none;
+  }
+
+  .nav-item {
+    width: 40px;
+    height: 40px;
+  }
+
+  .nav-item .tooltip {
+    display: none;
+  }
+
+  /* Stack the common resizable 3-column page layouts into a single column */
+  .notes-page,
+  .dashboard,
+  .streaks-layout {
+    grid-template-columns: 1fr !important;
+    grid-template-rows: auto 1fr !important;
+    height: auto;
+    min-height: 100%;
+  }
+
+  .notes-page .resize-handle,
+  .dashboard .resize-handle,
+  .streaks-layout .resize-handle {
+    display: none;
+  }
+
+  .notes-list,
+  .plant-section,
+  .streaks-layout .list-panel {
+    max-height: 45vh;
+    min-height: 180px;
+    overflow: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .editor-panel,
+  .activity-section,
+  .streaks-layout .detail-panel {
+    min-height: 55vh;
+  }
+
+  /* Goals page */
+  .goals-body {
+    max-width: none !important;
+    padding: var(--s3);
+  }
+}
+
 /* ── Global Resize Handle ────────────────────────────────────────────────────── */
 .resize-handle {
   background: transparent;

--- a/frontend/src/routes/streaks/+page.svelte
+++ b/frontend/src/routes/streaks/+page.svelte
@@ -1325,4 +1325,27 @@
     background: color-mix(in srgb, black 15%, transparent);
     color: color-mix(in srgb, var(--theme-ac) 20%, black);
   }
+
+  @media (max-width: 768px) {
+    .streak-item {
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 10px;
+    }
+
+    .streak-item .item-count {
+      padding-right: 0;
+      margin-left: auto;
+    }
+
+    .streak-item .item-actions {
+      position: static;
+      opacity: 1 !important;
+      pointer-events: auto !important;
+      flex-direction: row;
+      width: 100%;
+      justify-content: flex-end;
+      gap: 6px;
+    }
+  }
 </style>


### PR DESCRIPTION
## Summary
Primer paso del issue #109 (responsive/mobile):

- `app.css`: agrega `@media (max-width: 768px)` que:
  - Mueve la sidebar al borde inferior como barra de navegación.
  - Oculta el statusbar.
  - Apila los layouts de 3 columnas (notas, dashboard, rachas) en una sola columna.
  - Quita el `max-width: 800px` de `.goals-body` en móvil.
- `routes/streaks/+page.svelte`: en pantallas pequeñas los botones de acción de rachas siempre son visibles y no dependen del hover.

Relates to #109

## Test plan
- [x] `cd frontend && npm run check` → 0 errores

Generated with [Devin](https://devin.ai)