### PR TITLE
fix(frontend): panel del grafo y elemento untitled page huérfano (#264)

### DIFF
--- a/frontend/src/lib/components/KnowledgeGraphForce.svelte
+++ b/frontend/src/lib/components/KnowledgeGraphForce.svelte
@@ -837,7 +837,12 @@
     z-index: 1010;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
     backdrop-filter: blur(12px);
-    transition: all 0.25s ease;
+    transition: all 0.25s ease, opacity 0.2s ease;
+    opacity: 0.4;
+  }
+
+  .graph-wrapper:hover .settings-toggle-btn {
+    opacity: 1;
   }
 
   .settings-toggle-btn:hover {

--- a/frontend/src/routes/graph/+page.svelte
+++ b/frontend/src/routes/graph/+page.svelte
@@ -29,6 +29,9 @@
   });
 </script>
 
+<svelte:head>
+  <title>Grafo de Conocimiento — Joidy</title>
+</svelte:head>
 
 <div class="graph-page">
   <div class="graph-header">


### PR DESCRIPTION
## Summary

- Add `<svelte:head>` with title "Grafo de Conocimiento — Joidy" to `/graph` page (was showing as "untitled page" in browser tab)
- Make settings gear button semi-transparent (opacity 0.4) by default, only fully visible on hover — prevents it from looking like an open panel on page load

#### Test plan
- [ ] Browser tab shows "Grafo de Conocimiento — Joidy" when on /graph
- [ ] Settings gear button is dimmed on page load
- [ ] Gear button becomes fully visible when hovering over the graph area
- [ ] Clicking gear button still opens the settings panel
- [ ] Settings panel still closes with × button

Closes #264

Generated with [Devin](https://devin.ai)