### PR TITLE
fix(api): import settings in config router so POST /config stops returning 500 (#199)

### DIFF
--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -5,6 +5,8 @@ from pydantic import BaseModel
 from services.auth_service import get_current_user
 from fastapi import Depends
 
+from config import settings
+
 router = APIRouter(prefix="/config", tags=["config"])
 
 ENV_FILE = Path("/app/.env") if Path("/app").exists() else Path(__file__).parent.parent.parent / ".env"

--- a/api/tests/test_e2e_config.py
+++ b/api/tests/test_e2e_config.py
@@ -1,0 +1,34 @@
+"""E2E tests for the /config endpoints.
+
+Regression coverage for #199: POST /config used to raise NameError because
+`settings` was not imported in `api/routers/config.py`, returning a 500.
+"""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+import routers.config as config_router
+
+
+def test_get_config_returns_200(client: TestClient):
+    resp = client.get("/config")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "configured_keys" in data
+
+
+def test_post_config_returns_200_not_500(client: TestClient):
+    """POST /config must not raise NameError on the in-memory settings update."""
+    fake_env = {"OBSIDIAN_VAULT_PATH": "/tmp/vault"}
+
+    with patch.object(config_router, "read_env", return_value=dict(fake_env)), \
+         patch.object(config_router, "write_env") as mock_write:
+        resp = client.post("/config", json={"obsidian_vault_path": "/tmp/new_vault"})
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    mock_write.assert_called_once()
+    # The new value must be persisted to the env dict passed to write_env
+    written = mock_write.call_args.args[0]
+    assert written["OBSIDIAN_VAULT_PATH"] == "/tmp/new_vault"


### PR DESCRIPTION
## Summary
- `POST /config` returned **500 Internal Server Error** because `update_config` referenced the module-level `settings` singleton without importing it, raising `NameError: name 'settings' is not defined` (caught by FastAPI and surfaced as 500).
- Adds the missing `from config import settings` import at the top of `api/routers/config.py`. The local import inside `perform_setup` already worked; this fixes the `update_config` path.
- Adds `tests/test_e2e_config.py` covering `GET /config` and a regression test for `POST /config` so the missing import cannot silently return.

## Root cause
`api/routers/config.py` line ~123:
```python
if value is not None and hasattr(settings, short_key):
    setattr(settings, short_key, value)
```
`settings` was never imported at module scope.

## Verification
- Reproduced the 500 (`NameError: name 'settings' is not defined`) by removing the import → regression test fails.
- With the fix, `tests/test_e2e_config.py` passes (2 passed) inside the `d4mag3/joidy-api` container with a sqlite `DATABASE_URL`.

#### Test plan
- [x] `PYTHONPATH=/app python -m pytest tests/test_e2e_config.py` passes.
- [x] Regression confirmed: removing the import reproduces the 500 from the issue.

Closes #199

Generated with [Devin](https://devin.ai)