### PR TITLE
fix(frontend): break infinite reactivity loop in NoteEditor (#202)

### DIFF
--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, onDestroy, onMount, tick } from 'svelte';
+  import { createEventDispatcher, onDestroy, onMount, tick, untrack } from 'svelte';
   import { Eye, EyeOff, Save, Trash2, X, Settings, Search, Maximize, ChevronLeft, ChevronRight, Download, RotateCcw, Bold, Italic, Strikethrough, Heading1, Heading2, Heading3, List, ListOrdered, Link, Quote, Code, Image, Paperclip } from 'lucide-svelte';
   import * as L from 'lucide-svelte';
   import DynamicIcon from './DynamicIcon.svelte';
@@ -94,18 +94,26 @@
   let tags = $state<string[]>([]);
   let previousContentTags = $state<string[]>([]);
 
+  // Sync editor state when the `note` prop changes. The body reads `content`
+  // and `tags` (via extractTagsFromContent / tags.includes) after writing them,
+  // which would create a self-dependency loop: tags = [...note.tags] makes a
+  // new array reference every run, the read re-triggers the effect, and it
+  // never converges. Wrap the writes in untrack() so only `note` is a
+  // dependency — user edits to content/tags no longer reset the editor.
   $effect(() => {
-    if (note) {
-      title = note.title ?? initialTitle;
-      content = note.content ?? '';
-      tags = [...(note.tags || [])];
+    const n = note;
+    if (!n) return;
+    untrack(() => {
+      title = n.title ?? initialTitle;
+      content = n.content ?? '';
+      tags = [...(n.tags || [])];
       previousContentTags = extractTagsFromContent(content);
       for (const t of previousContentTags) {
         if (!tags.includes(t)) tags.push(t);
       }
       historyStack = [content || ''];
       historyIndex = 0;
-    }
+    });
   });
   let tagInput = $state('');
   let saving = $state(false);


### PR DESCRIPTION
## Summary
The `$effect` that syncs editor state when the `note` prop changes was reading `content` and `tags` — the same `$state` it writes to — within a single effect run, creating a self-dependency loop.

```js
$effect(() => {
  if (note) {
    content = note.content ?? '';                    // writes content
    tags = [...(note.tags || [])];                   // writes tags (new array ref)
    previousContentTags = extractTagsFromContent(content); // reads content
    for (const t of previousContentTags) {
      if (!tags.includes(t)) tags.push(t);           // reads + mutates tags
    }
    historyStack = [content || ''];                  // reads content
  }
});
```

`tags = [...(note.tags || [])]` creates a **new array reference every run**. Since the effect reads `tags` (via `tags.includes`), the new reference re-triggers the effect, which creates another new array, which re-triggers again — an **infinite loop**. The same applies to `content` (read after write).

## Fix
Wrap the writes in `untrack()` so only `note` is a dependency. The effect now runs exactly once when the note changes, and user edits to `content`/`tags` no longer reset the editor (or loop).

## Verification
Headless Playwright against the Vite dev server (API stubbed):
- Editor loads note content: `INITIAL_VALUE: "Initial content"`
- After typing: `VALUE_AFTER_TYPE: "Initial content USER_TYPED_TEXT"`
- `USER_TEXT_PRESERVED: true` — user input is not reset
- `LOOP_ERRORS: []` — no infinite loop / stack overflow errors
- `cd frontend && npm run check` → 0 errors

#### Test plan
- [x] `npm run check` passes with no new errors.
- [x] Playwright: typing in the editor preserves user input (no reset from effect loop).
- [x] No infinite loop console errors.

Closes #202

Generated with [Devin](https://devin.ai)