### PR TITLE
fix(tests): configure pytest and coverage so reports are not empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ db-health: ## Verify migration head and required core tables
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm api sh -c "cd /app && alembic -c /app/alembic.ini current && python scripts/verify_db_health.py"
 
 test-api: ## Run all API unit tests via pytest
-	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm api sh -c "PYTHONPATH=/app pytest --cov=api --cov-report=term-missing"
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm api sh -c "cd /app && pytest --cov --cov-report=term-missing"
 
 test-frontend: ## Run frontend tests (vitest) inside Docker
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm frontend npm run test

--- a/api/.coveragerc
+++ b/api/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = api

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = api/tests
+pythonpath = .
+
+[coverage:run]
+source = api


### PR DESCRIPTION
## Summary
- Add `api/pytest.ini` to set `testpaths = api/tests` and `pythonpath = .`.
- Add `api/.coveragerc` with `source = api`.
- Update `make test-api` to use `pytest --cov --cov-report=term-missing` run from `/app`.

This should fix the empty coverage report mentioned in #208.

Part of #208.

Generated with [Devin](https://devin.ai)