### PR TITLE
fix(frontend): lazy-load analytics data on goals page (#279)

### DIFF
--- a/frontend/src/lib/components/GoalCard.svelte
+++ b/frontend/src/lib/components/GoalCard.svelte
@@ -12,6 +12,10 @@
   export let formatFailConfig: (c: string) => string;
   export let onTogglePin: (id: number) => void;
   export let onClick: (goal: any) => void;
+
+  // Build Maps for O(1) lookups instead of linear searches
+  const tagsMap = new Map(tags.map(t => [t.id, t]));
+  const notesMap = new Map(notes.map(n => [n.id, n]));
 </script>
 
 <div
@@ -63,12 +67,12 @@
     {#if goal.tag_id}
       <div class="meta-item">
         <Tag size={12} />
-        <span>{tags.find(t => t.id === goal.tag_id)?.name || 'Etiqueta'}</span>
+        <span>{tagsMap.get(goal.tag_id)?.name || 'Etiqueta'}</span>
       </div>
     {:else if goal.note_id}
       <div class="meta-item">
         <FileText size={12} />
-        <span>{notes.find(n => n.id === goal.note_id)?.title?.substring(0, 12) || 'Nota'}</span>
+        <span>{notesMap.get(goal.note_id)?.title?.substring(0, 12) || 'Nota'}</span>
       </div>
     {/if}
     {#if goal.fail_config !== 'STATIC'}

--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -185,14 +185,12 @@
     const cachedTags = getCachedData<TagType[]>('tags');
     if (cachedGoals) goals = cachedGoals;
     if (cachedTags) tags = cachedTags;
-    
+
     try {
-      [goals, tags, notes, streakData, xpEvents] = await Promise.all([
+      // Load only essential data immediately (goals + tags)
+      [goals, tags] = await Promise.all([
         api.goals.list(),
         api.tags.list(),
-        api.notes.list(),
-        api.goals.streak(),
-        api.gamification.events(500)
       ]);
       setCachedData('goals', goals);
       setCachedData('tags', tags);
@@ -202,7 +200,27 @@
         logger.error('[goals] onMount failed:', e);
       }
     }
+
+    // Lazy-load analytics data only when needed
+    if (currentTab === 'analytics') {
+      loadAnalyticsData();
+    }
   });
+
+  let analyticsLoaded = false;
+  async function loadAnalyticsData() {
+    if (analyticsLoaded) return;
+    analyticsLoaded = true;
+    try {
+      [notes, streakData, xpEvents] = await Promise.all([
+        api.notes.list(),
+        api.goals.streak(),
+        api.gamification.events(500)
+      ]);
+    } catch (e) {
+      logger.error('[goals] loadAnalyticsData failed:', e);
+    }
+  }
 
   let addError = $state('');
 
@@ -411,6 +429,8 @@
   // persist current tab and selected planning date in localStorage
   $effect(() => {
     if (typeof localStorage !== 'undefined') localStorage.setItem('goals.currentTab', currentTab);
+    // Lazy-load analytics data when analytics tab is opened
+    if (currentTab === 'analytics') loadAnalyticsData();
   });
 
   $effect(() => {


### PR DESCRIPTION
## Summary

- Split `onMount` data loading on goals page: `goals` + `tags` load immediately, but `notes` (up to 1000), `streakData`, and `xpEvents` (500 events) are deferred until the analytics tab is opened
- Add `loadAnalyticsData()` with `analyticsLoaded` guard to prevent duplicate loads
- Trigger lazy load via `$effect` when `currentTab` becomes `'analytics'`
- `GoalCard.svelte`: Replace linear `tags.find()` / `notes.find()` with `Map`-based O(1) lookups (`tagsMap.get()` / `notesMap.get()`)

#### Test plan
- [ ] Goals page loads faster on initial mount (no 500 XP events + 1000 notes fetched)
- [ ] Goals list renders immediately with goals + tags
- [ ] Clicking "Analytics" tab loads notes/streak/xpEvents data (one-time)
- [ ] Analytics tab shows correct data after lazy load
- [ ] Switching away from analytics and back doesn't re-fetch (guard works)
- [ ] GoalCard still shows correct tag name and note title

Closes #279

Generated with [Devin](https://devin.ai)