### PR TITLE
fix(frontend): resolve remaining typecheck errors

### DIFF
--- a/frontend/src/lib/components/LazyIconPicker.svelte
+++ b/frontend/src/lib/components/LazyIconPicker.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, type Component } from 'svelte';
+  import { onMount } from 'svelte';
 
   interface Props {
     selected?: string;
@@ -9,7 +9,7 @@
 
   let { selected = '', color, onSelect }: Props = $props();
 
-  let IconPicker = $state<Component | null>(null);
+  let IconPicker = $state<any>(null);
 
   onMount(async () => {
     const mod = await import('./IconPicker.svelte');
@@ -18,5 +18,5 @@
 </script>
 
 {#if IconPicker}
-  <svelte:component this={IconPicker} {selected} {color} {onSelect} />
+  <IconPicker {selected} {color} {onSelect} />
 {/if}

--- a/frontend/src/lib/components/StreakListPanel.svelte
+++ b/frontend/src/lib/components/StreakListPanel.svelte
@@ -19,7 +19,7 @@
     onToggleArchive: () => void;
     onCreate: () => void;
     onSelect: (id: number) => void;
-    onEdit: (id: number) => void;
+    onEdit: (streak: PersonalStreak) => void;
     onDelete: (id: number) => void;
   }
 


### PR DESCRIPTION
## Summary
- Fix `LazyIconPicker.svelte` type error by using a dynamic `<IconPicker ... />` tag and `any`-typed imported component.
- Correct `StreakListPanel.onEdit` prop type to `PersonalStreak` so it matches the `edit` event payload from `StreakListItem`.

Refs #236.

Generated with [Devin](https://devin.ai)