### PR TITLE
docs(agents): PRs must target development branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,3 +129,8 @@ Two concurrent asyncio tasks: `watch_vault()` (watches `/vault/*.md`, 2s debounc
 - Config via Pydantic `Settings` from `.env`; no hardcoded values
 - `svelte-kit sync` runs on `postinstall` — can fail if `.svelte-kit/` has root-owned files
 - Vite HMR in Docker: `server.hmr.clientPort: 3000` + `host: localhost` (in `vite.config.ts`)
+
+## Workflow
+
+- Base branch for pull requests is `development`. Always create feature branches from `development` and open PRs against `development`, not `main`.
+- `main` is reserved for releases and should only be updated from `development` via release or hotfix PRs.


### PR DESCRIPTION
## Summary
- Update `AGENTS.md` to document that all feature branches and PRs must target `development`.
- Clarify that `main` is reserved for releases.

## Test plan
- [x] Markdown renders correctly.

Generated with [Devin](https://devin.ai)