### PR TITLE
fix(frontend): iconos no renderizan — kebab-case no resuelto a PascalCase

### DIFF
--- a/frontend/src/lib/components/DynamicIcon.svelte
+++ b/frontend/src/lib/components/DynamicIcon.svelte
@@ -34,8 +34,9 @@
     if (packName === 'phosphor' || packName === 'material') {
       return phosphorMap[n] || Circle;
     }
-    // Synchronous lookup — no race condition
-    return (LucideIcons as any)[n] || Circle;
+    // Synchronous lookup — handles both PascalCase and kebab-case names
+    const pascal = n.split('-').map((p: string) => p.charAt(0).toUpperCase() + p.slice(1)).join('');
+    return (LucideIcons as any)[n] || (LucideIcons as any)[pascal] || Circle;
   }
 
   $: comp = getIconComponent(pack || $activeIconPack, name);

--- a/frontend/src/lib/components/StreakIcon.svelte
+++ b/frontend/src/lib/components/StreakIcon.svelte
@@ -10,8 +10,13 @@
 
   $: isEmoji = emojiRegex.test(name);
 
-  // Synchronous lookup — no race condition
-  $: lucideComp = name ? ((LucideIcons as any)[name] || Circle) : Circle;
+  // Convert kebab-case to PascalCase (e.g. "book-open" → "BookOpen")
+  function toPascalCase(s: string): string {
+    return s.split('-').map(p => p.charAt(0).toUpperCase() + p.slice(1)).join('');
+  }
+
+  // Synchronous lookup — handles both PascalCase and kebab-case names
+  $: lucideComp = name ? ((LucideIcons as any)[name] || (LucideIcons as any)[toPascalCase(name)] || Circle) : Circle;
 </script>
 
 {#if isEmoji}


### PR DESCRIPTION
## Summary

- Los nombres de iconos en la BD están en kebab-case (`dumbbell`, `book-open`, `code-2`) pero lucide-svelte los exporta en PascalCase (`Dumbbell`, `BookOpen`, `Code2`)
- El lookup `(LucideIcons as any)[name]` fallaba y caía al fallback `Circle` (círculo vacío)
- Añadido `toPascalCase()` que convierte kebab-case → PascalCase y prueba ambas variantes
- Aplicado a `StreakIcon.svelte` y `DynamicIcon.svelte`

#### Test plan
- [x] Iconos de rachas se renderizan correctamente (dumbbell, droplet, calendar, moon, book-open, pen-tool, languages, sparkles, code-2, wallet)
- [x] Iconos de navegación siguen funcionando (Home, BookOpen, Target, Flame)
- [x] Iconos de ajustes siguen funcionando (Settings, Database, GitBranch, Zap, etc.)
- [x] svelte-check: 0 errores

Generated with [Devin](https://devin.ai)