### PR TITLE
fix(frontend): racha con tema neon siempre en modo oscuro

### DIFF
--- a/frontend/src/lib/components/StreakListItem.svelte
+++ b/frontend/src/lib/components/StreakListItem.svelte
@@ -177,7 +177,8 @@
   }
 
   .streak-item.theme-neon {
-    background: #000; border: 1px solid var(--theme-ac);
+    background: color-mix(in srgb, var(--theme-ac) 8%, var(--surface));
+    border: 1px solid var(--theme-ac);
     box-shadow: 0 0 10px color-mix(in srgb, var(--theme-ac) 25%, transparent);
   }
   .streak-item.theme-neon .item-name, .streak-item.theme-neon .item-num {


### PR DESCRIPTION
## Summary

- El tema `neon` de las rachas tenía `background: #000` hardcodeado, haciendo que la racha siempre se viera oscura sin importar el modo de la app
- Reemplazado con `color-mix(in srgb, var(--theme-ac) 8%, var(--surface))` que mezcla 8% del color de la racha con el surface actual
- En modo claro: fondo blanco con tinte sutil del color de la racha
- En modo oscuro: fondo negro con tinte sutil, manteniendo el efecto neon

#### Test plan
- [x] Modo claro: racha con tema neon ya no tiene fondo negro
- [x] Modo oscuro: racha con tema neon mantiene efecto neon
- [x] svelte-check: 0 errores

Generated with [Devin](https://devin.ai)