### PR TITLE
test(coverage): add pytest coverage reporting and push/metrics tests (#13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Check Python syntax
         run: python -m compileall api ai-service worker
 
-      - name: Run tests
+      - name: Run tests with coverage
         working-directory: api
-        run: python -m pytest tests/ -v
+        run: python -m pytest tests/ -v --cov=api --cov-report=term-missing
 
   frontend-check:
     name: Frontend Typecheck

--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -1,0 +1,44 @@
+"""Tests for /export endpoints."""
+
+from models.note import Note
+
+
+def test_export_notes_markdown(client, db_session):
+    note = Note(title="Hello", content="World", source="joidy")
+    db_session.add(note)
+    db_session.commit()
+
+    resp = client.get("/export/notes/markdown")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "text/markdown; charset=utf-8"
+    body = resp.text
+    assert "# Hello" in body
+    assert "World" in body
+
+
+def test_export_notes_html(client, db_session):
+    note = Note(title="Hello", content="<b>World</b>", source="joidy")
+    db_session.add(note)
+    db_session.commit()
+
+    resp = client.get("/export/notes/html")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+    body = resp.text
+    assert "<h1>Hello</h1>" in body
+    assert "&lt;b&gt;World&lt;/b&gt;" in body
+
+
+def test_export_notes_zip(client, db_session):
+    note = Note(title="Hello", content="World", source="joidy")
+    db_session.add(note)
+    db_session.commit()
+
+    resp = client.get("/export/notes/zip")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/zip"
+
+
+def test_export_notes_markdown_empty(client):
+    resp = client.get("/export/notes/markdown")
+    assert resp.status_code == 404

--- a/api/tests/test_metrics.py
+++ b/api/tests/test_metrics.py
@@ -1,0 +1,19 @@
+"""Tests for Prometheus /metrics endpoint and middleware."""
+
+
+def test_metrics_endpoint_returns_prometheus_format(client):
+    """The /metrics endpoint should return Prometheus-compatible output."""
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    text = resp.text
+    assert "http_requests_total" in text or "python_info" in text
+
+
+def test_metrics_middleware_records_requests(client):
+    """The metrics middleware should track HTTP request counts."""
+    resp = client.get("/notes/")
+    assert resp.status_code == 200
+
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert "http_requests_total" in resp.text

--- a/api/tests/test_push.py
+++ b/api/tests/test_push.py
@@ -1,0 +1,40 @@
+"""Tests for the Web Push subscription router and service."""
+
+from unittest.mock import patch
+
+
+def test_vapid_public_key_unconfigured(client):
+    resp = client.get("/push/vapid-public-key")
+    assert resp.status_code == 503
+
+
+def test_subscribe_requires_keys(client):
+    resp = client.post("/push/subscribe", json={
+        "endpoint": "https://fcm.example.com/token",
+        "keys": {"p256dh": "foo"},
+    })
+    assert resp.status_code == 422
+
+
+def test_subscribe_and_unsubscribe(client):
+    resp = client.post("/push/subscribe", json={
+        "endpoint": "https://fcm.example.com/token",
+        "keys": {
+            "p256dh": "p256dh-key",
+            "auth": "auth-key",
+        },
+    })
+    assert resp.status_code == 200
+
+    resp = client.post("/push/unsubscribe")
+    assert resp.status_code == 200
+
+
+def test_send_test_push_without_subscriptions(client):
+    with patch("services.push_service.webpush") as mock_webpush:
+        resp = client.post("/push/test", json={
+            "title": "Hello",
+            "body": "World",
+        })
+        assert resp.status_code == 200
+        mock_webpush.assert_not_called()

--- a/api/tests/test_stats.py
+++ b/api/tests/test_stats.py
@@ -1,0 +1,46 @@
+"""Tests for the /stats router."""
+
+from datetime import datetime, timezone
+
+from models.gamification import UserStats, XPEvent
+from models.goal import Goal, GoalFailConfig, GoalMeasurement, GoalState, GoalTemporality
+from models.note import Note
+
+
+def test_get_system_stats(client, db_session):
+    db_session.add(Note(title="Note 1", content="", source="joidy"))
+    db_session.add(Goal(
+        title="Goal 1",
+        target_value=1,
+        current_value=0,
+        temporality=GoalTemporality.DAILY,
+        measurement_type=GoalMeasurement.COUNT,
+        state=GoalState.ACTIVE,
+        fail_config=GoalFailConfig.STATIC,
+    ))
+    db_session.add(UserStats(total_xp=100, current_streak=5, longest_streak=5, plant_stage=0))
+    db_session.add(XPEvent(event_type="note_created", xp=10, metadata_json='{}'))
+    db_session.commit()
+
+    resp = client.get("/stats/system")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["notes"] == 1
+    assert data["goals"] == 1
+    assert data["total_xp"] == 100
+    assert data["current_streak"] == 5
+
+
+def test_get_activity_stats(client, db_session):
+    now = datetime.now(timezone.utc)
+    db_session.add(Note(title="Recent", content="", created_at=now, source="joidy"))
+    db_session.add(XPEvent(event_type="note_created", xp=10, created_at=now, metadata_json='{}'))
+    db_session.commit()
+
+    resp = client.get("/stats/activity?days=7")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["days"]) == 7
+    today = data["days"][0]
+    assert today["notes_created"] == 1
+    assert today["xp_events"] == 1


### PR DESCRIPTION
## Summary
Progress toward #13 by setting up coverage reporting and adding missing tests.

- CI now runs `pytest --cov=api --cov-report=term-missing` so coverage is visible in every build.
- Added `tests/test_metrics.py` for the `/metrics` endpoint.
- Added `tests/test_push.py` for Web Push subscribe/unsubscribe/test flow.

Relates to #13

## Test plan
- [x] Tests pass locally/CI.
- [x] `/metrics` returns Prometheus text including `http_requests_total`.
- [x] Push endpoints return correct status codes for missing keys and no subscriptions.

Generated with [Devin](https://devin.ai)