### PR TITLE
fix(frontend): iconos no se renderizan — race condition en DynamicIcon (#277)

### DIFF
--- a/frontend/src/lib/components/DynamicIcon.svelte
+++ b/frontend/src/lib/components/DynamicIcon.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { activeIconPack } from '$lib/stores/settings';
   import { Circle } from 'lucide-svelte';
+  import * as LucideIcons from 'lucide-svelte';
 
   export let name: string;
   export let size: number = 18;
@@ -21,31 +22,20 @@
 
   $: isEmoji = emojiRegex.test(name);
 
-  let lucideComp: any = Circle;
-  let phosphorComp: any = null;
+  const phosphorMap: Record<string, any> = {
+    'Home': PHome, 'BookOpen': PBook, 'Network': PNet, 'Zap': PZap, 'Target': PTarget,
+    'Flame': PFlame, 'Settings': PCog, 'LayoutGrid': PGrid, 'X': PX, 'Moon': PMoon,
+    'Sun': PSun, 'Database': PDB, 'GitBranch': PGit, 'Palette': PPal, 'Plus': PPlus,
+    'Minus': PMinus, 'RotateCcw': PRot, 'SkipForward': PSkip, 'File': PFile,
+    'ChevronLeft': PLeft, 'ChevronRight': PRight, 'Wrench': PWrench,
+  };
 
-  async function loadLucide(n: string) {
-    const mod = await import('lucide-svelte');
-    lucideComp = mod[n as keyof typeof mod] || Circle;
-  }
-
-  $: if (!isEmoji && (pack || $activeIconPack) !== 'phosphor' && (pack || $activeIconPack) !== 'material') {
-    loadLucide(name);
-  }
-
-  function getIconComponent(packName: string, n: string) {
+  function getIconComponent(packName: string, n: string): any {
     if (packName === 'phosphor' || packName === 'material') {
-      const map: Record<string, any> = {
-        'Home': PHome, 'BookOpen': PBook, 'Network': PNet, 'Zap': PZap, 'Target': PTarget,
-        'Flame': PFlame, 'Settings': PCog, 'LayoutGrid': PGrid, 'X': PX, 'Moon': PMoon,
-        'Sun': PSun, 'Database': PDB, 'GitBranch': PGit, 'Palette': PPal, 'Plus': PPlus,
-        'Minus': PMinus, 'RotateCcw': PRot, 'SkipForward': PSkip, 'File': PFile,
-        'ChevronLeft': PLeft, 'ChevronRight': PRight, 'Wrench': PWrench,
-      };
-      phosphorComp = map[n] || null;
-      return phosphorComp || Circle;
+      return phosphorMap[n] || Circle;
     }
-    return lucideComp || Circle;
+    // Synchronous lookup — no race condition
+    return (LucideIcons as any)[n] || Circle;
   }
 
   $: comp = getIconComponent(pack || $activeIconPack, name);

--- a/frontend/src/lib/components/StreakIcon.svelte
+++ b/frontend/src/lib/components/StreakIcon.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Circle } from 'lucide-svelte';
+  import * as LucideIcons from 'lucide-svelte';
 
   export let name: string = '';
   export let size: number = 18;
@@ -9,16 +10,8 @@
 
   $: isEmoji = emojiRegex.test(name);
 
-  let lucideComp: any = Circle;
-
-  async function loadIcon(n: string) {
-    const mod = await import('lucide-svelte');
-    lucideComp = mod[n as keyof typeof mod] || Circle;
-  }
-
-  $: if (!isEmoji && name) {
-    loadIcon(name);
-  }
+  // Synchronous lookup — no race condition
+  $: lucideComp = name ? ((LucideIcons as any)[name] || Circle) : Circle;
 </script>
 
 {#if isEmoji}


### PR DESCRIPTION
## Summary

- Replace async `import('lucide-svelte')` with synchronous `import * as LucideIcons` in `DynamicIcon.svelte`
- Apply same fix to `StreakIcon.svelte` which had the identical race condition
- The async pattern returned the fallback `Circle` icon before the dynamic import resolved, causing ~90+ icon instances across 22 components to not render

#### Test plan
- [ ] Sidebar nav icons render (Home, Notas, Grafo, Habilidades, Objetivos, Rachas, Integraciones)
- [ ] Settings panel icons render (all 24 DynamicIcon instances)
- [ ] Notes page folder/file icons render
- [ ] Streak icons render in StreakListItem
- [ ] No icons showing as empty Circle fallback
- [ ] Phosphor/Material icon packs still work when selected in settings

Closes #277

Generated with [Devin](https://devin.ai)