### PR TITLE
fix(frontend,pwa): stop registering the service worker in dev (#205)

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -159,8 +159,14 @@
 
     connectWS();
 
-    // Register service worker for PWA
-    if ('serviceWorker' in navigator) {
+    // Register service worker for PWA (production only).
+    // In dev, SvelteKit does not emit a usable /service-worker.js (the
+    // `$service-worker` virtual module references build-time assets that do
+    // not exist at dev time), so registration fails with
+    // "ServiceWorker script evaluation failed" on every page load. The SW
+    // fetch handler would also intercept API calls and return 503 Offline
+    // while the dev backend is restarting, breaking the dev workflow (#205).
+    if (import.meta.env.PROD && 'serviceWorker' in navigator) {
       navigator.serviceWorker.register('/service-worker.js').catch((err) => {
         logger.warn('SW registration failed:', err);
       });

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -5,7 +5,15 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 const config = {
   preprocess: vitePreprocess(),
   kit: {
-    adapter: adapter({ port: 3000 })
+    adapter: adapter({ port: 3000 }),
+    // Disable SvelteKit's automatic service worker registration. In dev the
+    // service worker is not bundled, so the auto-registration tries to evaluate
+    // a non-functional /service-worker.js and fails with
+    // "ServiceWorker script evaluation failed" on every page load; its fetch
+    // handler would also intercept API calls and return 503 Offline while the
+    // dev backend restarts. Registration is handled manually in +layout.svelte
+    // for production builds only (#205).
+    serviceWorker: { register: false }
   }
 };
 


### PR DESCRIPTION
## Summary
In dev (`make dev`), every page load logged:
```
ServiceWorker registration failed: TypeError: Failed to register a ServiceWorker for scope ('...') with script ('.../service-worker.js'): ServiceWorker script evaluation failed
```

Per the SvelteKit docs, **the service worker is bundled for production builds but is not included during development**. However, SvelteKit still auto-registers `/service-worker.js` via an inline script it injects, so registration fails on every page load. Worse, the SW's `fetch` handler intercepted API calls and returned `503 Offline` while the dev backend was restarting, breaking the dev workflow (this was actively masking real API responses during testing).

- Set `kit.serviceWorker.register = false` in `svelte.config.js` to disable SvelteKit's automatic registration. The service worker is still bundled for production builds.
- Guard the manual registration in `+layout.svelte` with `import.meta.env.PROD` so the SW is only registered in production, where it is actually bundled and functional.

## Root cause
SvelteKit auto-registers the service worker whenever `src/service-worker.ts` exists, even in dev where the SW is not bundled → "ServiceWorker script evaluation failed".

## Verification
Headless Playwright against the Vite dev server (API stubbed), counting `navigator.serviceWorker.register` calls via an init-script monkeypatch:
- **Before:** `registerCalls: 1`, `registrationCount: 1`, plus the `ServiceWorker script evaluation failed` error and `503 Offline` responses on API calls.
- **After:** `registerCalls: 0`, `registrationCount: 0`, no SW-related console errors.
- `cd frontend && npm run check` → 0 errors.

#### Test plan
- [x] `npm run check` passes with no new errors.
- [x] Playwright: in dev, no `navigator.serviceWorker.register` call and no SW registration error.
- [ ] Production build still bundles and registers the SW (manual `npm run build` + serve).

Closes #205

Generated with [Devin](https://devin.ai)