### PR TITLE
fix(frontend): botones de acción sin aria-label (#262)

### DIFF
--- a/frontend/src/lib/components/StreakListPanel.svelte
+++ b/frontend/src/lib/components/StreakListPanel.svelte
@@ -62,10 +62,11 @@
           class:active={showArchived}
           on:click={onToggleArchive}
           title={showArchived ? 'Volver a activas' : 'Ver archivadas'}
+          aria-label={showArchived ? 'Volver a rachas activas' : 'Ver rachas archivadas'}
         >
           <Archive size={13} />
         </button>
-        <button class="new-btn" on:click={onCreate}>
+        <button class="new-btn" on:click={onCreate} aria-label="Crear nueva racha">
           <Plus size={13} />
         </button>
       </div>

--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -923,19 +923,19 @@
             </div>
             <div class="goal-actions">
               {#if goal.state === 'ACTIVE'}
-                <button class="btn btn-ghost text-muted" title="Pausar" onclick={() => updateGoalState(goal.id, 'PAUSED')}>
+                <button class="btn btn-ghost text-muted" title="Pausar" aria-label="Pausar objetivo" onclick={() => updateGoalState(goal.id, 'PAUSED')}>
                   <Pause size={14} />
                 </button>
-                <button class="btn btn-ghost text-success" title="Completar" onclick={() => completeGoal(goal.id)}>
+                <button class="btn btn-ghost text-success" title="Completar" aria-label="Completar objetivo" onclick={() => completeGoal(goal.id)}>
                   <Check size={14} />
                 </button>
               {:else if goal.state === 'PAUSED'}
-                <button class="btn btn-ghost text-muted" title="Reanudar" onclick={() => updateGoalState(goal.id, 'ACTIVE')}>
+                <button class="btn btn-ghost text-muted" title="Reanudar" aria-label="Reanudar objetivo" onclick={() => updateGoalState(goal.id, 'ACTIVE')}>
                   <Play size={14} />
                 </button>
               {/if}
               {#if goal.state !== 'COMPLETED' && goal.state !== 'FAILED'}
-                <button class="btn btn-ghost text-muted" title="Cancelar" onclick={() => updateGoalState(goal.id, 'CANCELLED')}>
+                <button class="btn btn-ghost text-muted" title="Cancelar" aria-label="Cancelar objetivo" onclick={() => updateGoalState(goal.id, 'CANCELLED')}>
                   <Ban size={14} />
                 </button>
               {/if}
@@ -943,9 +943,9 @@
                 <button class="btn btn-ghost text-danger" onclick={() => deleteGoal(goal.id)}>¿Eliminar?</button>
                 <button class="btn btn-ghost text-muted" onclick={() => deleteConfirm = null}>Cancelar</button>
               {:else}
-                <button class="btn btn-ghost text-muted" title="Eliminar" onclick={() => deleteGoal(goal.id)}>×</button>
+                <button class="btn btn-ghost text-muted" title="Eliminar" aria-label="Eliminar objetivo" onclick={() => deleteGoal(goal.id)}>×</button>
               {/if}
-              <button class="btn btn-ghost text-muted" title="Editar" onclick={() => openGoalEditor(goal)}>
+              <button class="btn btn-ghost text-muted" title="Editar" aria-label="Editar objetivo" onclick={() => openGoalEditor(goal)}>
                 <Pencil size={13} />
               </button>
             </div>
@@ -1008,9 +1008,9 @@
 
         <div class="dash-card" style="min-height: 280px; display: flex; flex-direction: column; padding: 0; overflow: hidden;">
           <div class="widget-header" style="display: flex; justify-content: space-between; align-items: center; padding: 12px; border-bottom: 1px solid var(--border-light); background: var(--bg-card);">
-            <button class="btn btn-ghost text-muted" style="padding: 4px;" onclick={() => activeWidgetIndex = (activeWidgetIndex - 1 + 5) % 5}><ChevronLeft size={14}/></button>
+            <button class="btn btn-ghost text-muted" style="padding: 4px;" aria-label="Widget anterior" onclick={() => activeWidgetIndex = (activeWidgetIndex - 1 + 5) % 5}><ChevronLeft size={14}/></button>
             <span class="widget-title" style="font-size: 12px; font-weight: 600; text-align: center; flex: 1;">{widgetTitles[activeWidgetIndex]}</span>
-            <button class="btn btn-ghost text-muted" style="padding: 4px;" onclick={() => activeWidgetIndex = (activeWidgetIndex + 1) % 5}><ChevronRight size={14}/></button>
+            <button class="btn btn-ghost text-muted" style="padding: 4px;" aria-label="Widget siguiente" onclick={() => activeWidgetIndex = (activeWidgetIndex + 1) % 5}><ChevronRight size={14}/></button>
           </div>
           <div class="widget-content" style="flex: 1; position: relative; padding: 16px; overflow: hidden; display: flex; align-items: center; justify-content: center;">
             {#if activeWidgetIndex === 0}
@@ -1507,9 +1507,9 @@
                 
                 {#if activityTab === 'horas'}
                   <div class="activity-day-selector" style="display: flex; justify-content: center; align-items: center; gap: 8px; background: var(--surface); padding: 4px 8px; border-radius: 6px; border: 1px solid var(--border);">
-                    <button class="icon-btn" onclick={prevActivityDay} style="background: none; border: none; cursor: pointer; color: var(--text-muted); display: flex; align-items: center; padding: 4px;"><ChevronLeft size={16} /></button>
+                    <button class="icon-btn" onclick={prevActivityDay} aria-label="Día anterior" style="background: none; border: none; cursor: pointer; color: var(--text-muted); display: flex; align-items: center; padding: 4px;"><ChevronLeft size={16} /></button>
                     <span style="font-size: 0.75rem; color: var(--text-secondary); min-width: 80px; text-align: center; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; font-family: var(--font-mono);">{daysOfWeek[activityDayOfWeek]}</span>
-                    <button class="icon-btn" onclick={nextActivityDay} style="background: none; border: none; cursor: pointer; color: var(--text-muted); display: flex; align-items: center; padding: 4px;"><ChevronRight size={16} /></button>
+                    <button class="icon-btn" onclick={nextActivityDay} aria-label="Día siguiente" style="background: none; border: none; cursor: pointer; color: var(--text-muted); display: flex; align-items: center; padding: 4px;"><ChevronRight size={16} /></button>
                   </div>
                 {/if}
               </div>
@@ -1579,7 +1579,7 @@
               <span class="new-goal-sub">Define un nuevo hábito o meta a seguir</span>
             </div>
           </div>
-          <button class="history-close-btn" onclick={() => showAddForm = false} title="Cerrar">
+          <button class="history-close-btn" onclick={() => showAddForm = false} title="Cerrar" aria-label="Cerrar formulario">
             <X size={15} />
           </button>
         </div>

--- a/frontend/src/routes/streaks/+page.svelte
+++ b/frontend/src/routes/streaks/+page.svelte
@@ -344,6 +344,7 @@
               class="detail-exit-btn"
               on:click={() => selectedId = null}
               title="Volver al menú"
+              aria-label="Volver al menú"
             >
               <X size={14} />
             </button>
@@ -365,6 +366,7 @@
                     on:click={() => !selected.is_archived && !selected.today_checked && !isStreakCompleted(selected) && checkin(selected.id)}
                     disabled={selected.is_archived || selected.today_checked || busy.has(selected.id) || isStreakCompleted(selected)}
                     title={isStreakCompleted(selected) ? 'Racha completada' : (selected.today_checked ? 'Ya hiciste check-in hoy' : 'Hacer check-in')}
+                    aria-label={isStreakCompleted(selected) ? 'Racha completada' : (selected.today_checked ? 'Ya hiciste check-in hoy' : 'Hacer check-in')}
                   >
                     {#if isStreakCompleted(selected)}
                       <span class="counter-num mono" style="color: #10b981;">✓</span>


### PR DESCRIPTION
## Summary

- **StreakListPanel**: `aria-label` on archive toggle button ("Ver rachas archivadas") and create new streak button ("Crear nueva racha")
- **streaks/+page.svelte**: `aria-label` on exit button ("Volver al menú") and check-in ring button (dynamic label based on state)
- **goals/+page.svelte**: `aria-label` on all icon-only action buttons:
  - Pausar/Completar/Reanudar/Cancelar/Eliminar/Editar goal buttons
  - Widget navigation arrows (anterior/siguiente)
  - Activity day navigation arrows (día anterior/siguiente)
  - Close form button

#### Test plan
- [ ] Screen reader announces button purposes when navigating streaks page
- [ ] Screen reader announces button purposes when navigating goals page
- [ ] No a11y warnings for missing aria-label on icon-only buttons
- [ ] All buttons still function correctly

Closes #262

Generated with [Devin](https://devin.ai)