### PR TITLE
feat(api): GitHub OAuth Web Flow + reducir scopes (#287)

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -11,10 +11,10 @@ class Settings(BaseSettings):
     app_env: str = "development"
     cors_allowed_origins: str = ""  # Comma-separated origins for production (e.g. "https://joidy.app,https://www.joidy.app")
 
-    # GitHub Integration (OAuth - Device Flow)
+    # GitHub Integration (OAuth - Web Flow + Device Flow)
     github_client_id: str = ""
     github_client_secret: str = ""
-    github_oauth_web_url: str = ""
+    github_oauth_web_url: str = ""  # Redirect URL for Web Flow callback
     github_token: str = ""
     github_username: str = ""
     github_webhook_url: str = ""

--- a/api/routers/integrations/github.py
+++ b/api/routers/integrations/github.py
@@ -742,29 +742,8 @@ async def sync_repo(repo_id: int, db: Session = Depends(get_db)):
 
 GITHUB_OAUTH_SCOPES = [
     "repo",
-    "repo:status",
-    "repo_deployment",
-    "public_repo",
-    "repo:invite",
-    "security_events",
     "read:user",
     "user:email",
-    "user:follow",
-    "delete_repo",
-    "write:discussion",
-    "read:discussion",
-    "admin:repo_hook",
-    "write:repo_hook",
-    "read:repo_hook",
-    "admin:org",
-    "write:org",
-    "read:org",
-    "admin:public_key",
-    "write:public_key",
-    "read:public_key",
-    "admin:org_hook",
-    "write:org_hook",
-    "read:org_hook",
     "workflow",
 ]
 
@@ -850,6 +829,88 @@ async def poll_device_code(
         return {"status": "expired", "message": "Device code expired. Start new flow"}
     elif error == "access_denied":
         return {"status": "denied", "message": "User denied access"}
+
+    access_token = data.get("access_token")
+    token_type = data.get("token_type", "bearer")
+    scope = data.get("scope", "")
+
+    return {
+        "status": "authorized",
+        "access_token": access_token,
+        "token_type": token_type,
+        "scope": scope,
+    }
+
+
+# ── Web Flow (OAuth callback) ──────────────────────────────────────────────────
+
+@router.get("/oauth/web/start")
+async def start_web_flow():
+    """
+    Inicia el Web Flow de OAuth para GitHub.
+    Redirige al usuario a la página de autorización de GitHub.
+    Tras autorizar, GitHub redirige a la URL configurada (github_oauth_web_url).
+    """
+    if not settings.github_client_id:
+        raise HTTPException(
+            status_code=400,
+            detail="GitHub OAuth not configured. Set GITHUB_CLIENT_ID in .env"
+        )
+
+    redirect_uri = settings.github_oauth_web_url or "http://localhost:8000/integrations/github/oauth/callback"
+    authorize_url = (
+        f"https://github.com/login/oauth/authorize"
+        f"?client_id={settings.github_client_id}"
+        f"&redirect_uri={redirect_uri}"
+        f"&scope={'%20'.join(GITHUB_OAUTH_SCOPES)}"
+    )
+    return {"authorize_url": authorize_url, "redirect_uri": redirect_uri}
+
+
+@router.get("/oauth/callback")
+async def oauth_callback(
+    code: str = Query(..., description="Authorization code from GitHub"),
+    state: str | None = Query(None, description="State parameter for CSRF protection"),
+    error: str | None = Query(None, description="Error from GitHub"),
+):
+    """
+    Callback endpoint para el Web Flow de GitHub OAuth.
+    GitHub redirige aquí tras la autorización del usuario.
+    Intercambia el código por un access_token.
+    """
+    if error:
+        raise HTTPException(status_code=400, detail=f"OAuth error: {error}")
+
+    if not settings.github_client_id or not settings.github_client_secret:
+        raise HTTPException(
+            status_code=400,
+            detail="GitHub OAuth not configured. Set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET in .env"
+        )
+
+    token_url = "https://github.com/login/oauth/access_token"
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        r = await client.post(
+            token_url,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
+            json={
+                "client_id": settings.github_client_id,
+                "client_secret": settings.github_client_secret,
+                "code": code,
+                "redirect_uri": settings.github_oauth_web_url or "http://localhost:8000/integrations/github/oauth/callback",
+            },
+        )
+        r.raise_for_status()
+        data = r.json()
+
+    if data.get("error"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Token exchange failed: {data.get('error_description', data['error'])}"
+        )
 
     access_token = data.get("access_token")
     token_type = data.get("token_type", "bearer")

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -333,6 +333,8 @@ github: {
     repos: () => req<{ repos: { id: number; name: string; full_name: string; color: string }[] }>('GET', '/integrations/github/repos'),
     startDeviceAuth: () => req<{ device_code: string; user_code: string; verification_uri: string; verification_uri_secondary?: string; expires_in: number; interval: number }>('GET', '/integrations/github/oauth/device/start'),
     pollDeviceCode: (device_code: string) => req<{ status: 'authorized'; access_token: string; token_type: string; scope: string } | { status: 'pending' | 'slowdown' | 'expired' | 'denied'; message: string }>('POST', `/integrations/github/oauth/device/polling?device_code=${encodeURIComponent(device_code)}`),
+    startWebFlow: () => req<{ authorize_url: string; redirect_uri: string }>('GET', '/integrations/github/oauth/web/start'),
+    oauthCallback: (code: string, state?: string) => req<{ status: string; access_token: string; token_type: string; scope: string }>('GET', `/integrations/github/oauth/callback?code=${encodeURIComponent(code)}${state ? `&state=${encodeURIComponent(state)}` : ''}`),
     revoke: () => req<{ status: string }>('POST', '/integrations/github/oauth/revoke'),
   },
 


### PR DESCRIPTION
## Summary

- **New: Web Flow endpoints**
  - `GET /integrations/github/oauth/web/start` — returns `authorize_url` for redirecting the user to GitHub's authorization page
  - `GET /integrations/github/oauth/callback` — handles GitHub's redirect after user authorizes, exchanges the authorization code for an `access_token`
  - Uses `github_oauth_web_url` from config as the `redirect_uri` (this setting was defined but unused before)

- **Reduced OAuth scopes** from 25 to 4:
  - Kept: `repo`, `read:user`, `user:email`, `workflow`
  - Removed dangerous scopes: `delete_repo`, `admin:org`, `admin:repo_hook`, `admin:public_key`, `admin:org_hook`, `write:discussion`, `user:follow`, and 14 others

- **Frontend**: Added `startWebFlow()` and `oauthCallback()` methods to `api.github` in `api.ts`

- **Config**: Updated comment to reflect both Web Flow and Device Flow support

#### Test plan
- [ ] `GET /integrations/github/oauth/web/start` returns `authorize_url` when `GITHUB_CLIENT_ID` is set
- [ ] `GET /integrations/github/oauth/web/start` returns 400 when `GITHUB_CLIENT_ID` is empty
- [ ] `GET /integrations/github/oauth/callback?code=xxx` exchanges code for token
- [ ] `GET /integrations/github/oauth/callback?error=access_denied` returns 400
- [ ] Device Flow endpoints still work (backward compatible)
- [ ] All 140 API tests pass
- [ ] Frontend typecheck passes

Closes #287

Generated with [Devin](https://devin.ai)