### PR TITLE
fix(frontend): NoteEditor renderiza markdown en cada tecla — debounce (#281)

### DIFF
--- a/frontend/src/lib/components/GoalEditor.svelte
+++ b/frontend/src/lib/components/GoalEditor.svelte
@@ -65,9 +65,22 @@
   $: visibleContent = content;
   $: wordCount = visibleContent.trim() ? visibleContent.trim().split(/\s+/).length : 0;
   $: charCount = visibleContent.length;
-  $: renderedHtml = renderMarkdown(visibleContent);
   $: lineCount = Math.max(1, visibleContent.split('\n').length);
   $: lineNumbers = Array.from({ length: lineCount }, (_, i) => i + 1);
+
+  // Debounced content for expensive markdown rendering
+  let debouncedContent = content;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  $: {
+    const current = visibleContent;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debouncedContent = current;
+      renderedHtml = renderMarkdown(current);
+      editorHighlightedHtml = highlightMarkdown(current);
+    }, 300);
+  }
+  $: renderedHtml = renderMarkdown(debouncedContent);
 
   function renderMarkdown(md: string): string {
     if (!md.trim()) return '<p style="color:var(--text-muted);font-style:italic;">Escribe algo para ver el preview...</p>';
@@ -78,7 +91,6 @@
     content = (e.currentTarget as HTMLTextAreaElement).value;
     wordCount = content.trim() ? content.trim().split(/\s+/).length : 0;
     charCount = content.length;
-    renderedHtml = renderMarkdown(content);
   }
 
   async function handleSave() {
@@ -142,7 +154,7 @@
     return html;
   }
 
-  $: editorHighlightedHtml = highlightMarkdown(visibleContent);
+  $: editorHighlightedHtml = highlightMarkdown(debouncedContent);
 </script>
 
 <svelte:window on:keydown={onKeydown} />

--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -250,11 +250,26 @@
     return val;
   })());
 
+  // Debounced content for expensive operations (markdown render + syntax highlight)
+  let debouncedContent = $state(visibleEditorContent);
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  $effect(() => {
+    const current = visibleEditorContent;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debouncedContent = current;
+    }, 300);
+  });
+
+  // Cheap computations stay on visibleEditorContent (instant feedback)
   let wordCount = $derived(visibleEditorContent.trim() ? visibleEditorContent.trim().split(/\s+/).length : 0);
   let charCount = $derived(visibleEditorContent.length);
-  let renderedHtml = $derived(renderMarkdown(visibleEditorContent));
   let lineCount = $derived(Math.max(1, visibleEditorContent.split('\n').length));
   let lineNumbers = $derived(Array.from({ length: lineCount }, (_, i) => i + 1));
+
+  // Expensive computations use debouncedContent (300ms after last keystroke)
+  let renderedHtml = $derived(renderMarkdown(debouncedContent));
 
   function updateVisibleContent(e: Event) {
     const val = (e.currentTarget as HTMLTextAreaElement).value;
@@ -700,7 +715,7 @@
     return html;
   }
 
-  let editorHighlightedHtml = $derived(highlightMarkdown(visibleEditorContent));
+  let editorHighlightedHtml = $derived(highlightMarkdown(debouncedContent));
 </script>
 
 <svelte:window onkeydown={onKeydown} />


### PR DESCRIPTION
## Summary

- `NoteEditor.svelte`: Add `debouncedContent` state with 300ms debounce; `renderedHtml` and `editorHighlightedHtml` now use debounced content instead of `visibleEditorContent`
- `GoalEditor.svelte`: Same debounce pattern; `renderedHtml` and `editorHighlightedHtml` use `debouncedContent`; removed immediate `renderMarkdown` call from `updateContent()`
- Cheap operations (wordCount, charCount, lineCount, lineNumbers) remain on `visibleEditorContent` for instant feedback

#### Test plan
- [ ] Typing in NoteEditor is smooth, no lag on long notes
- [ ] Markdown preview updates ~300ms after stopping typing
- [ ] Syntax highlighting updates ~300ms after stopping typing
- [ ] Word count and line count update instantly (no debounce)
- [ ] Same behavior in GoalEditor
- [ ] No visual glitches during the debounce delay

Closes #281

Generated with [Devin](https://devin.ai)