### PR TITLE
feat(integrations): add Strava and Spotify OAuth foundation (#44 #45)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,18 @@ GITHUB_USERNAME=
 # Webhook callback URL
 GITHUB_WEBHOOK_URL=
 
+# ── Strava OAuth ──────────────────────────────────
+# Create an app at: https://www.strava.com/settings/api
+STRAVA_CLIENT_ID=
+STRAVA_CLIENT_SECRET=
+STRAVA_REDIRECT_URI=http://localhost:8000/integrations/strava/callback
+
+# ── Spotify OAuth ─────────────────────────────────
+# Create an app at: https://developer.spotify.com/dashboard
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+SPOTIFY_REDIRECT_URI=http://localhost:8000/integrations/spotify/callback
+
 # ── Telegram Bot (optional) ───────────────────────
 # Create a bot via @BotFather on Telegram
 # Leave empty to disable Telegram bot

--- a/api/config.py
+++ b/api/config.py
@@ -40,5 +40,15 @@ class Settings(BaseSettings):
     # Authentication
     auth_password: str = ""  # Password for single-user auth (optional)
 
+    # Strava OAuth (Activities, Athlete data)
+    strava_client_id: str = ""
+    strava_client_secret: str = ""
+    strava_redirect_uri: str = ""
+
+    # Spotify OAuth (Playback, Playlists, Top tracks)
+    spotify_client_id: str = ""
+    spotify_client_secret: str = ""
+    spotify_redirect_uri: str = ""
+
 
 settings = Settings()

--- a/api/main.py
+++ b/api/main.py
@@ -32,7 +32,7 @@ from routers import (
     vault,
     websocket,
 )
-from routers.integrations import github
+from routers.integrations import github, spotify, strava
 from services.auth_service import get_current_user
 from fastapi import Depends
 from services.response_cache import get_cache_stats
@@ -147,6 +147,8 @@ app.include_router(gamification.router, dependencies=[Depends(get_current_user)]
 app.include_router(personal_streaks.router, dependencies=[Depends(get_current_user)])
 app.include_router(push.router, dependencies=[Depends(get_current_user)])
 app.include_router(github.router, dependencies=[Depends(get_current_user)])
+app.include_router(strava.router, dependencies=[Depends(get_current_user)])
+app.include_router(spotify.router, dependencies=[Depends(get_current_user)])
 app.include_router(vault.router, dependencies=[Depends(get_current_user)])
 app.include_router(folders.router, dependencies=[Depends(get_current_user)])
 app.include_router(ai.router, dependencies=[Depends(get_current_user)])

--- a/api/routers/integrations/spotify.py
+++ b/api/routers/integrations/spotify.py
@@ -1,0 +1,88 @@
+"""Spotify integration router."""
+
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from services import spotify_service as sp
+from services.auth_service import get_current_user
+
+router = APIRouter(prefix="/integrations/spotify", tags=["integrations"])
+
+
+class SpotifyAuthUrl(BaseModel):
+    url: str
+
+
+@router.get("/auth", response_model=SpotifyAuthUrl)
+async def get_spotify_auth_url():
+    """Return the Spotify OAuth consent URL."""
+    try:
+        url = sp.get_auth_url()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"url": url}
+
+
+@router.get("/callback")
+async def spotify_oauth_callback(code: str = "", error: str = ""):
+    """Handle the OAuth callback from Spotify."""
+    if error:
+        raise HTTPException(status_code=400, detail=f"Spotify OAuth error: {error}")
+    if not code:
+        raise HTTPException(status_code=400, detail="Missing authorization code")
+
+    try:
+        tokens = await sp.exchange_code(code)
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=exc.response.status_code, detail="Spotify token exchange failed")
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    return {
+        "access_token": tokens.get("access_token", ""),
+        "refresh_token": tokens.get("refresh_token"),
+        "expires_in": tokens.get("expires_in", 0),
+        "token_type": tokens.get("token_type", "Bearer"),
+        "scope": tokens.get("scope"),
+    }
+
+
+@router.get("/recently-played")
+async def get_spotify_recently_played(
+    token: str,
+    limit: int = 20,
+    user: dict = Depends(get_current_user),
+):
+    """List recently played Spotify tracks."""
+    try:
+        return await sp.get_recently_played(token, limit)
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=exc.response.status_code, detail="Spotify API error")
+
+
+@router.get("/top-tracks")
+async def get_spotify_top_tracks(
+    token: str,
+    limit: int = 20,
+    user: dict = Depends(get_current_user),
+):
+    """List top Spotify tracks."""
+    try:
+        return await sp.get_top_tracks(token, limit)
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=exc.response.status_code, detail="Spotify API error")
+
+
+@router.get("/playlists")
+async def get_spotify_playlists(
+    token: str,
+    limit: int = 20,
+    user: dict = Depends(get_current_user),
+):
+    """List Spotify playlists."""
+    try:
+        return await sp.get_playlists(token, limit)
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=exc.response.status_code, detail="Spotify API error")

--- a/api/routers/integrations/strava.py
+++ b/api/routers/integrations/strava.py
@@ -1,0 +1,71 @@
+"""Strava integration router."""
+
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from services import strava_service as ss
+from services.auth_service import get_current_user
+
+router = APIRouter(prefix="/integrations/strava", tags=["integrations"])
+
+
+class StravaAuthUrl(BaseModel):
+    url: str
+
+
+@router.get("/auth", response_model=StravaAuthUrl)
+async def get_strava_auth_url():
+    """Return the Strava OAuth consent URL."""
+    try:
+        url = ss.get_auth_url()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"url": url}
+
+
+@router.get("/callback")
+async def strava_oauth_callback(code: str = "", error: str = ""):
+    """Handle the OAuth callback from Strava."""
+    if error:
+        raise HTTPException(status_code=400, detail=f"Strava OAuth error: {error}")
+    if not code:
+        raise HTTPException(status_code=400, detail="Missing authorization code")
+
+    try:
+        tokens = await ss.exchange_code(code)
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=exc.response.status_code, detail="Strava token exchange failed")
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    return {
+        "access_token": tokens.get("access_token", ""),
+        "refresh_token": tokens.get("refresh_token"),
+        "expires_in": tokens.get("expires_in", 0),
+        "token_type": tokens.get("token_type", "Bearer"),
+        "athlete": tokens.get("athlete"),
+    }
+
+
+@router.get("/activities")
+async def get_strava_activities(
+    token: str,
+    per_page: int = 30,
+    user: dict = Depends(get_current_user),
+):
+    """List recent Strava activities."""
+    try:
+        return await ss.list_activities(token, per_page)
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=exc.response.status_code, detail="Strava API error")
+
+
+@router.get("/athlete")
+async def get_strava_athlete(token: str, user: dict = Depends(get_current_user)):
+    """Get the authenticated Strava athlete."""
+    try:
+        return await ss.get_athlete(token)
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=exc.response.status_code, detail="Strava API error")

--- a/api/services/spotify_service.py
+++ b/api/services/spotify_service.py
@@ -1,0 +1,84 @@
+"""Spotify OAuth and API helpers."""
+
+from typing import Any
+
+import httpx
+from config import settings
+
+SPOTIFY_AUTH_URL = "https://accounts.spotify.com/authorize"
+SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
+SPOTIFY_API = "https://api.spotify.com/v1"
+
+
+def get_auth_url(state: str = "") -> str:
+    """Build the Spotify OAuth consent URL."""
+    if not settings.spotify_client_id or not settings.spotify_redirect_uri:
+        raise RuntimeError("Spotify OAuth is not configured")
+
+    params = {
+        "client_id": settings.spotify_client_id,
+        "redirect_uri": settings.spotify_redirect_uri,
+        "response_type": "code",
+        "scope": "user-read-recently-played user-read-playback-state user-top-read playlist-read-private",
+    }
+    if state:
+        params["state"] = state
+
+    query = httpx.QueryParams(params)
+    return f"{SPOTIFY_AUTH_URL}?{query}"
+
+
+async def exchange_code(code: str) -> dict[str, Any]:
+    """Exchange an OAuth authorization code for tokens."""
+    if not settings.spotify_client_secret or not settings.spotify_redirect_uri:
+        raise RuntimeError("Spotify OAuth is not configured")
+
+    auth = httpx.BasicAuth(settings.spotify_client_id, settings.spotify_client_secret)
+    payload = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": settings.spotify_redirect_uri,
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        r = await client.post(SPOTIFY_TOKEN_URL, data=payload, auth=auth)
+        r.raise_for_status()
+        return r.json()
+
+
+async def _request(token: str, url: str, params: dict | None = None) -> Any:
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        r = await client.get(url, headers=headers, params=params or {})
+        r.raise_for_status()
+        return r.json()
+
+
+async def get_recently_played(token: str, limit: int = 20) -> list[dict[str, Any]]:
+    """Get the user's recently played tracks."""
+    data = await _request(
+        token,
+        f"{SPOTIFY_API}/me/player/recently-played",
+        params={"limit": limit},
+    )
+    return data.get("items", [])
+
+
+async def get_top_tracks(token: str, limit: int = 20) -> list[dict[str, Any]]:
+    """Get the user's top tracks."""
+    data = await _request(
+        token,
+        f"{SPOTIFY_API}/me/top/tracks",
+        params={"limit": limit},
+    )
+    return data.get("items", [])
+
+
+async def get_playlists(token: str, limit: int = 20) -> list[dict[str, Any]]:
+    """Get the user's playlists."""
+    data = await _request(
+        token,
+        f"{SPOTIFY_API}/me/playlists",
+        params={"limit": limit},
+    )
+    return data.get("items", [])

--- a/api/services/strava_service.py
+++ b/api/services/strava_service.py
@@ -1,0 +1,69 @@
+"""Strava OAuth and API helpers."""
+
+from typing import Any
+
+import httpx
+from config import settings
+
+STRAVA_AUTH_URL = "https://www.strava.com/oauth/authorize"
+STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token"
+STRAVA_API = "https://www.strava.com/api/v3"
+
+
+def get_auth_url(state: str = "") -> str:
+    """Build the Strava OAuth consent URL."""
+    if not settings.strava_client_id or not settings.strava_redirect_uri:
+        raise RuntimeError("Strava OAuth is not configured")
+
+    params = {
+        "client_id": settings.strava_client_id,
+        "redirect_uri": settings.strava_redirect_uri,
+        "response_type": "code",
+        "approval_prompt": "force",
+        "scope": "read,activity:read",
+    }
+    if state:
+        params["state"] = state
+
+    query = httpx.QueryParams(params)
+    return f"{STRAVA_AUTH_URL}?{query}"
+
+
+async def exchange_code(code: str) -> dict[str, Any]:
+    """Exchange an OAuth authorization code for tokens."""
+    if not settings.strava_client_secret or not settings.strava_redirect_uri:
+        raise RuntimeError("Strava OAuth is not configured")
+
+    payload = {
+        "client_id": settings.strava_client_id,
+        "client_secret": settings.strava_client_secret,
+        "code": code,
+        "grant_type": "authorization_code",
+    }
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        r = await client.post(STRAVA_TOKEN_URL, data=payload)
+        r.raise_for_status()
+        return r.json()
+
+
+async def _request(token: str, url: str, params: dict | None = None) -> Any:
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        r = await client.get(url, headers=headers, params=params or {})
+        r.raise_for_status()
+        return r.json()
+
+
+async def list_activities(token: str, per_page: int = 30) -> list[dict[str, Any]]:
+    """List the athlete's recent activities."""
+    return await _request(
+        token,
+        f"{STRAVA_API}/athlete/activities",
+        params={"per_page": per_page},
+    )
+
+
+async def get_athlete(token: str) -> dict[str, Any]:
+    """Get the authenticated athlete's profile."""
+    return await _request(token, f"{STRAVA_API}/athlete")

--- a/api/tests/test_spotify.py
+++ b/api/tests/test_spotify.py
@@ -1,0 +1,90 @@
+"""Tests for Spotify integration router and service."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def test_spotify_auth_url_unconfigured(client):
+    resp = client.get("/integrations/spotify/auth")
+    assert resp.status_code == 400
+
+
+def test_spotify_auth_url_configured(client, monkeypatch):
+    monkeypatch.setattr(
+        "services.spotify_service.settings.spotify_client_id", "spotify-client-id"
+    )
+    monkeypatch.setattr(
+        "services.spotify_service.settings.spotify_redirect_uri",
+        "http://localhost:8000/integrations/spotify/callback",
+    )
+
+    resp = client.get("/integrations/spotify/auth")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "accounts.spotify.com" in data["url"]
+    assert "spotify-client-id" in data["url"]
+
+
+def test_spotify_callback_missing_code(client):
+    resp = client.get("/integrations/spotify/callback")
+    assert resp.status_code == 400
+
+
+def test_spotify_callback_error(client):
+    resp = client.get("/integrations/spotify/callback?error=access_denied")
+    assert resp.status_code == 400
+
+
+def test_spotify_callback_exchanges_code(client, monkeypatch):
+    monkeypatch.setattr(
+        "services.spotify_service.settings.spotify_client_id", "spotify-client-id"
+    )
+    monkeypatch.setattr(
+        "services.spotify_service.settings.spotify_client_secret",
+        "spotify-client-secret",
+    )
+    monkeypatch.setattr(
+        "services.spotify_service.settings.spotify_redirect_uri",
+        "http://localhost:8000/integrations/spotify/callback",
+    )
+
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "access_token": "ACCESS",
+        "refresh_token": "REFRESH",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+        "scope": "user-read-recently-played",
+    }
+    fake_response.raise_for_status.return_value = None
+
+    with patch("httpx.AsyncClient.post", new=AsyncMock(return_value=fake_response)):
+        resp = client.get("/integrations/spotify/callback?code=abc123")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["access_token"] == "ACCESS"
+    assert data["refresh_token"] == "REFRESH"
+
+
+def test_spotify_recently_played(client, monkeypatch):
+    monkeypatch.setattr(
+        "services.spotify_service.settings.spotify_client_id", "spotify-client-id"
+    )
+    monkeypatch.setattr(
+        "services.spotify_service.settings.spotify_redirect_uri",
+        "http://localhost:8000/integrations/spotify/callback",
+    )
+
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "items": [{"track": {"name": "Song 1"}}]
+    }
+    fake_response.raise_for_status.return_value = None
+
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=fake_response)):
+        resp = client.get("/integrations/spotify/recently-played?token=xyz")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["track"]["name"] == "Song 1"

--- a/api/tests/test_strava.py
+++ b/api/tests/test_strava.py
@@ -1,0 +1,87 @@
+"""Tests for Strava integration router and service."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def test_strava_auth_url_unconfigured(client):
+    resp = client.get("/integrations/strava/auth")
+    assert resp.status_code == 400
+
+
+def test_strava_auth_url_configured(client, monkeypatch):
+    monkeypatch.setattr(
+        "services.strava_service.settings.strava_client_id", "strava-client-id"
+    )
+    monkeypatch.setattr(
+        "services.strava_service.settings.strava_redirect_uri",
+        "http://localhost:8000/integrations/strava/callback",
+    )
+
+    resp = client.get("/integrations/strava/auth")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "strava.com" in data["url"]
+    assert "strava-client-id" in data["url"]
+
+
+def test_strava_callback_missing_code(client):
+    resp = client.get("/integrations/strava/callback")
+    assert resp.status_code == 400
+
+
+def test_strava_callback_error(client):
+    resp = client.get("/integrations/strava/callback?error=access_denied")
+    assert resp.status_code == 400
+
+
+def test_strava_callback_exchanges_code(client, monkeypatch):
+    monkeypatch.setattr(
+        "services.strava_service.settings.strava_client_id", "strava-client-id"
+    )
+    monkeypatch.setattr(
+        "services.strava_service.settings.strava_client_secret", "strava-client-secret"
+    )
+    monkeypatch.setattr(
+        "services.strava_service.settings.strava_redirect_uri",
+        "http://localhost:8000/integrations/strava/callback",
+    )
+
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "access_token": "ACCESS",
+        "refresh_token": "REFRESH",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+        "athlete": {"id": 1, "firstname": "Ada"},
+    }
+    fake_response.raise_for_status.return_value = None
+
+    with patch("httpx.AsyncClient.post", new=AsyncMock(return_value=fake_response)):
+        resp = client.get("/integrations/strava/callback?code=abc123")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["access_token"] == "ACCESS"
+    assert data["athlete"]["firstname"] == "Ada"
+
+
+def test_strava_activities_list(client, monkeypatch):
+    monkeypatch.setattr(
+        "services.strava_service.settings.strava_client_id", "strava-client-id"
+    )
+    monkeypatch.setattr(
+        "services.strava_service.settings.strava_redirect_uri",
+        "http://localhost:8000/integrations/strava/callback",
+    )
+
+    fake_response = MagicMock()
+    fake_response.json.return_value = [{"id": 123, "name": "Morning Run"}]
+    fake_response.raise_for_status.return_value = None
+
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=fake_response)):
+        resp = client.get("/integrations/strava/activities?token=xyz")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["name"] == "Morning Run"


### PR DESCRIPTION
## Summary
- Add Strava and Spotify OAuth flows (auth URL and callback).
- Add service helpers and list endpoints for Strava activities/athlete and Spotify recently played/top tracks/playlists.
- Add `STRAVA_*` and `SPOTIFY_*` settings and `.env.example` values.
- Mount the new routers in `api/main.py`.
- Add `tests/test_strava.py` and `tests/test_spotify.py`.

## Test plan
- [x] `python -m compileall api/`
- [x] `PYTHONPATH=/app python -m pytest tests/test_strava.py tests/test_spotify.py`

Closes #44, closes #45.

Generated with [Devin](https://devin.ai)