### PR TITLE
fix(frontend,compose): use env vars for API/WS/HMR ports (#200)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,7 @@ services:
       - /app/node_modules
     environment:
       - NODE_ENV=development
+      - FRONTEND_PORT=${FRONTEND_PORT:-3000}
       - VITE_API_URL=http://localhost:${API_PORT:-8000}
       - VITE_INTERNAL_API_URL=http://api:8000
     command: npm run dev -- --host 0.0.0.0 --port 3000

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,7 +6,8 @@ import { showNotification } from './stores/notifications';
 import { session, getToken } from './stores/session';
 
 const BASE = browser
-  ? `${window.location.protocol}//${window.location.hostname}:8000`
+  ? (import.meta.env.VITE_API_URL as string ||
+    `${window.location.protocol}//${window.location.hostname}:8000`)
   : (import.meta.env.VITE_INTERNAL_API_URL as string || 'http://api:8000');
 
 async function req<T>(method: string, path: string, body?: unknown): Promise<T> {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -110,7 +110,20 @@
       
       const host = window.location.hostname;
       const wsProto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const wsUrl = `${wsProto}//${host}:8000/ws`;
+      // Derive the WebSocket URL from VITE_API_URL (which already reflects the
+      // configured API_PORT) so the app works on non-default ports. Fall back
+      // to the previous hostname:8000 behaviour when VITE_API_URL is unset.
+      let wsHost = `${host}:8000`;
+      const apiUrl = import.meta.env.VITE_API_URL as string | undefined;
+      if (apiUrl) {
+        try {
+          const parsed = new URL(apiUrl);
+          wsHost = `${parsed.hostname}:${parsed.port || (parsed.protocol === 'https:' ? '443' : '80')}`;
+        } catch {
+          wsHost = `${host}:8000`;
+        }
+      }
+      const wsUrl = `${wsProto}//${wsHost}/ws`;
 
       logger.info('[layout] Connecting to WebSocket:', wsUrl);
       ws = new WebSocket(wsUrl);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 
+// The browser connects to the host-mapped frontend port, which may differ from
+// the container's internal port (3000) when FRONTEND_PORT is overridden.
+const FRONTEND_PORT =
+  (typeof process !== 'undefined' && Number(process.env.FRONTEND_PORT)) || 3000;
+
 export default defineConfig({
   plugins: [sveltekit()],
   server: {
@@ -11,7 +16,7 @@ export default defineConfig({
       // When running inside Docker, the browser connects to the host-mapped
       // port. Without this, Vite tries to connect the WS to the container's
       // internal address and the browser gets a connection refused error.
-      clientPort: 3000,
+      clientPort: FRONTEND_PORT,
       host: 'localhost'
     }
   },


### PR DESCRIPTION
## Summary
The frontend hardcoded port `8000` for the API base URL and the WebSocket URL, and Vite's HMR `clientPort` was hardcoded to `3000`. When `API_PORT` or `FRONTEND_PORT` were overridden (e.g. to run multiple instances or avoid port conflicts), the browser still talked to `:8000` and Vite HMR still targeted `:3000`, so the app broke.

- **`api.ts`**: prefer `VITE_API_URL` for the browser API base URL, falling back to the previous `hostname:8000` default when unset.
- **`+layout.svelte`**: derive the WebSocket URL from `VITE_API_URL` (honoring `API_PORT`) instead of hardcoding `hostname:8000`.
- **`vite.config.ts`**: read `FRONTEND_PORT` from the environment for `server.hmr.clientPort`, defaulting to `3000`.
- **`docker-compose.dev.yml`**: pass `FRONTEND_PORT` into the frontend container so Vite HMR uses the host-mapped port.

## Verification
Headless Playwright against the Vite dev server:
- With `VITE_API_URL=http://localhost:9000`: WS URL → `ws://localhost:9000/ws` (was `ws://localhost:8000/ws`).
- Without `VITE_API_URL` (fallback): WS URL → `ws://127.0.0.1:8000/ws` (unchanged from previous behavior).
- `cd frontend && npm run check` → 0 errors.

#### Test plan
- [x] `npm run check` passes with no new errors.
- [x] Playwright: WS URL follows `VITE_API_URL` when set, falls back to `:8000` when unset.
- [ ] Docker dev with `API_PORT=9000 FRONTEND_PORT=4000` works end-to-end (manual).

Closes #200

Generated with [Devin](https://devin.ai)