### PR TITLE
fix(frontend): heatmap de rachas descentrado (#283)

### DIFF
--- a/frontend/src/lib/components/StreakHeatmap.svelte
+++ b/frontend/src/lib/components/StreakHeatmap.svelte
@@ -340,9 +340,8 @@
     justify-content: center;
     gap: 8px;
     width: 100%;
-    min-height: 100%;
-    height: 100%;
-    max-height: 100%;
+    flex: 1;
+    min-height: 0;
   }
 
   .tabs {

--- a/frontend/src/routes/streaks/+page.svelte
+++ b/frontend/src/routes/streaks/+page.svelte
@@ -843,6 +843,7 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
     aspect-ratio: 2 / 0.68;
     gap: 0;
+    flex-shrink: 0;
   }
 
   /* Counter */


### PR DESCRIPTION
## Summary

- `StreakHeatmap.svelte`: Replace `height: 100%` + `max-height: 100%` on `.activity` with `flex: 1` + `min-height: 0` — the old values caused the heatmap to collapse inside the flex parent (`.heatmap-section` with `flex: 1; min-height: 0`)
- `streaks/+page.svelte`: Add `flex-shrink: 0` to `.top-metrics` so the counter section doesn't compress and steal vertical space from the heatmap

#### Test plan
- [ ] Heatmap is centered horizontally and vertically in the detail panel
- [ ] Week view shows 7 days centered
- [ ] Month view shows calendar grid centered
- [ ] Year view shows month grid centered with navigation arrows
- [ ] Heatmap doesn't get cut off or overflow
- [ ] Works on different viewport heights

Closes #283

Generated with [Devin](https://devin.ai)