### PR TITLE
fix(frontend): elemento <main> anidado en /offline (#267)

### DIFF
--- a/frontend/src/routes/offline/+page.svelte
+++ b/frontend/src/routes/offline/+page.svelte
@@ -12,11 +12,11 @@
   <title>Sin conexión — Joidy</title>
 </svelte:head>
 
-<main class="offline-page">
+<section class="offline-page">
   <h1>Sin conexión</h1>
   <p>No se pudo conectar con Joidy. Algunas funciones pueden no estar disponibles sin internet.</p>
   <button onclick={reload} class="reload-button">Reintentar</button>
-</main>
+</section>
 
 <style>
   .offline-page {


### PR DESCRIPTION
## Summary

- Replace `<main>` with `<section>` in `offline/+page.svelte` — the layout already has a `<main>` element, creating invalid nested `<main>` tags

#### Test plan
- [ ] Navigate to /offline
- [ ] No nested `<main>` elements in the DOM
- [ ] Page renders correctly with same styling
- [ ] Reload button still works

Closes #267

Generated with [Devin](https://devin.ai)