### PR TITLE
fix(ci): resolve typecheck and folders auth test failures

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -67,5 +67,19 @@ def client(db_session):
 
 @pytest.fixture
 def client_no_auth():
+    def override_get_current_user():
+        from fastapi import HTTPException, status
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
     with TestClient(app) as test_client:
         yield test_client
+
+    app.dependency_overrides.clear()
+    app.dependency_overrides.update(original_overrides)

--- a/frontend/src/lib/components/DynamicIcon.svelte
+++ b/frontend/src/lib/components/DynamicIcon.svelte
@@ -21,8 +21,8 @@
 
   $: isEmoji = emojiRegex.test(name);
 
-  let lucideComp: any = $state(Circle);
-  let phosphorComp = $state<any>(null);
+  let lucideComp: any = Circle;
+  let phosphorComp: any = null;
 
   async function loadLucide(n: string) {
     const mod = await import('lucide-svelte');
@@ -33,8 +33,8 @@
     loadLucide(name);
   }
 
-  function getIconComponent(pack: string, n: string) {
-    if (pack === 'phosphor' || pack === 'material') {
+  function getIconComponent(packName: string, n: string) {
+    if (packName === 'phosphor' || packName === 'material') {
       const map: Record<string, any> = {
         'Home': PHome, 'BookOpen': PBook, 'Network': PNet, 'Zap': PZap, 'Target': PTarget,
         'Flame': PFlame, 'Settings': PCog, 'LayoutGrid': PGrid, 'X': PX, 'Moon': PMoon,

--- a/frontend/src/lib/components/StreakIcon.svelte
+++ b/frontend/src/lib/components/StreakIcon.svelte
@@ -9,7 +9,7 @@
 
   $: isEmoji = emojiRegex.test(name);
 
-  let lucideComp: any = $state(Circle);
+  let lucideComp: any = Circle;
 
   async function loadIcon(n: string) {
     const mod = await import('lucide-svelte');


### PR DESCRIPTION
## Summary
- Fixes `DynamicIcon.svelte` and `StreakIcon.svelte` type errors by using legacy Svelte reactivity (remove `$state` mixed with `export let`).
- Makes `client_no_auth` fixture override `get_current_user` to return `401`, so the `/folders` auth tests pass.

Closes #236.

Generated with [Devin](https://devin.ai)