### PR TITLE
feat(api): añadir paginación a endpoints que retornan todos los registros (#280)

### DIFF
--- a/api/routers/goals.py
+++ b/api/routers/goals.py
@@ -193,9 +193,25 @@ def _serialize_goal(goal: Goal, db: Session, precalculated_progress: float | Non
 
 
 @router.get("/")
-def list_goals(db: Session = Depends(get_db)):
+def list_goals(
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+):
+    if skip < 0:
+        skip = 0
+    if limit < 1:
+        limit = 1
+    if limit > 1000:
+        limit = 1000
     evaluate_active_goals(db)
-    goals = db.query(Goal).order_by(Goal.is_completed, Goal.created_at.desc()).all()
+    goals = (
+        db.query(Goal)
+        .order_by(Goal.is_completed, Goal.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
     progress_map = get_bulk_goal_progress(goals, db)
     return [_serialize_goal(g, db, precalculated_progress=progress_map.get(g.id)) for g in goals]
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -267,7 +267,7 @@ export const api = {
   },
 
   goals: {
-    list:     ()                    => req<Goal[]>('GET', '/goals/'),
+    list:     (skip?: number, limit?: number) => req<Goal[]>('GET', `/goals/${skip !== undefined || limit !== undefined ? `?${skip !== undefined ? `skip=${skip}&` : ''}${limit !== undefined ? `limit=${limit}` : ''}` : ''}`),
     get:      (id: number)        => req<Goal>('GET', `/goals/${id}`),
     create:   (data: { title: string; description?: string; temporality?: string; measurement_type?: string; target_value?: number; fail_config?: string; fail_emoji?: string; color?: string; theme?: string; tag_id?: number | null; note_id?: number | null; parent_id?: number | null; max_assignment_days?: number | null }) =>
       req<Goal>('POST', '/goals/', data),


### PR DESCRIPTION
## Summary

- Add `skip` / `limit` query params to `GET /goals/` (default `limit=100`, max `1000`) — previously returned all goals with no pagination
- Update frontend `api.ts` `goals.list()` to accept optional `skip` / `limit` params
- Notes endpoint already had pagination (`skip`/`limit`, max 1000) — no change needed
- Gamification events endpoint already had `limit` cap (max 500) — no change needed

#### Test plan
- [ ] `GET /goals/` returns up to 100 goals by default
- [ ] `GET /goals/?skip=10&limit=50` returns 50 goals starting from offset 10
- [ ] `GET /goals/?limit=0` clamps to 1
- [ ] `GET /goals/?limit=5000` clamps to 1000
- [ ] Existing goals tests pass (`test_routers_goals.py`, `test_e2e_goals.py`)
- [ ] Frontend `api.goals.list()` still works with no args (uses defaults)

Closes #280

Generated with [Devin](https://devin.ai)