### PR TITLE
fix(frontend): eliminar calculadora científica del sidebar de Notas (#259)

### DIFF
--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -4,7 +4,6 @@
   import { goto } from '$app/navigation';
   import { Search, Plus, X, List, FolderTree, ChevronRight, FileEdit, FolderPlus, ChevronsUpDown, ArrowUpDown, Settings } from 'lucide-svelte';
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
-  import ScientificCalculator from '$lib/components/ScientificCalculator.svelte';
   import NoteEditor from '$lib/components/NoteEditor.svelte';
   import NoteCard from '$lib/components/NoteCard.svelte';
   import LazyIconPicker from '$lib/components/LazyIconPicker.svelte';
@@ -988,13 +987,6 @@
                 </button>
               {/each}
             </div>
-          </div>
-
-          <div class="dash-widget">
-            <div class="dash-widget-title" style="margin-bottom: 5px;">
-              <DynamicIcon name="Calculator" size={13}/> Calculadora
-            </div>
-            <ScientificCalculator />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Removed the scientific calculator widget from the notes sidebar — it broke UI cohesion by embedding an unrelated tool in a note-taking context
- Removed the `ScientificCalculator` import

#### Test plan
- [x] Notes sidebar no longer shows calculator widget
- [x] Quick actions and recent notes widgets still present
- [x] svelte-check: 0 errors

Closes #259

Generated with [Devin](https://devin.ai)