### PR TITLE
perf(frontend): lazy-load lucide-svelte to reduce main bundle

### DIFF
--- a/frontend/src/lib/components/DynamicIcon.svelte
+++ b/frontend/src/lib/components/DynamicIcon.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { activeIconPack } from '$lib/stores/settings';
+  import { Circle } from 'lucide-svelte';
 
   export let name: string;
   export let size: number = 18;
@@ -7,11 +8,6 @@
   export let pack: string | undefined = undefined;
 
   const emojiRegex = /\p{Extended_Pictographic}/u;
-
-  // ── Lucide ──
-  import * as L from 'lucide-svelte';
-  
-
 
   // ── Phosphor ──
   import {
@@ -23,17 +19,22 @@
     Wrench as PWrench
   } from 'phosphor-svelte';
 
-
-
-  // Note: project uses Svelte 5; avoid svelte-material-icons (incompatible)
-  // We'll reuse Phosphor/ Lucide icons instead for the 'material' pack mapping.
   $: isEmoji = emojiRegex.test(name);
-  $: comp = getIconComponent(pack || $activeIconPack, name);
+
+  let lucideComp: any = $state(Circle);
+  let phosphorComp = $state<any>(null);
+
+  async function loadLucide(n: string) {
+    const mod = await import('lucide-svelte');
+    lucideComp = mod[n as keyof typeof mod] || Circle;
+  }
+
+  $: if (!isEmoji && (pack || $activeIconPack) !== 'phosphor' && (pack || $activeIconPack) !== 'material') {
+    loadLucide(name);
+  }
 
   function getIconComponent(pack: string, n: string) {
-
-
-    if (pack === 'phosphor') {
+    if (pack === 'phosphor' || pack === 'material') {
       const map: Record<string, any> = {
         'Home': PHome, 'BookOpen': PBook, 'Network': PNet, 'Zap': PZap, 'Target': PTarget,
         'Flame': PFlame, 'Settings': PCog, 'LayoutGrid': PGrid, 'X': PX, 'Moon': PMoon,
@@ -41,25 +42,13 @@
         'Minus': PMinus, 'RotateCcw': PRot, 'SkipForward': PSkip, 'File': PFile,
         'ChevronLeft': PLeft, 'ChevronRight': PRight, 'Wrench': PWrench,
       };
-      return map[n] || (L as any)[n] || (L as any)['Circle'];
+      phosphorComp = map[n] || null;
+      return phosphorComp || Circle;
     }
-
-    if (pack === 'material') {
-      const map: Record<string, any> = {
-        // map common material names to phosphor equivalents
-        'Home': PHome, 'BookOpen': PBook, 'Network': PNet, 'Zap': PZap, 'Target': PTarget,
-        'Flame': PFlame, 'Settings': PCog, 'LayoutGrid': PGrid, 'X': PX, 'Moon': PMoon,
-        'Sun': PSun, 'Database': PDB, 'GitBranch': PGit, 'Palette': PPal, 'Plus': PPlus,
-        'Minus': PMinus, 'RotateCcw': PRot, 'SkipForward': PSkip, 'File': PFile,
-        'ChevronLeft': PLeft, 'ChevronRight': PRight, 'Wrench': PWrench,
-      };
-      return map[n] || (L as any)[n] || (L as any)['Circle'];
-    }
-
-    // Default fallback to Lucide (also handles 'lucide' implicitly or missing ones)
-    const lMap = (L as any);
-    return lMap[n] || lMap['Circle'];
+    return lucideComp || Circle;
   }
+
+  $: comp = getIconComponent(pack || $activeIconPack, name);
 </script>
 
 {#if isEmoji}

--- a/frontend/src/lib/components/IconPicker.svelte
+++ b/frontend/src/lib/components/IconPicker.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createIconPickerStore } from '$lib/stores/iconPicker';
 	import DynamicIcon from './DynamicIcon.svelte';
-	import * as L from 'lucide-svelte';
+	import { Search } from 'lucide-svelte';
 
 	interface Props {
 		selected?: string;
@@ -21,7 +21,7 @@
 
 <div class="icon-picker">
 	<div class="search-box">
-		<L.Search size={16} class="search-icon" />
+		<Search size={16} class="search-icon" />
 		<input
 			type="text"
 			placeholder="Buscar iconos..."

--- a/frontend/src/lib/components/LazyIconPicker.svelte
+++ b/frontend/src/lib/components/LazyIconPicker.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { onMount, type Component } from 'svelte';
+
+  interface Props {
+    selected?: string;
+    color?: string;
+    onSelect: (icon: string) => void;
+  }
+
+  let { selected = '', color, onSelect }: Props = $props();
+
+  let IconPicker = $state<Component | null>(null);
+
+  onMount(async () => {
+    const mod = await import('./IconPicker.svelte');
+    IconPicker = mod.default;
+  });
+</script>
+
+{#if IconPicker}
+  <svelte:component this={IconPicker} {selected} {color} {onSelect} />
+{/if}

--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy, onMount, tick } from 'svelte';
   import { Eye, EyeOff, Save, Trash2, X, Settings, Search, Maximize, ChevronLeft, ChevronRight, Download, RotateCcw, Bold, Italic, Strikethrough, Heading1, Heading2, Heading3, List, ListOrdered, Link, Quote, Code, Image, Paperclip } from 'lucide-svelte';
-  import * as L from 'lucide-svelte';
   import DynamicIcon from './DynamicIcon.svelte';
-  import IconPicker from './IconPicker.svelte';
+  import LazyIconPicker from './LazyIconPicker.svelte';
   import { marked } from 'marked';
   import DOMPurify from 'dompurify';
   import hljs from 'highlight.js';
@@ -968,7 +967,7 @@
         
         <!-- Icon picker -->
         <div class="folder-icon-row">
-          <IconPicker color={customColor} onSelect={(ic) => { pickIcon(ic); showIconSettings = false; }} />
+          <LazyIconPicker color={customColor} onSelect={(ic) => { pickIcon(ic); showIconSettings = false; }} />
         </div>
         
         <div class="folder-modal-btns">

--- a/frontend/src/lib/components/StreakCreateModal.svelte
+++ b/frontend/src/lib/components/StreakCreateModal.svelte
@@ -2,7 +2,7 @@
   import { createEventDispatcher } from 'svelte';
   import { X, Calendar, Snowflake, Target, Clock, Archive } from 'lucide-svelte';
   import StreakIcon from '$lib/components/StreakIcon.svelte';
-  import IconPicker from '$lib/components/IconPicker.svelte';
+  import LazyIconPicker from '$lib/components/LazyIconPicker.svelte';
   import type { PersonalStreak } from '$lib/api';
   import { liquidGlass } from '$lib/actions/liquidGlass';
   import { getContrastColor } from '$lib/stores/settings';
@@ -256,7 +256,7 @@
           </div>
         {:else}
           <div class="field">
-            <IconPicker selected={icon} color={color} onSelect={(ic) => icon = ic} />
+            <LazyIconPicker selected={icon} color={color} onSelect={(ic) => icon = ic} />
           </div>
         {/if}
 

--- a/frontend/src/lib/components/StreakIcon.svelte
+++ b/frontend/src/lib/components/StreakIcon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import * as L from 'lucide-svelte';
+  import { Circle } from 'lucide-svelte';
 
   export let name: string = '';
   export let size: number = 18;
@@ -8,7 +8,17 @@
   const emojiRegex = /\p{Extended_Pictographic}/u;
 
   $: isEmoji = emojiRegex.test(name);
-  $: comp = (L as Record<string, any>)[name] || L.Circle;
+
+  let lucideComp: any = $state(Circle);
+
+  async function loadIcon(n: string) {
+    const mod = await import('lucide-svelte');
+    lucideComp = mod[n as keyof typeof mod] || Circle;
+  }
+
+  $: if (!isEmoji && name) {
+    loadIcon(name);
+  }
 </script>
 
 {#if isEmoji}
@@ -20,7 +30,7 @@
   </span>
 {:else}
   <svelte:component
-    this={comp}
+    this={lucideComp}
     {size}
     {color}
     style="width: {size}px; height: {size}px; color: {color || 'inherit'}; display: inline-flex; flex-shrink: 0;"

--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -11,7 +11,7 @@
   import StreakIcon from '$lib/components/StreakIcon.svelte';
   import StreakHeatmap from '$lib/components/StreakHeatmap.svelte';
   import GoalCard from '$lib/components/GoalCard.svelte';
-  import IconPicker from '$lib/components/IconPicker.svelte';
+  import LazyIconPicker from '$lib/components/LazyIconPicker.svelte';
 
   let goals = $state<Goal[]>([]);
   let tags = $state<TagType[]>([]);
@@ -1665,7 +1665,7 @@
                     </div>
                   {:else}
                     <div class="field ng-large-grid" style="display: flex; flex-direction: column; height: 280px; padding: 8px; border: 1px solid var(--border); border-radius: var(--r); background: var(--surface-hover); overflow: hidden;">
-                      <IconPicker selected={newFailIcon} color={newGoalColor} onSelect={(ic) => newFailIcon = ic} />
+                      <LazyIconPicker selected={newFailIcon} color={newGoalColor} onSelect={(ic) => newFailIcon = ic} />
                     </div>
                   {/if}
                 </div>

--- a/frontend/src/routes/goals/[id]/+page.svelte
+++ b/frontend/src/routes/goals/[id]/+page.svelte
@@ -5,7 +5,7 @@
   import { api, type Goal, type Tag as TagType, type Note } from '$lib/api';
   import { logger } from '$lib/utils/logger';
   import GoalEditor from '$lib/components/GoalEditor.svelte';
-  import IconPicker from '$lib/components/IconPicker.svelte';
+  import LazyIconPicker from '$lib/components/LazyIconPicker.svelte';
   import StreakIcon from '$lib/components/StreakIcon.svelte';
 
   let goal: Goal | null = null;
@@ -262,7 +262,7 @@
                   </div>
                 {:else}
                   <div class="field ng-large-grid" style="display: flex; flex-direction: column; height: 280px; padding: 8px; border: 1px solid var(--border); border-radius: var(--r); background: var(--surface-hover); overflow: hidden;">
-                    <IconPicker selected={editFailIcon} color={editColor} onSelect={(ic) => editFailIcon = ic} />
+                    <LazyIconPicker selected={editFailIcon} color={editColor} onSelect={(ic) => editFailIcon = ic} />
                   </div>
                 {/if}
               </div>

--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -7,7 +7,7 @@
   import ScientificCalculator from '$lib/components/ScientificCalculator.svelte';
   import NoteEditor from '$lib/components/NoteEditor.svelte';
   import NoteCard from '$lib/components/NoteCard.svelte';
-  import IconPicker from '$lib/components/IconPicker.svelte';
+  import LazyIconPicker from '$lib/components/LazyIconPicker.svelte';
   import VirtualList from '$lib/components/VirtualList.svelte';
   import { notes, notesLoading, loadNotes, createNote, updateNote, deleteNote, aiSuggestions, notesLoadedOnce, selectedNoteIds, bulkMode, toggleNoteSelection, selectAllNotes, clearNoteSelection, deleteSelectedNotes, tagSelectedNotes, untagSelectedNotes } from '$lib/stores/notes';
   import { buildTree, flattenTree, extractFrontmatter, getFileIcon, type SortMode, type FlatNode } from '$lib/utils/fileTree';
@@ -802,7 +802,7 @@
         
         <div class="folder-icon-row">
           <span class="folder-label mono">Icono</span>
-          <IconPicker selected={newFolderIcon} color={newFolderColor} onSelect={(ic) => newFolderIcon = ic} />
+          <LazyIconPicker selected={newFolderIcon} color={newFolderColor} onSelect={(ic) => newFolderIcon = ic} />
         </div>
         
         <div class="folder-modal-btns">
@@ -875,7 +875,7 @@
         <!-- Icon picker -->
         <div class="folder-icon-row">
           <span class="folder-label mono">Icono</span>
-          <IconPicker selected={folderIcon} color={folderColor} onSelect={(ic) => folderIcon = ic} />
+          <LazyIconPicker selected={folderIcon} color={folderColor} onSelect={(ic) => folderIcon = ic} />
         </div>
         
         <div class="folder-modal-btns">


### PR DESCRIPTION
## Summary
- `DynamicIcon` and `StreakIcon` now lazy-load `lucide-svelte` on demand instead of `import * as L`.
- `NoteEditor` no longer imports the whole `lucide-svelte` namespace.
- Added `LazyIconPicker.svelte` so the icon picker (and its full icon list) is loaded only when opened.
- The main bundle no longer eagerly pulls in all 1500+ Lucide icons.

Closes #209.

Generated with [Devin](https://devin.ai)