### PR TITLE
fix(api): fetch only needed tags in get_skill_tree (#206)

### DIFF
--- a/api/services/skill_tree.py
+++ b/api/services/skill_tree.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 
 from models.note import NoteTag, Tag
 from models.skill import Skill, compute_skill_level
-from repositories import SkillRepository, TagRepository
+from repositories import SkillRepository
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -104,7 +104,20 @@ def sync_skills(db: Session) -> list[dict]:
 def get_skill_tree(db: Session) -> dict:
     """Return skill tree as nested structure for D3 visualization."""
     skills = SkillRepository(db).list()
-    tags = {t.id: t for t in TagRepository(db).list()}
+    if not skills:
+        return {"nodes": [], "edges": []}
+
+    # Fetch only the tags referenced by skills (and their parent tags) instead
+    # of TagRepository(db).list(), which caps at 100 rows. When a user has
+    # 100+ tags from notes, skill tags with IDs > 100 were missing from the
+    # dict and the corresponding nodes were silently skipped, so the tree
+    # rendered fewer nodes than the sidebar (#206).
+    tag_ids = {s.tag_id for s in skills}
+    tags = {t.id: t for t in db.query(Tag).filter(Tag.id.in_(tag_ids)).all()}
+    # Include parent tags so edges can be drawn.
+    parent_ids = {t.parent_id for t in tags.values() if t.parent_id}
+    if parent_ids:
+        tags.update({t.id: t for t in db.query(Tag).filter(Tag.id.in_(parent_ids)).all()})
 
     nodes = []
     edges = []


### PR DESCRIPTION
## Summary
The `/skills` page sidebar showed 4 unlocked skills, but the force-graph tree rendered only one node. The root cause is in the backend `get_skill_tree` function.

`get_skill_tree` used `TagRepository(db).list()` to build a `tags` dict, but `list()` caps at **100 rows** (`limit=100`). When a user has 100+ tags from notes, skill tags with IDs > 100 were missing from the dict, and the corresponding nodes were silently skipped (`if not tag: continue`).

Meanwhile, the sidebar's `_cached_list_skills` fetched **all** tags without limit (`db.query(Tag.id, Tag.name).all()`), so it showed all unlocked skills correctly — creating the mismatch.

## Fix
Fetch only the tags referenced by skills (and their parent tags) via `Tag.id.in_(tag_ids)` instead of loading all tags with a `limit=100`.

```python
tag_ids = {s.tag_id for s in skills}
tags = {t.id: t for t in db.query(Tag).filter(Tag.id.in_(tag_ids)).all()}
parent_ids = {t.parent_id for t in tags.values() if t.parent_id}
if parent_ids:
    tags.update({t.id: t for t in db.query(Tag).filter(Tag.id.in_(parent_ids)).all()})
```

## Verification
- `python -m compileall api/services/skill_tree.py` → OK
- Frontend SkillTree component verified via Playwright (with stubbed 4-node API): all 4 nodes render correctly with proper data. The bug was in the backend data, not the frontend rendering.
- The sidebar's `_cached_list_skills` was already fetching all tags correctly (no limit), confirming the mismatch was backend-only.

#### Test plan
- [x] `compileall` passes.
- [x] Frontend Playwright test confirms SkillTree renders all nodes when data is complete.
- [ ] API test with 100+ tags and 4 skills confirms all 4 appear in tree (requires Docker).

Closes #206

Generated with [Devin](https://devin.ai)