### PR TITLE
fix(frontend): silenciar error VAPID 503 en cada carga de página (#278)

### DIFF
--- a/frontend/src/lib/push.ts
+++ b/frontend/src/lib/push.ts
@@ -28,7 +28,12 @@ export async function initPushNotifications(): Promise<void> {
     });
 
     await sendSubscriptionToServer(subscription);
-  } catch (e) {
+  } catch (e: any) {
+    // 503 = VAPID not configured — this is an optional feature, not an error
+    const msg = e?.message || String(e);
+    if (msg.includes('503') || msg.includes('VAPID not configured')) {
+      return; // Silent fail — push notifications are optional
+    }
     logger.error('[push] Failed to init push notifications:', e);
   }
 }


### PR DESCRIPTION
## Summary

- In `push.ts`, catch block now checks if the error is a 503 (VAPID not configured) and silently returns instead of logging to console
- Push notifications are an optional feature — missing VAPID config should not spam the console on every page load

#### Test plan
- [ ] No `[push] Failed to init push notifications` error in console when VAPID is not configured
- [ ] No toast notification shown to user for VAPID missing
- [ ] Push notifications still work when VAPID is configured (no silent fail in that case)
- [ ] Other push errors (non-503) still log to console

Closes #278

Generated with [Devin](https://devin.ai)