### PR TITLE
feat(monitoring): Prometheus metrics endpoint and monitoring stack (#15)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -20,6 +20,7 @@ from routers import (
     export,
     gamification,
     goals,
+    metrics,
     notes,
     personal_streaks,
     planning,
@@ -138,6 +139,7 @@ app.add_middleware(RequestIdMiddleware)
 
 app.include_router(notes.router, dependencies=[Depends(get_current_user)])
 app.include_router(config.router)
+app.include_router(metrics.router)
 app.include_router(tags.router, dependencies=[Depends(get_current_user)])
 app.include_router(skills.router, dependencies=[Depends(get_current_user)])
 app.include_router(goals.router, dependencies=[Depends(get_current_user)])

--- a/api/middleware/metrics.py
+++ b/api/middleware/metrics.py
@@ -6,8 +6,22 @@ import time
 from collections import defaultdict
 
 from fastapi import Request
+from prometheus_client import Counter, Histogram
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
+
+
+http_requests_total = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    ["method", "path", "status"],
+)
+
+http_request_duration = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request duration in seconds",
+    ["method", "path"],
+)
 
 
 class MetricsCollector:
@@ -85,13 +99,26 @@ class MetricsMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:
         start_time = time.perf_counter()
         response = await call_next(request)
-        duration_ms = (time.perf_counter() - start_time) * 1000
+        duration = time.perf_counter() - start_time
+
+        normalized = _collector._normalize_path(request.url.path)
 
         _collector.record(
             method=request.method,
             path=request.url.path,
             status=response.status_code,
-            duration_ms=duration_ms
+            duration_ms=duration * 1000,
         )
+
+        http_requests_total.labels(
+            method=request.method,
+            path=normalized,
+            status=str(response.status_code),
+        ).inc()
+
+        http_request_duration.labels(
+            method=request.method,
+            path=normalized,
+        ).observe(duration)
 
         return response

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -13,6 +13,7 @@ pgvector>=0.3.0
 pyjwt==2.13.0
 bleach==6.4.0
 passlib[bcrypt]==1.7.4
+prometheus-client==0.21.0
 pywebpush==2.0.0
 pytest
 pytest-cov

--- a/api/routers/metrics.py
+++ b/api/routers/metrics.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter, Response
+from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, CollectorRegistry, generate_latest
+
+router = APIRouter(tags=["metrics"])
+
+
+@router.get("/metrics")
+def metrics() -> Response:
+    """Expose Prometheus-compatible metrics."""
+    return Response(
+        content=generate_latest(REGISTRY),
+        media_type=CONTENT_TYPE_LATEST,
+    )

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,29 @@
+services:
+  prometheus:
+    image: prom/prometheus:v3.0.0
+    container_name: joidy-prometheus
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    networks:
+      - joidy
+
+  grafana:
+    image: grafana/grafana:11.0.0
+    container_name: joidy-grafana
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+    networks:
+      - joidy
+
+networks:
+  joidy:
+    external: true
+
+volumes:
+  grafana-data:

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,27 @@
+# Monitoring
+
+Joidy expone métricas en formato Prometheus en el endpoint `/metrics` del API.
+
+## Métricas disponibles
+
+- `http_requests_total` — contador de requests por método, ruta y status.
+- `http_request_duration_seconds` — histograma de latencia de requests.
+- Métricas por defecto de `prometheus_client` (información del proceso, GC, etc.).
+
+## Ejecutar Prometheus + Grafana
+
+```bash
+docker compose -f docker-compose.monitoring.yml up -d
+```
+
+URLs:
+- Prometheus: http://localhost:9090
+- Grafana: http://localhost:3001 (admin / admin)
+
+Prometheus se conecta al servicio `api` en el puerto 8000 del contenedor.
+
+## Grafana
+
+1. Inicia sesión con admin / admin.
+2. Añade Prometheus como datasource (`http://prometheus:9090`).
+3. Importa un dashboard para FastAPI o crea paneles con las métricas de arriba.

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'joidy-api'
+    static_configs:
+      - targets: ['api:8000']
+    metrics_path: /metrics
+    scheme: http


### PR DESCRIPTION
## Summary
Adds Prometheus/Grafana monitoring requested in #15.

- `prometheus-client` dependency and `/metrics` router.
- `MetricsMiddleware` now emits `http_requests_total` and `http_request_duration_seconds`.
- `docker-compose.monitoring.yml` with Prometheus and Grafana services.
- `monitoring/prometheus.yml` scrape config.
- `docs/MONITORING.md` setup guide.

Relates to #15

## Test plan
- [x] `python -m compileall` de archivos modificados.
- [x] El endpoint `/metrics` devuelve métricas en formato Prometheus.

Generated with [Devin](https://devin.ai)