### PR TITLE
feat(frontend): eliminar feature de arrastrar widgets del dashboard (#276)

### DIFF
--- a/frontend/src/lib/components/Widget.svelte
+++ b/frontend/src/lib/components/Widget.svelte
@@ -1,74 +1,17 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-  import type { WidgetId, DashboardLayout } from '$lib/stores/layout';
-  import DynamicIcon from './DynamicIcon.svelte';
+  import type { WidgetId } from '$lib/stores/layout';
   import { WIDGET_REGISTRY } from '$lib/stores/layout';
 
-  export let id:    WidgetId;
-  export let panel: 'left' | 'right';
-  export let index: number;
-  export let total: number;
-  export let layout: DashboardLayout;
-
-  let dragOver = false;
-
-  const dispatch = createEventDispatcher<{
-    drop: { id: WidgetId; fromPanel: 'left' | 'right'; fromIdx: number; toPanel: 'left' | 'right'; toIdx: number };
-  }>();
-
-  function handleDragStart(e: DragEvent) {
-    if (!e.dataTransfer) return;
-    e.dataTransfer.effectAllowed = 'move';
-    e.dataTransfer.setData('text/plain', JSON.stringify({ id, panel, index }));
-    e.dataTransfer.setData('application/x-widget', '');
-  }
-
-  function handleDragOver(e: DragEvent) {
-    e.preventDefault();
-    if (!e.dataTransfer) return;
-    e.dataTransfer.dropEffect = 'move';
-    dragOver = true;
-  }
-
-  function handleDragLeave() {
-    dragOver = false;
-  }
-
-  function handleDrop(e: DragEvent) {
-    e.preventDefault();
-    dragOver = false;
-    if (!e.dataTransfer) return;
-    try {
-      const src = JSON.parse(e.dataTransfer.getData('text/plain'));
-      if (src.id === id && src.panel === panel) return;
-      dispatch('drop', {
-        id: src.id as WidgetId,
-        fromPanel: src.panel,
-        fromIdx: src.index,
-        toPanel: panel,
-        toIdx: index,
-      });
-    } catch {}
-  }
+  export let id: WidgetId;
 
   $: label = WIDGET_REGISTRY[id]?.label ?? id;
 </script>
 
 <div
   class="widget"
-  class:drag-over={dragOver}
-  draggable="true"
-  on:dragstart={handleDragStart}
-  on:dragover={handleDragOver}
-  on:dragleave={handleDragLeave}
-  on:drop={handleDrop}
-  on:dragend={() => { dragOver = false; }}
   role="listitem"
   aria-label={label}
 >
-  <div class="widget-handle">
-    <DynamicIcon name="GripVertical" size={10} />
-  </div>
   <div class="widget-content">
     <slot />
   </div>
@@ -81,42 +24,6 @@
     background: transparent;
     overflow: hidden;
     box-shadow: none;
-    transition: opacity var(--t-fast), border-color var(--t-fast);
-  }
-
-  .widget[draggable="true"] {
-    cursor: grab;
-  }
-
-  .widget[draggable="true"]:active {
-    cursor: grabbing;
-    opacity: 0.6;
-  }
-
-  .widget.drag-over {
-    border: 1px dashed var(--accent);
-    border-radius: var(--r);
-    opacity: 0.8;
-  }
-
-  .widget-handle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 2px 0;
-    color: var(--text-muted);
-    opacity: 0;
-    transition: opacity var(--t-fast);
-    cursor: grab;
-    height: 12px;
-  }
-
-  .widget:hover .widget-handle {
-    opacity: 0.5;
-  }
-
-  .widget-handle:hover {
-    opacity: 1 !important;
   }
 
   .widget-content {

--- a/frontend/src/lib/stores/layout.ts
+++ b/frontend/src/lib/stores/layout.ts
@@ -28,7 +28,7 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetMeta> = {
   'github-issues':  { id: 'github-issues',   label: 'GitHub',       panel: 'right' },
 };
 
-// ── Layout: two ordered columns ────────────────────────────────────────────────
+// ── Layout: two ordered columns (static, no reordering) ───────────────────────
 export interface DashboardLayout {
   left:  WidgetId[];
   right: WidgetId[];
@@ -39,74 +39,4 @@ const DEFAULT: DashboardLayout = {
   right: ['recent-notes', 'github-issues'],
 };
 
-const KEY = 'joidy-dashboard-layout-v2';
-
-function load(): DashboardLayout {
-  if (typeof localStorage === 'undefined') return DEFAULT;
-  try {
-    const raw = localStorage.getItem(KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw) as DashboardLayout;
-      if (Array.isArray(parsed.left) && Array.isArray(parsed.right)) {
-        if (!parsed.left.includes('time-widget') && !parsed.right.includes('time-widget')) {
-          const pIdx = parsed.left.indexOf('pomodoro');
-          if (pIdx > -1) parsed.left.splice(pIdx, 0, 'time-widget');
-          else parsed.left.push('time-widget');
-        }
-        return parsed;
-      }
-    }
-  } catch { /* */ }
-  return DEFAULT;
-}
-
-function save(l: DashboardLayout) {
-  if (typeof localStorage !== 'undefined') localStorage.setItem(KEY, JSON.stringify(l));
-}
-
-let _initialized = false;
-
-function createLayoutStore() {
-  const { subscribe, update, set } = writable<DashboardLayout>(DEFAULT);
-
-  return {
-    subscribe,
-    init() {
-      if (_initialized) return;
-      _initialized = true;
-      set(load());
-    },
-
-    reload() {
-      set(load());
-    },
-
-    // Move widget up/down within its panel
-    move(panel: 'left' | 'right', fromIdx: number, toIdx: number) {
-      update(l => {
-        const col = [...l[panel]];
-        const [item] = col.splice(fromIdx, 1);
-        col.splice(toIdx, 0, item);
-        const next = { ...l, [panel]: col };
-        save(next);
-        return next;
-      });
-    },
-
-    // Move widget between panels
-    switchPanel(id: WidgetId, from: 'left' | 'right') {
-      const to = from === 'left' ? 'right' : 'left';
-      update(l => {
-        const src  = l[from].filter(w => w !== id);
-        const dest = [...l[to], id];
-        const next = { ...l, [from]: src, [to]: dest };
-        save(next);
-        return next;
-      });
-    },
-
-    reset() { save(DEFAULT); set(DEFAULT); },
-  };
-}
-
-export const dashboardLayout = createLayoutStore();
+export const dashboardLayout = writable<DashboardLayout>(DEFAULT);

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { afterNavigate } from '$app/navigation';
   import { goto } from '$app/navigation';
   import { dev } from '$app/environment';
   import { fly } from 'svelte/transition';
@@ -20,7 +19,7 @@
   import { totalXP, currentStreak, lastActivity, nextStageXP } from '$lib/stores/gamification';
   import ActivityProgress from '$lib/components/ActivityProgress.svelte';
   import { notes, loadNotes, notesLoadedOnce } from '$lib/stores/notes';
-  import { dashboardLayout, type WidgetId } from '$lib/stores/layout';
+  import { dashboardLayout } from '$lib/stores/layout';
   import { accentColors } from '$lib/stores/settings';
   import { api } from '$lib/api';
   import { loadUserSettings, patchUserSettings } from '$lib/utils/userSettings';
@@ -187,12 +186,6 @@
       moduleIdx = snap.state.moduleIdx ?? 0;
       slideDir = snap.state.slideDir ?? 1;
     }
-    
-    dashboardLayout.init();
-
-    afterNavigate(() => {
-      dashboardLayout.reload();
-    });
 
     const savedNotesUi = loadUserSettings().notesUi;
     if (savedNotesUi?.panelWidth !== undefined) {
@@ -277,15 +270,6 @@
 
   // Resizable panel synced with notes
   let panelWidth = 260;
-
-  function handleWidgetDrop(e: CustomEvent<{ id: WidgetId; fromPanel: 'left' | 'right'; fromIdx: number; toPanel: 'left' | 'right'; toIdx: number }>) {
-    const { id, fromPanel, toPanel, toIdx } = e.detail;
-    if (fromPanel === toPanel) {
-      dashboardLayout.move(fromPanel, e.detail.fromIdx, toIdx);
-    } else {
-      dashboardLayout.switchPanel(id, fromPanel);
-    }
-  }
 </script>
 
 <div class="dashboard" style="--panel-w: {panelWidth}px">
@@ -294,7 +278,7 @@
   <section class="plant-section">
 
     {#each $dashboardLayout.left as wid, i (wid)}
-      <Widget id={wid} panel="left" index={i} total={$dashboardLayout.left.length} layout={$dashboardLayout} on:drop={handleWidgetDrop}>
+      <Widget id={wid}>
 
         {#if wid === 'plant-carousel'}
           <div class="widget-centered">
@@ -420,7 +404,7 @@
   <section class="activity-section">
 
     {#each $dashboardLayout.right as wid, i (wid)}
-      <Widget id={wid} panel="right" index={i} total={$dashboardLayout.right.length} layout={$dashboardLayout} on:drop={handleWidgetDrop}>
+      <Widget id={wid}>
 
         {#if wid === 'recent-notes'}
           <div class="section-header">


### PR DESCRIPTION
## Summary

- Remove all drag-and-drop handlers from `Widget.svelte` (draggable, dragstart, dragover, dragleave, drop, dragend) and the GripVertical handle icon
- Simplify `layout.ts`: remove `move()`, `switchPanel()`, `save()`, `load()`, localStorage persistence, and `init()`/`reload()` — layout is now a static default
- Remove `handleWidgetDrop` and drag-related props (`panel`, `index`, `total`, `layout`, `on:drop`) from `+page.svelte`
- Remove unused imports (`afterNavigate`, `WidgetId` type)

#### Test plan
- [ ] Dashboard renders with the default static layout
- [ ] No drag handle icon appears on widgets
- [ ] Widgets cannot be dragged or reordered
- [ ] No cursor:grab or cursor:grabbing on widgets
- [ ] Dashboard layout is the same on every visit (no localStorage persistence)

Closes #276

Generated with [Devin](https://devin.ai)