### PR TITLE
feat: image and file attachments in notes (#67)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -24,6 +24,11 @@ class Settings(BaseSettings):
     embedding_retry_base_seconds: int = 60
     xp_table_json: str = ""
 
+    # File uploads
+    upload_dir: str = "data/uploads"
+    upload_max_image_bytes: int = 10 * 1024 * 1024  # 10 MB
+    upload_max_file_bytes: int = 50 * 1024 * 1024   # 50 MB
+
     # Authentication
     auth_password: str = ""  # Password for single-user auth (optional)
 

--- a/api/main.py
+++ b/api/main.py
@@ -25,6 +25,7 @@ from routers import (
     skills,
     stats,
     tags,
+    upload,
     vault,
     websocket,
 )
@@ -35,6 +36,7 @@ from services.response_cache import get_cache_stats
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
+from starlette.staticfiles import StaticFiles
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +150,9 @@ app.include_router(websocket.router)
 app.include_router(auth.router)
 app.include_router(export.router, dependencies=[Depends(get_current_user)])
 app.include_router(stats.router, dependencies=[Depends(get_current_user)])
+app.include_router(upload.router, dependencies=[Depends(get_current_user)])
+
+app.mount("/uploads", StaticFiles(directory=settings.upload_dir), name="uploads")
 
 
 @app.get("/health")

--- a/api/main.py
+++ b/api/main.py
@@ -1,5 +1,6 @@
 import logging
 from contextlib import asynccontextmanager
+from pathlib import Path
 from time import perf_counter
 
 from config import settings
@@ -152,6 +153,8 @@ app.include_router(export.router, dependencies=[Depends(get_current_user)])
 app.include_router(stats.router, dependencies=[Depends(get_current_user)])
 app.include_router(upload.router, dependencies=[Depends(get_current_user)])
 
+# Ensure the upload directory exists before serving it.
+Path(settings.upload_dir).mkdir(parents=True, exist_ok=True)
 app.mount("/uploads", StaticFiles(directory=settings.upload_dir), name="uploads")
 
 

--- a/api/routers/upload.py
+++ b/api/routers/upload.py
@@ -1,0 +1,101 @@
+import logging
+import mimetypes
+import re
+import uuid
+from pathlib import Path
+
+from config import settings
+from fastapi import APIRouter, File, HTTPException, UploadFile
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/upload", tags=["upload"])
+
+ALLOWED_IMAGE_TYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+    "image/svg+xml",
+    "image/avif",
+}
+
+ALLOWED_FILE_TYPES = {
+    "application/pdf",
+    "text/plain",
+    "text/markdown",
+    "text/x-markdown",
+    "application/json",
+    "application/rtf",
+    "application/msword",
+    "application/vnd.ms-excel",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+
+
+def _ensure_upload_dir() -> Path:
+    path = Path(settings.upload_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _secure_filename(name: str | None) -> str:
+    if not name:
+        return "file"
+    base = Path(name).name
+    base = re.sub(r"[^a-zA-Z0-9_.-]", "_", base)
+    if not base:
+        base = "file"
+    return base
+
+
+def _save_upload(file: UploadFile, max_bytes: int, allowed: set[str]) -> dict:
+    upload_path = _ensure_upload_dir()
+
+    content_type = file.content_type or "application/octet-stream"
+    if content_type not in allowed:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Tipo de archivo no permitido: {content_type}",
+        )
+
+    content = file.file.read()
+    if len(content) > max_bytes:
+        raise HTTPException(status_code=413, detail="Archivo demasiado grande")
+
+    safe_name = _secure_filename(file.filename)
+    ext = Path(file.filename or "").suffix
+    if not ext:
+        ext = mimetypes.guess_extension(content_type) or ".bin"
+    if not safe_name.endswith(ext):
+        safe_name = f"{safe_name}{ext}"
+
+    unique_name = f"{uuid.uuid4().hex[:8]}_{safe_name}"
+    dest = upload_path / unique_name
+
+    with open(dest, "wb") as f:
+        f.write(content)
+
+    logger.info("[upload] saved %s (%s bytes) -> %s", content_type, len(content), dest)
+
+    return {
+        "url": f"/uploads/{unique_name}",
+        "filename": safe_name,
+        "mime": content_type,
+        "size": len(content),
+    }
+
+
+@router.post("/image")
+async def upload_image(file: UploadFile = File(...)):
+    """Sube una imagen y devuelve la URL pública."""
+    return _save_upload(file, settings.upload_max_image_bytes, ALLOWED_IMAGE_TYPES)
+
+
+@router.post("/file")
+async def upload_file(file: UploadFile = File(...)):
+    """Sube un archivo adjunto y devuelve la URL pública."""
+    return _save_upload(file, settings.upload_max_file_bytes, ALLOWED_FILE_TYPES)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - AI_SERVICE_URL=http://ai-service:8002
       - WORKER_URL=http://worker:8001
       - APP_ENV=${APP_ENV:-production}
+      - UPLOAD_DIR=/data/uploads
     depends_on:
       postgres:
         condition: service_healthy

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -379,4 +379,37 @@ github: {
       return req('DELETE', `/folders/${encodeURIComponent(path)}`);
     }
   },
+
+  upload: {
+    image: async (file: File) => {
+      const form = new FormData();
+      form.append('file', file);
+      const token = getToken();
+      const headers: Record<string, string> = {};
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+      const res = await fetch(`${BASE}/upload/image`, { method: 'POST', headers, body: form });
+      if (!res.ok) {
+        const err = await res.text().catch(() => res.statusText);
+        throw new Error(`Upload failed: ${res.status} ${err}`);
+      }
+      const result = await res.json() as { url: string; filename: string; mime: string; size: number };
+      result.url = result.url.startsWith('http') ? result.url : `${BASE}${result.url}`;
+      return result;
+    },
+    file: async (file: File) => {
+      const form = new FormData();
+      form.append('file', file);
+      const token = getToken();
+      const headers: Record<string, string> = {};
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+      const res = await fetch(`${BASE}/upload/file`, { method: 'POST', headers, body: form });
+      if (!res.ok) {
+        const err = await res.text().catch(() => res.statusText);
+        throw new Error(`Upload failed: ${res.status} ${err}`);
+      }
+      const result = await res.json() as { url: string; filename: string; mime: string; size: number };
+      result.url = result.url.startsWith('http') ? result.url : `${BASE}${result.url}`;
+      return result;
+    },
+  },
 };

--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy, onMount, tick } from 'svelte';
-  import { Eye, EyeOff, Save, Trash2, X, Settings, Search, Maximize, ChevronLeft, ChevronRight, Download, RotateCcw, Bold, Italic, Strikethrough, Heading1, Heading2, Heading3, List, ListOrdered, Link, Quote, Code } from 'lucide-svelte';
+  import { Eye, EyeOff, Save, Trash2, X, Settings, Search, Maximize, ChevronLeft, ChevronRight, Download, RotateCcw, Bold, Italic, Strikethrough, Heading1, Heading2, Heading3, List, ListOrdered, Link, Quote, Code, Image, Paperclip } from 'lucide-svelte';
   import * as L from 'lucide-svelte';
   import DynamicIcon from './DynamicIcon.svelte';
   import IconPicker from './IconPicker.svelte';
@@ -499,6 +499,9 @@
   let backdropEl = $state<HTMLElement | undefined>();
   let textareaEl = $state<HTMLTextAreaElement | undefined>();
   let lineGutterEl = $state<HTMLElement | undefined>();
+  let imageInputEl = $state<HTMLInputElement | undefined>();
+  let fileInputEl = $state<HTMLInputElement | undefined>();
+  let uploading = $state(false);
 
   function syncScroll() {
     if (backdropEl && textareaEl) {
@@ -561,6 +564,58 @@
         textareaEl?.setSelectionRange(pos, pos);
       }
     });
+  }
+
+  function insertAtCursor(text: string) {
+    if (!textareaEl) return;
+    const { selectionStart, selectionEnd } = textareaEl;
+    const before = content.substring(0, selectionStart);
+    const after = content.substring(selectionEnd);
+    content = before + text + after;
+    tick().then(() => {
+      const pos = selectionStart + text.length;
+      textareaEl?.focus();
+      textareaEl?.setSelectionRange(pos, pos);
+    });
+  }
+
+  async function uploadAttachment(file: File, type: 'image' | 'file') {
+    if (!file) return;
+    uploading = true;
+    try {
+      const result = type === 'image' ? await api.upload.image(file) : await api.upload.file(file);
+      const insertion = type === 'image'
+        ? `![${result.filename}](${result.url})`
+        : `[${result.filename}](${result.url})`;
+      insertAtCursor(insertion);
+      showNotification(`${type === 'image' ? 'Imagen' : 'Archivo'} subido`, 'success');
+    } catch (e: any) {
+      showNotification(e.message || 'Error subiendo archivo', 'error');
+    } finally {
+      uploading = false;
+      if (imageInputEl) imageInputEl.value = '';
+      if (fileInputEl) fileInputEl.value = '';
+    }
+  }
+
+  async function handleImageUpload(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const file = target.files?.[0];
+    if (file) await uploadAttachment(file, 'image');
+  }
+
+  async function handleFileUpload(e: Event) {
+    const target = e.target as HTMLInputElement;
+    const file = target.files?.[0];
+    if (file) await uploadAttachment(file, 'file');
+  }
+
+  function openImageUpload() {
+    imageInputEl?.click();
+  }
+
+  function openFileUpload() {
+    fileInputEl?.click();
   }
 
   function highlightMarkdown(text: string): string {
@@ -698,8 +753,19 @@
         <button class="toolbar-btn icon-only" onclick={() => formatMarkdown('code')} title="Bloque de código">
           <Code size={13} />
         </button>
+
+        <div class="format-divider"></div>
+
+        <button class="toolbar-btn icon-only" onclick={openImageUpload} disabled={uploading} title="Insertar imagen">
+          <Image size={13} />
+        </button>
+        <button class="toolbar-btn icon-only" onclick={openFileUpload} disabled={uploading} title="Adjuntar archivo">
+          <Paperclip size={13} />
+        </button>
       </div>
     </div>
+    <input bind:this={imageInputEl} type="file" accept="image/*" style="display:none" onchange={handleImageUpload} />
+    <input bind:this={fileInputEl} type="file" style="display:none" onchange={handleFileUpload} />
 
     <div class="toolbar-right">
       <span class="stat">{wordCount} palabras</span>


### PR DESCRIPTION
## Summary
Implementa la subida de imágenes y archivos adjuntos en notas.

- Backend:
  - Nuevo router `upload.py` con `POST /upload/image` y `POST /upload/file`.
  - Guarda archivos en `data/uploads/` con nombres únicos y validación de tipo/tamaño.
  - Sirve los archivos de forma estática en `/uploads`.
- Frontend:
  - Nuevos métodos `api.upload.image(file)` y `api.upload.file(file)`.
  - Botones en la barra del editor para insertar imagen y adjuntar archivo.
  - Tras la subida inserta la sintaxis markdown correspondiente en el cursor.

## Test plan
- [x] `cd frontend && npm run check` → 0 errores
- [x] `cd api && python -m compileall .` → OK

Part of #67

Generated with [Devin](https://devin.ai)