### PR TITLE
fix(frontend): hide YAML frontmatter with Windows line endings (#207)

### DIFF
--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -226,7 +226,7 @@
     }
   }
 
-  let rawFrontmatterMatch = $derived(content.match(/^---\n[\s\S]*?\n---/));
+  let rawFrontmatterMatch = $derived(content.match(/^---\r?\n[\s\S]*?\r?\n---/));
   let rawFrontmatter = $derived(rawFrontmatterMatch ? rawFrontmatterMatch[0] : '');
 
   let tagsLineMatch = $derived(content.match(/^#\s*Tags?:\s*.*$/im));
@@ -235,7 +235,7 @@
   let visibleEditorContent = $derived((() => {
     let val = content;
     if (!$showFrontmatter && rawFrontmatter) {
-      val = val.replace(/^---\n[\s\S]*?\n---[\n]*/, '');
+      val = val.replace(/^---\r?\n[\s\S]*?\r?\n---[\r\n]*/, '');
     }
     if ($hideTagsLine && tags.length > 0 && currentTagsLine) {
       val = val.replace(/^#\s*Tags?:\s*.*$/im, '').trim();
@@ -440,7 +440,7 @@
   }
 
   function updateFrontmatter(key: string, value: string) {
-    const m = content.match(/^---\n([\s\S]*?)\n---/);
+    const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     if (m) {
       let yaml = m[1];
       const regex = new RegExp(`(?:^|\\n)${key}:.*`);
@@ -450,7 +450,7 @@
         yaml += `\n${key}: ${value}`;
       }
       yaml = yaml.replace(/\n{2,}/g, '\n').trim();
-      content = content.replace(/^---\n[\s\S]*?\n---/, `---\n${yaml}\n---`);
+      content = content.replace(/^---\r?\n[\s\S]*?\r?\n---/, `---\n${yaml}\n---`);
     } else {
       content = `---\n${key}: ${value}\n---\n\n` + content;
     }

--- a/frontend/src/lib/utils/fileTree.ts
+++ b/frontend/src/lib/utils/fileTree.ts
@@ -87,7 +87,7 @@ const FILE_ICONS: [RegExp, string][] = [
 ];
 
 export function extractFrontmatter(content: string) {
-  const m = content.match(/^---\n([\s\S]*?)\n---/);
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!m) return { icon: null, color: null, pack: null };
   const yaml = m[1];
   const ic = yaml.match(/(?:^|\n)icon:\s*([^\n]+)/);

--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -885,7 +885,7 @@
               updateFolderMeta(editingFolder, { icon: folderIcon, color: folderColor });
               if (editingFolderNote) {
                 let content = editingFolderNote.content;
-                const match = content.match(/^---\n([\s\S]*?)\n---/);
+                const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
                 if (match) {
                   let yaml = match[1];
                   if (yaml.match(/(?:^|\n)icon:\s*([^\n]*)/)) {
@@ -898,7 +898,7 @@
                   } else {
                     yaml += `\niconColor: ${folderColor}`;
                   }
-                  content = content.replace(/^---\n([\s\S]*?)\n---/, `---\n${yaml}\n---`);
+                  content = content.replace(/^---\r?\n([\s\S]*?)\r?\n---/, `---\n${yaml}\n---`);
                 } else {
                   content = `---\nicon: ${folderIcon}\niconColor: ${folderColor}\n---\n\n${content}`;
                 }


### PR DESCRIPTION
## Summary
The NoteEditor's frontmatter detection regexes used `\n` exclusively. Notes with `\r\n` (Windows/CRLF) line endings — e.g. edited in Obsidian on Windows, or synced through a vault that normalises to CRLF — did not match the frontmatter pattern. The `rawFrontmatter` derived value was empty, so `visibleEditorContent` did not strip the `---` block, and the editor showed the YAML frontmatter as editable content.

## Fix
Use `\r?\n` in all frontmatter regexes so both Unix (`\n`) and Windows (`\r\n`) line endings are matched:

- **`NoteEditor.svelte`**: `rawFrontmatterMatch`, `visibleEditorContent` strip, and `updateFrontmatter`
- **`fileTree.ts`**: `extractFrontmatter` (used for icon/color extraction)
- **`notes/+page.svelte`**: folder icon/color frontmatter update

## Verification
Headless Playwright against the Vite dev server (API stubbed with a note containing `\r\n` frontmatter):

**Before** (CRLF content):
- `textareaValue`: `"---\nicon: Target\n...\n---\n\nThis is the actual note body..."` — frontmatter visible
- `bodyContainsFrontmatter: true`

**After** (CRLF content):
- `textareaValue`: `"This is the actual note body. It should be visible..."` — frontmatter hidden
- `bodyContainsFrontmatter: false`
- `bodyContainsActualContent: true`

- `cd frontend && npm run check` → 0 errors

#### Test plan
- [x] `npm run check` passes with no new errors.
- [x] Playwright: CRLF frontmatter is hidden from the editor textarea.
- [x] Playwright: Unix (`\n`) frontmatter still hidden (no regression).

Closes #207

Generated with [Devin](https://devin.ai)