### PR TITLE
fix(security): auth and path traversal checks for /folders

### DIFF
--- a/api/routers/folders.py
+++ b/api/routers/folders.py
@@ -1,48 +1,61 @@
 import os
 import shutil
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+from services.auth_service import get_current_user
 
 router = APIRouter(prefix="/folders", tags=["folders"])
+
 
 class FolderCreate(BaseModel):
     path: str
 
+
+def _get_safe_path(vault: str, requested: str) -> str:
+    """Resolve a vault-relative path and make sure it stays inside the vault."""
+    full_path = os.path.realpath(os.path.join(vault, requested))
+    vault_path = os.path.realpath(vault)
+    if os.path.commonpath([full_path, vault_path]) != vault_path:
+        raise HTTPException(status_code=400, detail="Invalid path")
+    return full_path
+
+
 @router.post("/")
-def create_folder(folder: FolderCreate):
+def create_folder(
+    folder: FolderCreate,
+    user: dict = Depends(get_current_user),
+):
     vault = os.environ.get("OBSIDIAN_VAULT_PATH")
     if not vault:
         raise HTTPException(status_code=400, detail="OBSIDIAN_VAULT_PATH not set")
-    
-    if ".." in folder.path or folder.path.startswith("/"):
-        raise HTTPException(status_code=400, detail="Invalid path")
 
-    full_path = os.path.join(vault, folder.path)
+    full_path = _get_safe_path(vault, folder.path)
     if os.path.exists(full_path):
         raise HTTPException(status_code=400, detail="Folder already exists")
-    
+
     try:
         os.makedirs(full_path, exist_ok=True)
         return {"status": "ok", "path": folder.path}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @router.delete("/{path:path}")
-def delete_folder(path: str):
+def delete_folder(
+    path: str,
+    user: dict = Depends(get_current_user),
+):
     vault = os.environ.get("OBSIDIAN_VAULT_PATH")
     if not vault:
         raise HTTPException(status_code=400, detail="OBSIDIAN_VAULT_PATH not set")
-    
-    if ".." in path or path.startswith("/"):
-        raise HTTPException(status_code=400, detail="Invalid path")
 
-    full_path = os.path.join(vault, path)
+    full_path = _get_safe_path(vault, path)
     if not os.path.exists(full_path):
         raise HTTPException(status_code=404, detail="Folder not found")
-    
+
     if not os.path.isdir(full_path):
         raise HTTPException(status_code=400, detail="Not a folder")
-        
+
     try:
         shutil.rmtree(full_path)
         return {"status": "ok"}

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -63,3 +63,9 @@ def client(db_session):
 
     app.dependency_overrides.clear()
     app.dependency_overrides.update(original_overrides)
+
+
+@pytest.fixture
+def client_no_auth():
+    with TestClient(app) as test_client:
+        yield test_client

--- a/api/tests/test_folders.py
+++ b/api/tests/test_folders.py
@@ -1,0 +1,32 @@
+"""Tests for folders router security and path validation."""
+
+import os
+
+
+def test_create_folder_requires_auth(client_no_auth):
+    resp = client_no_auth.post("/folders/", json={"path": "test-folder"})
+    assert resp.status_code == 401
+
+
+def test_delete_folder_requires_auth(client_no_auth):
+    resp = client_no_auth.delete("/folders/test-folder")
+    assert resp.status_code == 401
+
+
+def test_create_folder_path_traversal(client, monkeypatch, tmp_path):
+    vault = str(tmp_path / "vault")
+    os.makedirs(vault, exist_ok=True)
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", vault)
+
+    resp = client.post("/folders/", json={"path": "../outside"})
+    assert resp.status_code == 400
+
+
+def test_create_folder_success(client, monkeypatch, tmp_path):
+    vault = str(tmp_path / "vault")
+    os.makedirs(vault, exist_ok=True)
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", vault)
+
+    resp = client.post("/folders/", json={"path": "notes/daily"})
+    assert resp.status_code == 200
+    assert os.path.isdir(os.path.join(vault, "notes", "daily"))


### PR DESCRIPTION
## Summary
- Add explicit `Depends(get_current_user)` to folder create/delete.
- Use `os.path.realpath` and `os.path.commonpath` to prevent path traversal outside `OBSIDIAN_VAULT_PATH`.
- Add `tests/test_folders.py` with auth and traversal cases.

Closes #220, closes #223.

Generated with [Devin](https://devin.ai)