### PR TITLE
fix(frontend): icon picker muestra iconos duplicados (Icon + IconIcon) (#272)

### DIFF
--- a/frontend/src/lib/stores/iconPicker.ts
+++ b/frontend/src/lib/stores/iconPicker.ts
@@ -1,8 +1,14 @@
 import { writable, derived } from 'svelte/store';
 import * as L from 'lucide-svelte';
 
-const ALL_ICONS = Object.keys(L).filter(
+// Get all icon names, filtering out duplicates where lucide-svelte exports
+// both "X" and "XIcon" for the same icon (e.g. "File" and "FileIcon")
+const _rawIcons = Object.keys(L).filter(
   (k) => /^[A-Z]/.test(k) && k !== 'default' && k !== 'createLucideIcon'
+);
+const _iconSet = new Set(_rawIcons);
+const ALL_ICONS = _rawIcons.filter(
+  (k) => !(k.endsWith('Icon') && _iconSet.has(k.slice(0, -4)))
 );
 
 export function createIconPickerStore() {


### PR DESCRIPTION
## Summary

- `lucide-svelte` exports both `X` and `XIcon` for many icons (e.g. `File` and `FileIcon`), causing duplicates in the icon picker grid
- Filter out any key ending with `Icon` if the base name (without `Icon` suffix) also exists in the export set

#### Test plan
- [ ] Open icon picker in folder creation / streak creation
- [ ] No duplicate icons visible in the grid
- [ ] Search still works correctly
- [ ] Icon count is lower (no duplicates)
- [ ] Selecting an icon still works

Closes #272

Generated with [Devin](https://devin.ai)