### PR TITLE
fix(frontend): make goal color dots clickable above the preview overlay (#203)

### DIFF
--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -2241,6 +2241,10 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+    /* The preview is purely visual (no interactive children). Disable pointer
+       events so it can never intercept clicks meant for the color dots above it
+       when both share the same stacking context (#203). */
+    pointer-events: none;
   }
   .ng-preview-label {
     font-size: 10px;
@@ -2454,6 +2458,9 @@
     cursor: pointer;
     transition: all 0.15s;
     flex-shrink: 0;
+    /* Raise above the non-interactive preview so clicks always land on the dot (#203). */
+    position: relative;
+    z-index: 2;
   }
   .color-dot:hover { transform: scale(1.15); }
   .color-dot.selected { 


### PR DESCRIPTION
## Summary
In the **Nuevo Objetivo** modal → **Apariencia** tab, the color dots (`.color-dot`) were not clickable because the `.ng-bottom-preview` "Vista Previa" card sat in front of them (`document.elementFromPoint()` returned the preview, not the dots).

The preview card is purely visual (no interactive children), so:
- `pointer-events: none` on `.ng-bottom-preview` — it can never intercept clicks meant for the dots; clicks pass through to the dots behind it.
- `position: relative; z-index: 2` on `.color-dot` — the dots always sit above any overlapping sibling.

## Root cause
The color dot row and the "Vista Previa" card share the same stacking context; the preview is `pointer-events: auto` and covers the dots.

## Files
- `frontend/src/routes/goals/+page.svelte` (`.ng-bottom-preview` and `.color-dot` styles)

## Verification
- `cd frontend && npm run check` → 0 errors (239 pre-existing warnings unchanged).

#### Test plan
- [x] `npm run check` passes with no new errors/warnings.
- [ ] Manual: open Nuevo Objetivo → Apariencia → click each color dot → selected color changes and the preview card updates.

Closes #203

Generated with [Devin](https://devin.ai)