### PR TITLE
fix(frontend): remove non-existent .minimap() call so the graph page loads (#201)

### DIFF
--- a/frontend/src/lib/components/KnowledgeGraphForce.svelte
+++ b/frontend/src/lib/components/KnowledgeGraphForce.svelte
@@ -461,13 +461,13 @@
       .onNodeClick(handleNodeClick)
       .onNodeHover((node: GraphNode | null) => {
         hoveredNode = node;
-      })
-      .minimap('#graph-minimap', {
-        width: 160,
-        height: 120,
-        center: [0, 0],
-        zoom: 0.05,
       });
+
+    // NOTE: a `.minimap('#graph-minimap', ...)` chain used to be appended here,
+    // but `force-graph` (>=1.48) does not expose a `minimap()` method, so the
+    // call threw `TypeError: ...minimap is not a function` and left the graph
+    // stuck on "Cargando grafo de conocimiento..." (#201). The minimap can be
+    // re-implemented as a separate <canvas> overlay in a follow-up.
 
     applyStyling();
     rebuildGraph();
@@ -787,9 +787,6 @@
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="action-icon"><path d="M21 4H8l-7 8 7 8h13a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2z"></path><line x1="18" y1="9" x2="12" y2="15"></line><line x1="12" y1="9" x2="18" y2="15"></line></svg>
       </button>
     </div>
-
-    <!-- MINIMAP -->
-    <div class="graph-minimap" id="graph-minimap"></div>
   {/if}
 </div>
 
@@ -1275,30 +1272,5 @@
     background: transparent;
     border: none;
     cursor: pointer;
-  }
-
-  /* Minimap */
-  .graph-minimap {
-    position: absolute;
-    bottom: 16px;
-    right: 16px;
-    z-index: 1000;
-    border-radius: 8px;
-    overflow: hidden;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-    border: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
-    opacity: 0.7;
-    transition: opacity 0.2s;
-    pointer-events: all;
-  }
-
-  .graph-minimap:hover {
-    opacity: 1;
-  }
-
-  .graph-minimap canvas {
-    display: block;
-    width: 160px !important;
-    height: 120px !important;
   }
 </style>


### PR DESCRIPTION
## Summary
The `/graph` page was stuck on "Cargando grafo de conocimiento..." forever. `KnowledgeGraphForce.svelte` chained `.minimap('#graph-minimap', {...})` onto the `force-graph` instance, but `force-graph` (resolved to **1.51.4** from `^1.47.0`) **does not expose a `minimap()` method** (0 occurrences of `minimap` anywhere in the package), so the call threw `TypeError: ForceGraph(...)(...).minimap is not a function` during component init and the graph never finished loading.

- Remove the `.minimap()` chain so the graph initialises and renders.
- Remove the now-orphaned `#graph-minimap` container div and its CSS (it would otherwise render as an empty bordered box in the corner).

The minimap can be re-implemented as a separate `<canvas>` overlay in a follow-up, as suggested in the issue.

## Root cause
`frontend/src/lib/components/KnowledgeGraphForce.svelte` line ~465:
```js
.minimap('#graph-minimap', { width: 160, height: 120, center: [0,0], zoom: 0.05 })
```
`minimap` is not part of the `force-graph` API in the installed version.

## Verification
- Confirmed `minimap` is absent from `node_modules/force-graph` (1.51.4).
- Ran a headless Playwright check against the Vite dev server (API responses stubbed, service workers blocked): **before** the page was stuck loading; **after** the fix `document.querySelector('.graph-wrapper')` is present, a `<canvas>` is rendered (`canvasCount: 1`), and there are **no `minimap` console errors**.
- `cd frontend && npm run check` → 0 errors (238 warnings, one fewer than before since the orphaned minimap CSS was removed).

#### Test plan
- [x] `npm run check` passes with no new errors.
- [x] Playwright: `/graph` renders the force-graph canvas with no `minimap is not a function` error.

Closes #201

Generated with [Devin](https://devin.ai)