### PR TITLE
fix(frontend): Dev Mode no oculta features experimentales al desactivarse (#285)

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -37,7 +37,7 @@
     { href: '/skills',  label: 'Habilidades', icon: 'Zap',      status: 'dev' },
     { href: '/goals',   label: 'Objetivos',   icon: 'Target',   status: 'ready' },
     { href: '/streaks', label: 'Rachas',      icon: 'Flame',    status: 'ready' },
-    { href: '/integraciones', label: 'Integraciones', icon: 'Puzzle', status: 'ready' },
+    { href: '/integraciones', label: 'Integraciones', icon: 'Puzzle', status: 'dev' },
   ];
 
   let settingsOpen = false;
@@ -459,16 +459,18 @@
   <!-- Sidebar -->
   <nav class="app-sidebar">
     {#each navItems as { href, label, icon, status }}
-      {@const active = $page.url.pathname === href || ($page.url.pathname.startsWith(href) && href !== '/')}
-      <a {href} class="nav-item" class:active class:nav-dev={status === 'dev'} class:nav-placeholder={status === 'placeholder'} title={label}>
-        <DynamicIcon name={icon} size={16} />
-        {#if status === 'dev'}
-          <span class="nav-dev-dot" title="Requiere Dev Mode"></span>
-        {:else if status === 'placeholder'}
-          <!-- Pronto badge removed -->
-        {/if}
-        <span class="tooltip">{label}</span>
-      </a>
+      {#if status === 'ready' || $devMode}
+        {@const active = $page.url.pathname === href || ($page.url.pathname.startsWith(href) && href !== '/')}
+        <a {href} class="nav-item" class:active class:nav-dev={status === 'dev'} class:nav-placeholder={status === 'placeholder'} title={label}>
+          <DynamicIcon name={icon} size={16} />
+          {#if status === 'dev'}
+            <span class="nav-dev-dot" title="Requiere Dev Mode"></span>
+          {:else if status === 'placeholder'}
+            <!-- Pronto badge removed -->
+          {/if}
+          <span class="tooltip">{label}</span>
+        </a>
+      {/if}
     {/each}
   </nav>
 

--- a/frontend/src/routes/graph/+page.svelte
+++ b/frontend/src/routes/graph/+page.svelte
@@ -3,6 +3,7 @@
   import KnowledgeGraphForce from '$lib/components/KnowledgeGraphForce.svelte';
   import { graphData, graphLoading, loadGraph, selectedTag } from '$lib/stores/graph';
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
+  import { devMode } from '$lib/stores/settings';
   import type { GraphNode, GraphEdge } from '$lib/api';
 
   let containerEl: HTMLDivElement;
@@ -30,6 +31,7 @@
 </script>
 
 
+{#if $devMode}
 <div class="graph-page">
   <div class="graph-header">
     <div>
@@ -69,6 +71,15 @@
     <span class="legend-hint">doble-click para abrir · drag parafixar</span>
   </div>
 </div>
+{:else}
+<div class="construction-page">
+  <div class="construction-box">
+    <DynamicIcon name="Network" size={48} />
+    <h3>En Construcción</h3>
+    <p>Activa el Modo Desarrollo en Ajustes para acceder al Grafo de Conocimiento.</p>
+  </div>
+</div>
+{/if}
 
 <style>
   .graph-page {
@@ -170,5 +181,36 @@
     margin-left: auto;
     color: var(--text-muted);
     opacity: 0.7;
+  }
+
+  .construction-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+  }
+
+  .construction-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    color: var(--text-muted);
+    text-align: center;
+    padding: 40px;
+  }
+
+  .construction-box h3 {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin: 0;
+  }
+
+  .construction-box p {
+    font-size: 13px;
+    margin: 0;
+    max-width: 320px;
   }
 </style>

--- a/frontend/src/routes/skills/+page.svelte
+++ b/frontend/src/routes/skills/+page.svelte
@@ -5,6 +5,7 @@
   import { logger } from '$lib/utils/logger';
   import { displayTagName } from '$lib/utils/format';
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
+  import { devMode } from '$lib/stores/settings';
   import { Search, X } from 'lucide-svelte';
 
   let skills: Skill[] = $state([]);
@@ -42,6 +43,7 @@
 </script>
 
 
+{#if $devMode}
 <div class="skills-page">
   <div class="skills-header">
     <div>
@@ -138,6 +140,15 @@
     {/each}
   </div>
 </div>
+{:else}
+<div class="construction-page">
+  <div class="construction-box">
+    <DynamicIcon name="Zap" size={48} />
+    <h3>En Construcción</h3>
+    <p>Activa el Modo Desarrollo en Ajustes para acceder al Árbol de Habilidades.</p>
+  </div>
+</div>
+{/if}
 
 <style>
   .skills-page {
@@ -377,4 +388,35 @@
   .legend-dot[data-level='journeyman'] { border-color: var(--text-secondary); }
   .legend-dot[data-level='expert']     { border-color: var(--accent); }
   .legend-dot[data-level='master']     { background: var(--accent); border-color: var(--accent); }
+
+  .construction-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+  }
+
+  .construction-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    color: var(--text-muted);
+    text-align: center;
+    padding: 40px;
+  }
+
+  .construction-box h3 {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin: 0;
+  }
+
+  .construction-box p {
+    font-size: 13px;
+    margin: 0;
+    max-width: 320px;
+  }
 </style>


### PR DESCRIPTION
## Summary

- Filter `navItems` in `+layout.svelte` by `$devMode`: items with `status: 'dev'` only render when Dev Mode is ON
- Change Integraciones from `status: 'ready'` to `status: 'dev'`
- Add `{#if $devMode}` gate to `/graph` and `/skills` pages — shows "En Construcción" message when Dev Mode is off, preventing direct URL access

#### Test plan
- [ ] With Dev Mode OFF: Grafo, Habilidades, and Integraciones are NOT visible in sidebar
- [ ] With Dev Mode ON: all nav items are visible
- [ ] Navigating directly to /graph with Dev Mode off shows "En Construcción"
- [ ] Navigating directly to /skills with Dev Mode off shows "En Construcción"
- [ ] Toggling Dev Mode in Settings immediately updates the sidebar (no reload needed)
- [ ] Dev Mode state persists across page reloads

Closes #285

Generated with [Devin](https://devin.ai)