### PR TITLE
docs(a11y): accessibility and internationalization guides (#32)

### DIFF
--- a/docs/A11Y.md
+++ b/docs/A11Y.md
@@ -1,0 +1,34 @@
+# Accesibilidad (a11y) en Joidy
+
+Joidy busca ser usable para el mayor número de personas. Esta guía resume los criterios y patrones aplicados en el frontend.
+
+## Principios generales
+
+- **WCAG 2.1 AA** como objetivo mínimo.
+- Uso correcto de `lang="es"` en `app.html`.
+- Contraste de color respetado en tema oscuro y claro.
+- Navegación completa con teclado.
+- Estados de foco visibles en todos los controles interactivos.
+
+## Patrones por componente
+
+| Patrón | Implementación |
+|--------|----------------|
+| Botones | `button` real, no `div` con `on:click`. Si es icono, usa `aria-label`. |
+| Modales | `role="dialog"`, `aria-modal="true"`, `focusTrap` para ciclar foco. |
+| Tarjetas | `role="button"` o `tabindex` solo cuando son clickeables; manejador de teclado `Enter`/`Space`. |
+| Formularios | `label` asociado a cada input, mensajes de error con `aria-describedby`. |
+| Iconos | Si no acompaña texto, usa `aria-label` o `aria-hidden="true"`. |
+| Notificaciones | `role="status"` o `role="alert"` en toasts. |
+
+## Chequeo manual
+
+- [ ] ¿Se puede navegar toda la UI con `Tab`?
+- [ ] ¿Los modales atraparán el foco y se cierran con `Escape`?
+- [ ] ¿Los lectores de pantalla anuncian correctamente los estados de carga y error?
+- [ ] ¿El contraste entre texto y fondo es al menos 4.5:1?
+
+## Recursos
+
+- [WCAG 2.1](https://www.w3.org/WAI/WCAG21/quickref/)
+- [A11y Project](https://www.a11yproject.com/)

--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -1,0 +1,37 @@
+# Internacionalización (i18n)
+
+Joidy está actualmente en español. Esta guía describe la estrategia para preparar la aplicación para múltiples idiomas en el futuro.
+
+## Estado actual
+
+- El HTML raíz declara `lang="es"`.
+- Todo el texto visible de la UI está en español.
+- No hay un sistema de catálogos de traducción activo.
+
+## Estrategia futura
+
+1. Extraer cadenas de texto a archivos JSON por idioma en `frontend/src/lib/i18n/`.
+2. Usar una store de i18n en Svelte que cargue el catálogo según `navigator.language` o preferencia del usuario.
+3. Componentes consume la store con `$t('clave')`.
+4. En el backend, mantener mensajes de error simples y sin placeholders confusos para facilitar traducción.
+
+## Convenciones de texto
+
+- Evitar concatenar cadenas. Preferir plantillas completas: `"{count} notas"` en lugar de `count + " notas"`.
+- No hardcodear fechas; usar `Intl.DateTimeFormat` y `Intl.RelativeTimeFormat`.
+- Mantener textos en `+page.svelte` o `app.css` con clases `.sr-only` para lectores de pantalla.
+
+## Ejemplo tentativo
+
+```ts
+import { t } from '$lib/i18n/store';
+
+<span>{$t('notes.empty')}</span>
+```
+
+```json
+// frontend/src/lib/i18n/es.json
+{
+  "notes.empty": "Sin notas aún."
+}
+```


### PR DESCRIPTION
## Summary
Adds documentation for accessibility and internationalization requested in #32.

- `docs/A11Y.md`: WCAG 2.1 AA checklist, component patterns, and manual review.
- `docs/I18N.md`: current Spanish-only state, future catalog strategy, and conventions.

Relates to #32

Generated with [Devin](https://devin.ai)