### PR TITLE
refactor(frontend): extract GoalFilters and GoalList from goals page

### DIFF
--- a/frontend/src/lib/components/GoalFilters.svelte
+++ b/frontend/src/lib/components/GoalFilters.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import { Search } from 'lucide-svelte';
+
+  let {
+    query = $bindable(''),
+    filter = $bindable<string | null>(null)
+  } = $props();
+</script>
+
+<div class="editor-header">
+  <h3 class="editor-title">Editor de Objetivos</h3>
+  <div class="editor-controls">
+    <div class="search-box">
+      <Search size={16} />
+      <input
+        type="text"
+        placeholder="Buscar objetivos..."
+        bind:value={query}
+      />
+    </div>
+    <div class="filter-buttons">
+      <button
+        class="filter-btn"
+        class:active={filter === null}
+        onclick={() => filter = null}
+      >Todos</button>
+      <button
+        class="filter-btn"
+        class:active={filter === 'PINNED'}
+        onclick={() => filter = 'PINNED'}
+      >Fijados</button>
+      <button
+        class="filter-btn"
+        class:active={filter === 'ACTIVE'}
+        onclick={() => filter = 'ACTIVE'}
+      >Activos</button>
+      <button
+        class="filter-btn"
+        class:active={filter === 'COMPLETED'}
+        onclick={() => filter = 'COMPLETED'}
+      >Completados</button>
+      <button
+        class="filter-btn"
+        class:active={filter === 'PAUSED'}
+        onclick={() => filter = 'PAUSED'}
+      >Pausados</button>
+      <button
+        class="filter-btn"
+        class:active={filter === 'FAILED'}
+        onclick={() => filter = 'FAILED'}
+      >Fallidos</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .editor-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 24px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+    flex-shrink: 0;
+    gap: 20px;
+    flex-wrap: wrap;
+  }
+
+  .editor-title {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+  }
+
+  .editor-controls {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+
+  .search-box {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    background: var(--surface-hover);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    color: var(--text-muted);
+  }
+
+  .search-box input {
+    background: transparent;
+    border: none;
+    color: var(--text-primary);
+    font-size: 13px;
+    outline: none;
+    width: 180px;
+  }
+
+  .search-box input::placeholder {
+    color: var(--text-muted);
+  }
+
+  .filter-buttons {
+    display: flex;
+    gap: 6px;
+  }
+
+  .filter-btn {
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 12px;
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+
+  .filter-btn:hover {
+    background: var(--surface-hover);
+    color: var(--text-primary);
+  }
+
+  .filter-btn.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--bg);
+    font-weight: 500;
+  }
+
+  @media (max-width: 768px) {
+    .editor-header {
+      flex-direction: column;
+      gap: 12px;
+      align-items: flex-start;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/GoalList.svelte
+++ b/frontend/src/lib/components/GoalList.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  import GoalCard from './GoalCard.svelte';
+  import type { Goal, Note } from '$lib/api';
+  import type { Tag as TagType } from '$lib/api';
+
+  interface Props {
+    goals: Goal[];
+    query: string;
+    filter: string | null;
+    pinned: Set<number>;
+    tags: TagType[];
+    notes: Note[];
+    getGoalColor: (goal: Goal) => string;
+    TEMPORALITY_LABELS: Record<string, string>;
+    STATE_LABELS: Record<string, string>;
+    formatFailConfig: (config: string) => string;
+    onTogglePin: (id: number) => void;
+    onClick: (goal: Goal) => void;
+  }
+
+  let {
+    goals,
+    query,
+    filter,
+    pinned,
+    tags,
+    notes,
+    getGoalColor,
+    TEMPORALITY_LABELS,
+    STATE_LABELS,
+    formatFailConfig,
+    onTogglePin,
+    onClick,
+  }: Props = $props();
+
+  function filteredGoals(goals: Goal[], query: string, filter: string | null, pinned: Set<number>) {
+    let result = goals;
+    if (query) {
+      const q = query.toLowerCase();
+      result = result.filter(g =>
+        g.title.toLowerCase().includes(q) ||
+        (g.description && g.description.toLowerCase().includes(q))
+      );
+    }
+    if (filter) {
+      if (filter === 'COMPLETED') {
+        result = result.filter(g => g.state === 'COMPLETED' || g.is_completed);
+      } else if (filter === 'PINNED') {
+        result = result.filter(g => pinned.has(g.id));
+      } else {
+        result = result.filter(g => g.state === filter);
+      }
+    }
+    return [...result].sort((a, b) => {
+      const aPinned = pinned.has(a.id) ? 0 : 1;
+      const bPinned = pinned.has(b.id) ? 0 : 1;
+      return aPinned - bPinned;
+    });
+  }
+
+  let visibleGoals = $derived(filteredGoals(goals, query, filter, pinned));
+</script>
+
+<div class="editor-grid-container">
+  {#if visibleGoals.length === 0}
+    <div class="empty-state">No hay objetivos que coincidan con los filtros.</div>
+  {:else}
+    <div class="editor-grid">
+      {#each visibleGoals as goal (goal.id)}
+        <GoalCard
+          {goal}
+          pinned={pinned.has(goal.id)}
+          {tags}
+          {notes}
+          {getGoalColor}
+          {TEMPORALITY_LABELS}
+          {STATE_LABELS}
+          {formatFailConfig}
+          onTogglePin={(id) => onTogglePin(id)}
+          onClick={(g) => onClick(g)}
+        />
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .editor-grid-container {
+    flex: 1;
+    overflow-y: auto;
+    padding: 24px;
+  }
+
+  .editor-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 20px;
+    width: 100%;
+  }
+
+  .empty-state {
+    padding: 32px;
+    text-align: center;
+    color: var(--text-muted);
+  }
+
+  @media (max-width: 768px) {
+    .editor-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -2,8 +2,10 @@
   import { onMount } from 'svelte';
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
-  import { Plus, Check, ChevronDown, Calendar, BarChart, Clock, Layout, Pause, Play, Ban, Pencil, X, Flame, ChevronRight, ChevronLeft, TrendingUp, TrendingDown, PieChart, Activity, Target, Trophy, Settings, Palette, Hexagon, Filter, AlertTriangle, FileEdit, Tag, FileText, Search, Pin, PinOff } from 'lucide-svelte';
+  import { Plus, Check, ChevronDown, Calendar, BarChart, Clock, Layout, Pause, Play, Ban, Pencil, X, Flame, ChevronRight, ChevronLeft, TrendingUp, TrendingDown, PieChart, Activity, Target, Trophy, Settings, Palette, Hexagon, Filter, AlertTriangle, FileEdit, Tag, FileText, Pin, PinOff } from 'lucide-svelte';
   import { api, type Goal, type Tag as TagType, type Note } from '$lib/api';
+  import GoalFilters from '$lib/components/GoalFilters.svelte';
+  import GoalList from '$lib/components/GoalList.svelte';
   import { use24HourClock } from '$lib/stores/settings';
   import { applyGamificationResult, showXPGain } from '$lib/stores/gamification';
   import { getCachedData, setCachedData } from '$lib/utils/userSettings';
@@ -25,31 +27,6 @@
   let goalFilterState = $state<string | null>(null);
   let pinnedGoals = $state<Set<number>>(new Set());
   let deleteConfirm = $state<number | null>(null);
-
-  function filteredGoals(goals: Goal[], query: string, filter: string | null, pinned: Set<number>) {
-    let result = goals;
-    if (query) {
-      const q = query.toLowerCase();
-      result = result.filter(g => 
-        g.title.toLowerCase().includes(q) || 
-        (g.description && g.description.toLowerCase().includes(q))
-      );
-    }
-    if (filter) {
-      if (filter === 'COMPLETED') {
-        result = result.filter(g => g.state === 'COMPLETED' || g.is_completed);
-      } else if (filter === 'PINNED') {
-        result = result.filter(g => pinned.has(g.id));
-      } else {
-        result = result.filter(g => g.state === filter);
-      }
-    }
-    return [...result].sort((a, b) => {
-      const aPinned = pinned.has(a.id) ? 0 : 1;
-      const bPinned = pinned.has(b.id) ? 0 : 1;
-      return aPinned - bPinned;
-    });
-  }
 
   function togglePinned(goalId: number) {
     const newPinned = new Set(pinnedGoals);
@@ -1893,73 +1870,21 @@
 
   {#if currentTab === 'editor'}
     <div class="tab-content fade-in editor-tab">
-      <div class="editor-header">
-        <h3 class="editor-title">Editor de Objetivos</h3>
-        <div class="editor-controls">
-          <div class="search-box">
-            <Search size={16} />
-            <input 
-              type="text" 
-              placeholder="Buscar objetivos..." 
-              bind:value={goalSearchQuery}
-            />
-          </div>
-          <div class="filter-buttons">
-            <button 
-              class="filter-btn" 
-              class:active={goalFilterState === null}
-              onclick={() => goalFilterState = null}
-            >Todos</button>
-            <button 
-              class="filter-btn" 
-              class:active={goalFilterState === 'PINNED'}
-              onclick={() => goalFilterState = 'PINNED'}
-            >Fijados</button>
-            <button 
-              class="filter-btn" 
-              class:active={goalFilterState === 'ACTIVE'}
-              onclick={() => goalFilterState = 'ACTIVE'}
-            >Activos</button>
-            <button 
-              class="filter-btn" 
-              class:active={goalFilterState === 'COMPLETED'}
-              onclick={() => goalFilterState = 'COMPLETED'}
-            >Completados</button>
-            <button 
-              class="filter-btn" 
-              class:active={goalFilterState === 'PAUSED'}
-              onclick={() => goalFilterState = 'PAUSED'}
-            >Pausados</button>
-            <button 
-              class="filter-btn" 
-              class:active={goalFilterState === 'FAILED'}
-              onclick={() => goalFilterState = 'FAILED'}
-            >Fallidos</button>
-          </div>
-        </div>
-      </div>
-      <div class="editor-grid-container">
-        {#if filteredGoals(goals, goalSearchQuery, goalFilterState, pinnedGoals).length === 0}
-          <div class="empty-state">No hay objetivos que coincidan con los filtros.</div>
-        {:else}
-          <div class="editor-grid">
-            {#each filteredGoals(goals, goalSearchQuery, goalFilterState, pinnedGoals) as goal (goal.id)}
-              <GoalCard
-                {goal}
-                pinned={pinnedGoals.has(goal.id)}
-                {tags}
-                {notes}
-                {getGoalColor}
-                {TEMPORALITY_LABELS}
-                {STATE_LABELS}
-                {formatFailConfig}
-                onTogglePin={(id) => togglePinned(id)}
-                onClick={(g) => openGoalEditor(g)}
-              />
-            {/each}
-          </div>
-        {/if}
-      </div>
+      <GoalFilters bind:query={goalSearchQuery} bind:filter={goalFilterState} />
+      <GoalList
+        {goals}
+        query={goalSearchQuery}
+        filter={goalFilterState}
+        pinned={pinnedGoals}
+        {tags}
+        {notes}
+        {getGoalColor}
+        {TEMPORALITY_LABELS}
+        {STATE_LABELS}
+        {formatFailConfig}
+        onTogglePin={togglePinned}
+        onClick={openGoalEditor}
+      />
     </div>
   {/if}
 </div>
@@ -3748,112 +3673,13 @@
     overflow: hidden;
   }
 
-  .editor-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 16px 24px;
-    border-bottom: 1px solid var(--border);
-    background: var(--surface);
-    flex-shrink: 0;
-    gap: 20px;
-    flex-wrap: wrap;
-  }
-
-  .editor-title {
-    font-size: 20px;
-    font-weight: 600;
-    color: var(--text-primary);
-    margin: 0;
-  }
-
-  .editor-controls {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    flex-wrap: wrap;
-  }
-
-  .search-box {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 14px;
-    background: var(--surface-hover);
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    color: var(--text-muted);
-  }
-
-  .search-box input {
-    background: transparent;
-    border: none;
-    color: var(--text-primary);
-    font-size: 13px;
-    outline: none;
-    width: 180px;
-  }
-
-  .search-box input::placeholder {
-    color: var(--text-muted);
-  }
-
-  .filter-buttons {
-    display: flex;
-    gap: 6px;
-  }
-
-  .filter-btn {
-    padding: 6px 12px;
-    border-radius: 6px;
-    font-size: 12px;
-    background: transparent;
-    border: 1px solid var(--border);
-    color: var(--text-muted);
-    cursor: pointer;
-    transition: all 0.2s ease;
-  }
-
-  .filter-btn:hover {
-    background: var(--surface-hover);
-    color: var(--text-primary);
-  }
-
-  .filter-btn.active {
-    background: var(--accent);
-    border-color: var(--accent);
-    color: var(--bg);
-    font-weight: 500;
-  }
-
-  .editor-grid-container {
-    flex: 1;
-    overflow-y: auto;
-    padding: 24px;
-  }
-
-  .editor-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-    gap: 20px;
-    width: 100%;
-  }
-
   .goal-date {
     font-size: 10px;
   }
 
   @media (max-width: 768px) {
-    .editor-header {
-      flex-direction: column;
-      gap: 12px;
-      align-items: flex-start;
-    }
     .editor-stats {
       flex-wrap: wrap;
-    }
-    .editor-grid {
-      grid-template-columns: 1fr;
     }
   }
 


### PR DESCRIPTION
## Summary
- Extract the goals editor filter/search header into `GoalFilters.svelte`.
- Extract the editor goal grid into `GoalList.svelte`.
- Update `routes/goals/+page.svelte` to compose these components.
- Remove duplicated `filteredGoals` logic and editor CSS.

This reduces the page size and improves HMR/maintainability.

Closes #58, closes #210.

Generated with [Devin](https://devin.ai)