### PR TITLE
fix(frontend): rutas huérfanas no enlazadas (#254)

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -35,6 +35,7 @@
     { href: '/notes',   label: 'Notas',       icon: 'BookOpen', status: 'ready' },
     { href: '/graph',   label: 'Grafo',       icon: 'Network',  status: 'dev' },
     { href: '/skills',  label: 'Habilidades', icon: 'Zap',      status: 'dev' },
+    { href: '/ai',      label: 'IA',          icon: 'Brain',    status: 'dev' },
     { href: '/goals',   label: 'Objetivos',   icon: 'Target',   status: 'ready' },
     { href: '/streaks', label: 'Rachas',      icon: 'Flame',    status: 'ready' },
   ];

--- a/frontend/src/routes/contactos/+page.svelte
+++ b/frontend/src/routes/contactos/+page.svelte
@@ -1,5 +1,0 @@
-<script lang="ts">
-  import IntegrationPlaceholder from '$lib/components/IntegrationPlaceholder.svelte';
-</script>
-
-<IntegrationPlaceholder icon="Users" title="Contactos" caption="Gestión de contactos y relaciones" />

--- a/frontend/src/routes/gmail/+page.svelte
+++ b/frontend/src/routes/gmail/+page.svelte
@@ -1,5 +1,0 @@
-<script lang="ts">
-  import IntegrationPlaceholder from '$lib/components/IntegrationPlaceholder.svelte';
-</script>
-
-<IntegrationPlaceholder icon="Mail" title="Gmail" caption="Correo electrónico de Google" color="#EA4335" />

--- a/frontend/src/routes/spotify/+page.svelte
+++ b/frontend/src/routes/spotify/+page.svelte
@@ -1,5 +1,0 @@
-<script lang="ts">
-  import IntegrationPlaceholder from '$lib/components/IntegrationPlaceholder.svelte';
-</script>
-
-<IntegrationPlaceholder icon="Music" title="Spotify" caption="Música y podcasts" color="#1DB954" />

--- a/frontend/src/routes/strava/+page.svelte
+++ b/frontend/src/routes/strava/+page.svelte
@@ -1,5 +1,0 @@
-<script lang="ts">
-  import IntegrationPlaceholder from '$lib/components/IntegrationPlaceholder.svelte';
-</script>
-
-<IntegrationPlaceholder icon="Activity" title="Strava" caption="Seguimiento de actividades deportivas" color="#FC4C02" />


### PR DESCRIPTION
## Summary

- Deleted `/contactos`, `/gmail`, `/spotify`, `/strava` placeholder pages — these were orphan routes not linked from navigation or any hub. Integrations are managed from the SettingsPanel.
- Added `/ai` to navigation with `status: 'dev'` so it's accessible when Dev Mode is enabled (it was also an orphan route)

#### Test plan
- [x] No 404 for deleted routes (they simply no longer exist)
- [x] /ai appears in navigation when Dev Mode is ON
- [x] /ai hidden when Dev Mode is OFF
- [x] svelte-check: 0 errors

Closes #254

Generated with [Devin](https://devin.ai)