### PR TITLE
feat(obsidian): sync_state model and /webhook/obsidian foundation (#73)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ EMBEDDING_MODEL=gemini:models/text-embedding-004
 # Absolute path to your Obsidian vault folder on the host
 # Example: /home/username/Documents/MyVault
 OBSIDIAN_VAULT_PATH=/path/to/your/obsidian/vault
+# Optional secret to validate /webhook/obsidian calls
+OBSIDIAN_WEBHOOK_SECRET=
 
 # ── GitHub OAuth (Device Flow) ──────────────────
 # Get at: https://github.com/settings/developers

--- a/api/alembic/versions/8261da3f5e9d_add_sync_state.py
+++ b/api/alembic/versions/8261da3f5e9d_add_sync_state.py
@@ -1,0 +1,40 @@
+"""add sync_state
+
+Revision ID: 8261da3f5e9d
+Revises: 2f638d55375d
+Create Date: 2026-07-30 02:30:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '8261da3f5e9d'
+down_revision: Union[str, None] = '2f638d55375d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'sync_state',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('note_id', sa.Integer(), nullable=False),
+        sa.Column('last_synced_at', sa.DateTime(), nullable=True),
+        sa.Column('local_mtime', sa.DateTime(), nullable=True),
+        sa.Column('remote_mtime', sa.DateTime(), nullable=True),
+        sa.Column('conflict', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['note_id'], ['notes.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('note_id')
+    )
+    op.create_index(op.f('ix_sync_state_id'), 'sync_state', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_sync_state_id'), table_name='sync_state')
+    op.drop_table('sync_state')

--- a/api/config.py
+++ b/api/config.py
@@ -40,5 +40,8 @@ class Settings(BaseSettings):
     # Authentication
     auth_password: str = ""  # Password for single-user auth (optional)
 
+    # Obsidian
+    obsidian_webhook_secret: str | None = None  # Optional secret for /webhook/obsidian
+
 
 settings = Settings()

--- a/api/main.py
+++ b/api/main.py
@@ -22,6 +22,7 @@ from routers import (
     goals,
     metrics,
     notes,
+    obsidian,
     personal_streaks,
     planning,
     push,
@@ -152,6 +153,7 @@ app.include_router(folders.router, dependencies=[Depends(get_current_user)])
 app.include_router(ai.router, dependencies=[Depends(get_current_user)])
 app.include_router(planning.router, dependencies=[Depends(get_current_user)])
 app.include_router(websocket.router)
+app.include_router(obsidian.router)
 app.include_router(auth.router)
 app.include_router(export.router, dependencies=[Depends(get_current_user)])
 app.include_router(stats.router, dependencies=[Depends(get_current_user)])

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -7,3 +7,4 @@ from .personal_streaks import *
 from .planning import *
 from .push_subscription import *
 from .skill import *
+from .sync_state import *

--- a/api/models/sync_state.py
+++ b/api/models/sync_state.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from database import Base
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+
+class SyncState(Base):
+    """Track Obsidian sync state and conflicts per note."""
+
+    __tablename__ = "sync_state"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    note_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("notes.id", ondelete="CASCADE"), unique=True, nullable=False
+    )
+    last_synced_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    local_mtime: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    remote_mtime: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    conflict: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now()
+    )
+
+    note: Mapped["Note"] = relationship("Note", backref="sync_state")

--- a/api/routers/obsidian.py
+++ b/api/routers/obsidian.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from config import settings
+from database import get_db
+from models.sync_state import SyncState
+
+router = APIRouter(prefix="/webhook/obsidian", tags=["obsidian"])
+
+
+class ObsidianChangeIn(BaseModel):
+    note_id: int
+    path: str
+    remote_mtime: int | None = None
+
+
+@router.post("")
+def obsidian_webhook(
+    payload: ObsidianChangeIn,
+    secret: str = "",
+    db: Session = Depends(get_db),
+):
+    """Receive external Obsidian change notifications.
+
+    This is the foundation for bidirectional WebSocket/push sync.
+    It records the remote mtime and flags potential conflicts.
+    """
+    if settings.obsidian_webhook_secret and secret != settings.obsidian_webhook_secret:
+        raise HTTPException(status_code=401, detail="Invalid webhook secret")
+
+    sync = db.query(SyncState).filter(SyncState.note_id == payload.note_id).first()
+    if not sync:
+        sync = SyncState(note_id=payload.note_id)
+        db.add(sync)
+
+    # TODO: compare local/remote mtime to detect conflicts (#73)
+    sync.remote_mtime = (
+        datetime.fromtimestamp(payload.remote_mtime, tz=timezone.utc)
+        if payload.remote_mtime
+        else None
+    )
+    sync.last_synced_at = datetime.now(timezone.utc)
+    db.commit()
+
+    return {"status": "ok", "note_id": payload.note_id}

--- a/api/routers/obsidian.py
+++ b/api/routers/obsidian.py
@@ -36,13 +36,29 @@ def obsidian_webhook(
         sync = SyncState(note_id=payload.note_id)
         db.add(sync)
 
-    # TODO: compare local/remote mtime to detect conflicts (#73)
     sync.remote_mtime = (
         datetime.fromtimestamp(payload.remote_mtime, tz=timezone.utc)
         if payload.remote_mtime
         else None
     )
     sync.last_synced_at = datetime.now(timezone.utc)
+
+    # Conflict detection: compare UTC seconds since mtimes are stored
+    # without timezone in some databases.
+    def _to_naive_utc(dt: datetime | None) -> datetime | None:
+        if dt is None:
+            return None
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt
+
+    local = _to_naive_utc(sync.local_mtime)
+    remote = _to_naive_utc(sync.remote_mtime)
+    if local is not None and remote is not None and local != remote:
+        sync.conflict = True
+    else:
+        sync.conflict = False
+
     db.commit()
 
-    return {"status": "ok", "note_id": payload.note_id}
+    return {"status": "ok", "note_id": payload.note_id, "conflict": sync.conflict}

--- a/api/tests/test_obsidian_sync.py
+++ b/api/tests/test_obsidian_sync.py
@@ -1,0 +1,34 @@
+"""Tests for Obsidian sync state and webhook endpoint."""
+
+from unittest.mock import patch
+
+
+@patch("config.settings.obsidian_webhook_secret", "super-secret")
+def test_obsidian_webhook_requires_secret(client):
+    resp = client.post("/webhook/obsidian?secret=wrong", json={
+        "note_id": 1,
+        "path": "/vault/note.md",
+        "remote_mtime": 1_700_000_000,
+    })
+    assert resp.status_code == 401
+
+
+from models.sync_state import SyncState
+
+
+def test_obsidian_webhook_unconfigured_accepts_any(client, db_session):
+    resp = client.post("/webhook/obsidian", json={
+        "note_id": 1,
+        "path": "/vault/note.md",
+        "remote_mtime": 1_700_000_000,
+    })
+    assert resp.status_code == 200
+
+    sync = db_session.query(SyncState).filter_by(note_id=1).first()
+    assert sync is not None
+    assert sync.remote_mtime is not None
+    assert sync.remote_mtime.timestamp() == 1_700_000_000
+
+
+def test_sync_state_model_exists():
+    assert SyncState.__tablename__ == "sync_state"

--- a/api/tests/test_obsidian_sync.py
+++ b/api/tests/test_obsidian_sync.py
@@ -1,5 +1,6 @@
 """Tests for Obsidian sync state and webhook endpoint."""
 
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 
@@ -32,3 +33,41 @@ def test_obsidian_webhook_unconfigured_accepts_any(client, db_session):
 
 def test_sync_state_model_exists():
     assert SyncState.__tablename__ == "sync_state"
+
+
+def test_obsidian_webhook_detects_conflict(client, db_session):
+    sync = SyncState(note_id=2, local_mtime=datetime.fromtimestamp(1_600_000_000, tz=timezone.utc))
+    db_session.add(sync)
+    db_session.commit()
+
+    resp = client.post("/webhook/obsidian", json={
+        "note_id": 2,
+        "path": "/vault/note.md",
+        "remote_mtime": 1_700_000_000,
+    })
+    assert resp.status_code == 200
+    assert resp.json()["conflict"] is True
+
+    updated = db_session.query(SyncState).filter_by(note_id=2).first()
+    assert updated.conflict is True
+
+
+def test_obsidian_webhook_no_conflict_when_mtimes_match(client, db_session):
+    mtime = 1_700_000_000
+    sync = SyncState(
+        note_id=3,
+        local_mtime=datetime.fromtimestamp(mtime, tz=timezone.utc),
+    )
+    db_session.add(sync)
+    db_session.commit()
+
+    resp = client.post("/webhook/obsidian", json={
+        "note_id": 3,
+        "path": "/vault/note.md",
+        "remote_mtime": mtime,
+    })
+    assert resp.status_code == 200
+    assert resp.json()["conflict"] is False
+
+    updated = db_session.query(SyncState).filter_by(note_id=3).first()
+    assert updated.conflict is False


### PR DESCRIPTION
## Summary
First step toward #73 (bidirectional Obsidian sync).

- New `SyncState` model to track `note_id`, `last_synced_at`, `local_mtime`, `remote_mtime` and `conflict`.
- Alembic migration `8261da3f5e9d_add_sync_state.py` for PostgreSQL.
- New `POST /webhook/obsidian` endpoint that receives Obsidian change notifications and stores `remote_mtime`.
- Optional `OBSIDIAN_WEBHOOK_SECRET` for validating calls.
- Basic tests for webhook auth and sync state persistence.

This is a foundation; conflict detection and UI resolution will be added in follow-ups.

Relates to #73

## Test plan
- [x] `POST /webhook/obsidian` accepts changes without a configured secret.
- [x] `POST /webhook/obsidian` rejects wrong secret when configured.
- [x] `SyncState` row is created/updated on webhook call.

Generated with [Devin](https://devin.ai)