### PR TITLE
fix(api): validar longitud máxima del título de nota (#275)

### DIFF
--- a/api/services/sanitizer.py
+++ b/api/services/sanitizer.py
@@ -42,7 +42,7 @@ def sanitize_title(title: str) -> str:
     if not title:
         raise ValueError("Title cannot be empty")
     if len(title) > MAX_TITLE_LENGTH:
-        title = title[:MAX_TITLE_LENGTH]
+        raise ValueError(f"Title cannot exceed {MAX_TITLE_LENGTH} characters")
     return sanitize_html(title)
 
 


### PR DESCRIPTION
## Summary

- `sanitize_title()` now raises `ValueError` when title exceeds 500 characters instead of silently truncating
- FastAPI will return a 422 validation error to the client, giving the user clear feedback

#### Test plan
- [ ] Creating a note with a title ≤ 500 chars works normally
- [ ] Creating a note with a title > 500 chars returns 422 with error message
- [ ] Updating a note with a title > 500 chars returns 422
- [ ] All 140 API tests pass

Closes #275

Generated with [Devin](https://devin.ai)