### PR TITLE
fix(goals): import resolve_pending_removal in goals router

### DIFF
--- a/api/routers/goals.py
+++ b/api/routers/goals.py
@@ -18,6 +18,7 @@ from services.goal_service import (
     get_goal_progress,
     get_bulk_goal_progress,
     get_goal_streak,
+    resolve_pending_removal,
     sync_goals_from_note,
 )
 from services.joidy_vault_writer import (


### PR DESCRIPTION
## Summary
- Fix `NameError` in `POST /goals/{goal_id}/resolve-removal` by importing `resolve_pending_removal` from `services.goal_service`.

Closes #222.

Generated with [Devin](https://devin.ai)