### PR TITLE
refactor(frontend): uso inconsistente de iconos (DynamicIcon vs imports directos) (#257)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,13 +96,19 @@ Factory pattern (`clients/`) for 6 providers (Gemini, OpenAI, Anthropic, Cohere,
 Two concurrent asyncio tasks: `watch_vault()` (watches `/vault/*.md`, 2s debounce) + `schedule_daily_writes()` (writes _joidy/ files at midnight).
 
 ### Frontend (`frontend/src/`)
-- `routes/`: SvelteKit pages (notes, goals, graph, skills, streaks, ai, integrations, etc.)
+- `routes/`: SvelteKit pages (notes, goals, graph, skills, streaks, ai, etc.)
 - `lib/stores/`: 20 Svelte stores (notes, gamification, pomodoro, graph, settings, etc.)
 - `lib/actions/`: Svelte actions (focusTrap, liquidGlass)
 - `lib/api.ts`: API client wrapper
-- `lib/components/`: Reusable Svelte components (Modal, DynamicIcon, GoalCard, StreakListItem, Calculator, etc.)
+- `lib/components/`: Reusable Svelte components (Modal, DynamicIcon, GoalCard, StreakListItem, etc.)
 - `lib/utils/debug.ts`: `debugLog()` / `debugWarn()` / `debugError()` — only logs when Dev Mode ON
 - Dev Mode is stored in localStorage key `joidy-dev-mode`, toggled in Settings. Pages under development show "En Construccion" unless dev mode is ON.
+
+#### Icon Usage Convention (#257)
+- **Static UI icons** (always the same icon, e.g. close button, search): Import directly from `lucide-svelte` — `import { Search, X } from 'lucide-svelte'`. This is tree-shakeable and more efficient.
+- **Dynamic icons** (icon name comes from data/config, e.g. streak icon, folder icon, nav item icon): Use `<DynamicIcon name={iconName} />` — supports runtime lookup, kebab-to-PascalCase conversion, and icon pack switching (Lucide/Phosphor/Material).
+- **Streak icons**: Use `<StreakIcon name={streak.icon} />` — optimized for streak items with emoji fallback.
+- Never use `<DynamicIcon name="StaticName" />` with a hardcoded string — import the icon directly instead.
 
 ### Gamification
 `api/services/gamification_engine.py`: XP events (note_created +10, note_edited +5, daily_activity +15, goal_completed +50), streaks (7/30/100/365d → +100 XP), plant stages (0→semilla, 300→brote, 1200→planton, 4000→joven, 10000→madura, 25000→floreciendo, 60000→arbol). Grace period: 1 missed day/week.

--- a/frontend/src/lib/components/CommandPalette.svelte
+++ b/frontend/src/lib/components/CommandPalette.svelte
@@ -2,6 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
   import { fade, fly } from 'svelte/transition';
+  import { Search } from 'lucide-svelte';
   import DynamicIcon from './DynamicIcon.svelte';
   import { notes } from '$lib/stores/notes';
 
@@ -111,7 +112,7 @@
   <div class="cp-backdrop" on:click={() => open = false} transition:fade={{duration: 100}}>
     <div class="cp-modal" on:click|stopPropagation transition:fly={{y: -20, duration: 150}}>
       <div class="cp-header">
-        <DynamicIcon name="Search" size={16} />
+        <Search size={16} />
         <input 
           bind:this={searchInput}
           bind:value={query}

--- a/frontend/src/lib/components/ErrorBoundary.svelte
+++ b/frontend/src/lib/components/ErrorBoundary.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { browser } from '$app/environment';
-  import DynamicIcon from './DynamicIcon.svelte';
+  import { AlertTriangle, RefreshCw } from 'lucide-svelte';
 
   let hasError = false;
   let errorMessage = '';
@@ -27,12 +27,12 @@
 
 {#if hasError}
   <div class="error-boundary">
-    <DynamicIcon name="AlertTriangle" size={32} />
+    <AlertTriangle size={32} />
     <h3>Algo sali&oacute; mal</h3>
     <p class="error-msg">{errorMessage || 'Error inesperado en este componente.'}</p>
     <div class="actions">
       <button class="btn" on:click={retry}>
-        <DynamicIcon name="RefreshCw" size={12} /> Reintentar
+        <RefreshCw size={12} /> Reintentar
       </button>
       <button class="btn btn-ghost" on:click={() => showDetails = !showDetails}>
         Detalles

--- a/frontend/src/lib/components/FileTree.svelte
+++ b/frontend/src/lib/components/FileTree.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import DynamicIcon from './DynamicIcon.svelte';
+  import { ChevronRight } from 'lucide-svelte';
   import type { TreeNode } from '$lib/utils/fileTree';
 
   export let nodes: TreeNode[];
@@ -27,7 +27,7 @@
       on:click={() => toggle(node.path)}
     >
       <span class="chevron" class:open={!collapsed.has(node.path)}>
-        <DynamicIcon name="ChevronRight" size={11} />
+        <ChevronRight size={11} />
       </span>
       <span class="icon">{node.icon}</span>
       <span class="row-name folder-name">{node.name}</span>

--- a/frontend/src/lib/components/FolderPicker.svelte
+++ b/frontend/src/lib/components/FolderPicker.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import type { FlatNode } from '$lib/utils/fileTree';
+  import { FolderRoot } from 'lucide-svelte';
   import DynamicIcon from './DynamicIcon.svelte';
 
   export let flatNodes: FlatNode[] = [];
@@ -28,7 +29,7 @@
         class:selected={selectedPath === ''}
         on:click={() => selectedPath = ''}
       >
-        <DynamicIcon name="FolderRoot" size={12} />
+        <FolderRoot size={12} />
         (Raíz)
       </button>
       {#each folders as f}

--- a/frontend/src/lib/components/Modal.svelte
+++ b/frontend/src/lib/components/Modal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { fade, scale } from 'svelte/transition';
   import { uiModal, closeModal } from '$lib/stores/ui';
-  import DynamicIcon from './DynamicIcon.svelte';
+  import { X } from 'lucide-svelte';
   import { focusTrap } from '$lib/actions/focusTrap';
 
   export let title = '';
@@ -35,7 +35,7 @@
       <div class="modal-header">
         <h3 class="modal-title">{title}</h3>
         <button class="modal-close" on:click={closeModal}>
-          <DynamicIcon name="X" size={18} />
+          <X size={18} />
         </button>
       </div>
       <div class="modal-body">

--- a/frontend/src/lib/components/PomodoroWidget.svelte
+++ b/frontend/src/lib/components/PomodoroWidget.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
-  import DynamicIcon from '$lib/components/DynamicIcon.svelte';
+  import { RotateCcw, SkipForward } from 'lucide-svelte';
 
   // ── Timer ──────────────────────────────────────────────────────────────────
   import {
@@ -68,8 +68,8 @@
     <button class="ctrl-main" class:active={$running} on:click={toggleTimer}>
       {$running ? 'Pausar' : 'Iniciar'}
     </button>
-    <button class="ctrl-icon" on:click={resetTimer} title="Reiniciar"><DynamicIcon name="RotateCcw" size={11}/></button>
-    <button class="ctrl-icon" on:click={skipTimer}  title="Saltar"><DynamicIcon name="SkipForward" size={11}/></button>
+    <button class="ctrl-icon" on:click={resetTimer} title="Reiniciar"><RotateCcw size={11}/></button>
+    <button class="ctrl-icon" on:click={skipTimer}  title="Saltar"><SkipForward size={11}/></button>
   </div>
 
   <div class="duration-row">

--- a/frontend/src/lib/components/StreakStatsPanel.svelte
+++ b/frontend/src/lib/components/StreakStatsPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { StreakStats } from '$lib/api';
-  import DynamicIcon from '$lib/components/DynamicIcon.svelte';
+  import { BarChart3, Calendar } from 'lucide-svelte';
 
   export let stats: StreakStats | null = null;
 </script>
@@ -8,7 +8,7 @@
 {#if stats}
   <div class="stats-panel">
     <div class="stats-header">
-      <DynamicIcon name="BarChart3" size={12} />
+      <BarChart3 size={12} />
       <span>RESUMEN GLOBAL</span>
     </div>
 
@@ -36,7 +36,7 @@
     {/if}
 
     <div class="tracker-row">
-      <DynamicIcon name="Calendar" size={11} />
+      <Calendar size={11} />
       <span>{stats.days_tracked} días trackeados</span>
       <span class="sep">·</span>
       <span>{stats.total_checkins} check-ins totales</span>

--- a/frontend/src/lib/components/TreeContextMenu.svelte
+++ b/frontend/src/lib/components/TreeContextMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, onMount } from 'svelte';
   import type { FlatNode } from '$lib/utils/fileTree';
-  import DynamicIcon from './DynamicIcon.svelte';
+  import { Edit, MoveRight, Trash2, FilePlus, FolderX } from 'lucide-svelte';
 
   export let x: number;
   export let y: number;
@@ -61,24 +61,24 @@
 <div class="ctx-menu" bind:this={menuEl} style={style} on:click|stopPropagation on:contextmenu|stopPropagation>
   {#if node.type === 'file'}
     <button class="ctx-item" on:click={handleItem('rename')}>
-      <DynamicIcon name="Edit" size={12} /> Renombrar
+      <Edit size={12} /> Renombrar
     </button>
     <button class="ctx-item" on:click={handleItem('move')}>
-      <DynamicIcon name="MoveRight" size={12} /> Mover a...
+      <MoveRight size={12} /> Mover a...
     </button>
     <div class="ctx-divider"></div>
     <button class="ctx-item ctx-danger" on:click={handleItem('deleteNote')}>
-      <DynamicIcon name="Trash2" size={12} /> Eliminar
+      <Trash2 size={12} /> Eliminar
     </button>
   {:else}
     <button class="ctx-item" on:click={handleItem('newNoteInFolder')}>
-      <DynamicIcon name="FilePlus" size={12} /> Nueva nota aquí
+      <FilePlus size={12} /> Nueva nota aquí
     </button>
     <button class="ctx-item" on:click={handleItem('rename')}>
-      <DynamicIcon name="Edit" size={12} /> Renombrar
+      <Edit size={12} /> Renombrar
     </button>
     <button class="ctx-item ctx-danger" on:click={handleItem('deleteFolder')}>
-      <DynamicIcon name="FolderX" size={12} /> Eliminar carpeta
+      <FolderX size={12} /> Eliminar carpeta
     </button>
   {/if}
 </div>


### PR DESCRIPTION
## Summary

- Documented icon usage convention in AGENTS.md:
  - **Static UI icons**: import directly from `lucide-svelte` (tree-shakeable, more efficient)
  - **Dynamic icons** (icon name from data/config): use `<DynamicIcon name={iconName} />`
  - **Streak icons**: use `<StreakIcon name={streak.icon} />`
  - Never use `<DynamicIcon name="StaticName" />` with a hardcoded string

- Migrated 8 components that used DynamicIcon with hardcoded strings to direct lucide-svelte imports:
  - Modal: X
  - ErrorBoundary: AlertTriangle, RefreshCw
  - CommandPalette: Search
  - PomodoroWidget: RotateCcw, SkipForward
  - FileTree: ChevronRight
  - StreakStatsPanel: BarChart3, Calendar
  - TreeContextMenu: Edit, MoveRight, Trash2, FilePlus, FolderX
  - FolderPicker: FolderRoot

#### Test plan
- [x] svelte-check: 0 errors
- [ ] All affected components render icons correctly
- [ ] No visual regressions

Closes #257

Generated with [Devin](https://devin.ai)