### PR TITLE
refactor(frontend): sintaxis de eventos mezclada Svelte 4/5 (#258)

### DIFF
--- a/frontend/src/lib/components/Card.svelte
+++ b/frontend/src/lib/components/Card.svelte
@@ -9,10 +9,9 @@
   class="card padding-{padding}"
   class:hoverable
   class:clickable
-  on:click
   role={clickable ? 'button' : 'none'}
   tabindex={clickable ? 0 : -1}
-  on:keydown={(e) => clickable && e.key === 'Enter' && e.currentTarget.click()}
+  onkeydown={(e) => clickable && e.key === 'Enter' && e.currentTarget.click()}
 >
   <slot />
 </div>

--- a/frontend/src/lib/components/CommandPalette.svelte
+++ b/frontend/src/lib/components/CommandPalette.svelte
@@ -109,8 +109,8 @@
 
 {#if open}
   <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-  <div class="cp-backdrop" on:click={() => open = false} transition:fade={{duration: 100}}>
-    <div class="cp-modal" on:click|stopPropagation transition:fly={{y: -20, duration: 150}}>
+  <div class="cp-backdrop" onclick={() => open = false} transition:fade={{duration: 100}}>
+    <div class="cp-modal" onclick={(e) => e.stopPropagation()} transition:fly={{y: -20, duration: 150}}>
       <div class="cp-header">
         <Search size={16} />
         <input 
@@ -133,8 +133,8 @@
             <button 
               class="cp-item" 
               class:selected={index === selectedIndex}
-              on:mouseenter={() => selectedIndex = index}
-              on:click={() => { open = false; item.action(); }}
+              onmouseenter={() => selectedIndex = index}
+              onclick={() => { open = false; item.action(); }}
             >
               <DynamicIcon name={item.icon} size={14} />
               <span class="cp-item-title">{item.title}</span>

--- a/frontend/src/lib/components/ErrorBoundary.svelte
+++ b/frontend/src/lib/components/ErrorBoundary.svelte
@@ -31,10 +31,10 @@
     <h3>Algo sali&oacute; mal</h3>
     <p class="error-msg">{errorMessage || 'Error inesperado en este componente.'}</p>
     <div class="actions">
-      <button class="btn" on:click={retry}>
+      <button class="btn" onclick={retry}>
         <RefreshCw size={12} /> Reintentar
       </button>
-      <button class="btn btn-ghost" on:click={() => showDetails = !showDetails}>
+      <button class="btn btn-ghost" onclick={() => showDetails = !showDetails}>
         Detalles
       </button>
     </div>

--- a/frontend/src/lib/components/FileTree.svelte
+++ b/frontend/src/lib/components/FileTree.svelte
@@ -24,7 +24,7 @@
     <div
       class="tree-row folder-row"
       style="padding-left: {8 + depth * 14}px"
-      on:click={() => toggle(node.path)}
+      onclick={() => toggle(node.path)}
     >
       <span class="chevron" class:open={!collapsed.has(node.path)}>
         <ChevronRight size={11} />
@@ -52,7 +52,7 @@
       class="tree-row file-row"
       class:active={node.note?.id === selectedNoteId}
       style="padding-left: {20 + depth * 14}px"
-      on:click={() => node.note && dispatch('select', node.note)}
+      onclick={() => node.note && dispatch('select', node.note)}
     >
       <span class="icon file-icon">{node.icon}</span>
       <span class="row-name file-name">{node.name}</span>

--- a/frontend/src/lib/components/FolderPicker.svelte
+++ b/frontend/src/lib/components/FolderPicker.svelte
@@ -17,8 +17,8 @@
   $: folders = flatNodes.filter(n => n.type === 'folder' && (!search || n.path.toLowerCase().includes(search.toLowerCase())));
 </script>
 
-<div class="folder-picker-backdrop" on:click={() => dispatch('close')} role="button" tabindex="-1" on:keydown={(e) => e.key === 'Enter' && dispatch('close')}>
-  <div class="folder-picker" on:click={(e) => e.stopPropagation()} role="button" tabindex="-1" on:keydown={(e) => e.stopPropagation()}>
+<div class="folder-picker-backdrop" onclick={() => dispatch('close')} role="button" tabindex="-1" onkeydown={(e) => e.key === 'Enter' && dispatch('close')}>
+  <div class="folder-picker" onclick={(e) => e.stopPropagation()} role="button" tabindex="-1" onkeydown={(e) => e.stopPropagation()}>
     <h3 class="folder-modal-title">Mover nota a carpeta</h3>
 
     <input type="text" class="input mono" bind:value={search} placeholder="Buscar carpeta..." style="width:100%; box-sizing:border-box; margin-bottom:8px;" />
@@ -27,7 +27,7 @@
       <button
         class="folder-opt"
         class:selected={selectedPath === ''}
-        on:click={() => selectedPath = ''}
+        onclick={() => selectedPath = ''}
       >
         <FolderRoot size={12} />
         (Raíz)
@@ -36,7 +36,7 @@
         <button
           class="folder-opt"
           class:selected={selectedPath === f.path}
-          on:click={() => selectedPath = f.path}
+          onclick={() => selectedPath = f.path}
         >
           <span class="folder-opt-indent" style="width: {f.depth * 14}px"></span>
           <DynamicIcon name={f.icon || 'Folder'} size={12} color={f.color} />
@@ -49,8 +49,8 @@
     </div>
 
     <div class="folder-modal-btns">
-      <button on:click={() => dispatch('close')}>Cancelar</button>
-      <button class="primary" on:click={() => dispatch('select', selectedPath)}>Mover aquí</button>
+      <button onclick={() => dispatch('close')}>Cancelar</button>
+      <button class="primary" onclick={() => dispatch('select', selectedPath)}>Mover aquí</button>
     </div>
   </div>
 </div>

--- a/frontend/src/lib/components/GithubWidget.svelte
+++ b/frontend/src/lib/components/GithubWidget.svelte
@@ -36,14 +36,14 @@
   </div>
   <div class="gh-filters">
     <div class="gh-filter">
-      <button class="filter-btn" class:active={ghType === 'all'} on:click={() => onSetType('all')}>Todo</button>
-      <button class="filter-btn" class:active={ghType === 'issues'} on:click={() => onSetType('issues')}>Issues</button>
-      <button class="filter-btn" class:active={ghType === 'prs'} on:click={() => onSetType('prs')}>PRs</button>
+      <button class="filter-btn" class:active={ghType === 'all'} onclick={() => onSetType('all')}>Todo</button>
+      <button class="filter-btn" class:active={ghType === 'issues'} onclick={() => onSetType('issues')}>Issues</button>
+      <button class="filter-btn" class:active={ghType === 'prs'} onclick={() => onSetType('prs')}>PRs</button>
     </div>
     <span class="gh-filter-divider">|</span>
     <div class="gh-filter">
-      <button class="filter-btn" class:active={ghFilter === 'created'} on:click={() => onSetFilter('created')}>Creados</button>
-      <button class="filter-btn" class:active={ghFilter === 'assigned'} on:click={() => onSetFilter('assigned')}>Asignados</button>
+      <button class="filter-btn" class:active={ghFilter === 'created'} onclick={() => onSetFilter('created')}>Creados</button>
+      <button class="filter-btn" class:active={ghFilter === 'assigned'} onclick={() => onSetFilter('assigned')}>Asignados</button>
     </div>
   </div>
 </div>

--- a/frontend/src/lib/components/GoalEditor.svelte
+++ b/frontend/src/lib/components/GoalEditor.svelte
@@ -157,7 +157,7 @@
   $: editorHighlightedHtml = highlightMarkdown(debouncedContent);
 </script>
 
-<svelte:window on:keydown={onKeydown} />
+<svelte:window onkeydown={onKeydown} />
 
 <div class="editor-shell" class:zen-mode={zenMode}>
   {#if !zenMode}
@@ -172,7 +172,7 @@
       <button
         class="toolbar-btn icon-only"
         class:active={zenMode}
-        on:click={() => zenMode = !zenMode}
+        onclick={() => zenMode = !zenMode}
         title="Modo Zen (Esc para salir)"
       >
         <Maximize size={14} />
@@ -181,7 +181,7 @@
       <button
         class="toolbar-btn"
         class:active={previewMode}
-        on:click={() => previewMode = !previewMode}
+        onclick={() => previewMode = !previewMode}
         title="Alternar preview (Ctrl+P)"
       >
         {#if previewMode}<EyeOff size={14} />{:else}<Eye size={14} />{/if}
@@ -191,7 +191,7 @@
       <button
         class="toolbar-btn save-btn"
         class:saved
-        on:click={handleSave}
+        onclick={handleSave}
         disabled={saving || !title.trim()}
         title="Guardar (Ctrl+S)"
       >
@@ -199,12 +199,12 @@
         <span class="save-status">{saved ? 'Guardado' : saving ? '...' : 'Guardar'}</span>
       </button>
 
-      <button class="toolbar-btn" on:click={() => dispatch('edit')} title="Editar ajustes del objetivo">
+      <button class="toolbar-btn" onclick={() => dispatch('edit')} title="Editar ajustes del objetivo">
         <Settings size={14} />
         <span>Ajustes</span>
       </button>
 
-      <button class="toolbar-btn" on:click={() => dispatch('cancel')} title="Cerrar">
+      <button class="toolbar-btn" onclick={() => dispatch('cancel')} title="Cerrar">
         <X size={14} />
       </button>
     </div>
@@ -216,13 +216,13 @@
       class="title-input"
       bind:value={title}
       placeholder="Título del objetivo..."
-      on:keydown={(e) => e.key === 'Enter' && handleSave()}
+      onkeydown={(e) => e.key === 'Enter' && handleSave()}
     />
   </div>
 
   <div class="content-area">
     {#if previewMode}
-      <div class="preview" on:dblclick={() => previewMode = false} role="button" tabindex="-1">
+      <div class="preview" ondblclick={() => previewMode = false} role="button" tabindex="-1">
         {@html renderedHtml}
       </div>
     {:else}
@@ -239,8 +239,8 @@
           class="content-textarea"
           bind:this={textareaEl}
           value={content}
-          on:input={updateContent}
-          on:scroll={syncScroll}
+          oninput={updateContent}
+          onscroll={syncScroll}
           placeholder="Escribe en markdown... (Ctrl+S para guardar, Ctrl+P para preview)"
           spellcheck="false"
         ></textarea>

--- a/frontend/src/lib/components/KnowledgeGraph.svelte
+++ b/frontend/src/lib/components/KnowledgeGraph.svelte
@@ -490,29 +490,29 @@
         type="search"
         placeholder="Buscar nodos..."
         bind:value={searchQuery}
-        on:input={rerender}
+        oninput={rerender}
       />
       {#if searchQuery.trim().length > 0}
-        <button class="search-clear" on:click={clearHighlights} aria-label="Limpiar busqueda">×</button>
+        <button class="search-clear" onclick={clearHighlights} aria-label="Limpiar busqueda">×</button>
       {/if}
     </div>
-    <button class="btn btn-ghost btn-icon" title="Alternar etiquetas" on:click={() => { showLabels = !showLabels; rerender(); }}>
+    <button class="btn btn-ghost btn-icon" title="Alternar etiquetas" onclick={() => { showLabels = !showLabels; rerender(); }}>
       <span style="font-size:10px; font-family: var(--font-mono);">Aa</span>
     </button>
-    <button class="btn btn-ghost btn-icon" title="Particulas" class:active={showParticles} on:click={() => { showParticles = !showParticles; }}>
+    <button class="btn btn-ghost btn-icon" title="Particulas" class:active={showParticles} onclick={() => { showParticles = !showParticles; }}>
       <span style="font-size:12px;">✨</span>
     </button>
-    <button class="btn btn-ghost btn-icon" title="Ajustar" on:click={recenter}>
+    <button class="btn btn-ghost btn-icon" title="Ajustar" onclick={recenter}>
       <span style="font-size:11px;">⊡</span>
     </button>
-    <button class="btn btn-ghost btn-icon" title="Restablecer vista" on:click={resetView}>
+    <button class="btn btn-ghost btn-icon" title="Restablecer vista" onclick={resetView}>
       <span style="font-size:11px;">⊙</span>
     </button>
-    <button class="btn btn-ghost btn-icon" title="Ocultar huerfanos" class:active={!showOrphans} on:click={() => { showOrphans = !showOrphans; rerender(); }}>
+    <button class="btn btn-ghost btn-icon" title="Ocultar huerfanos" class:active={!showOrphans} onclick={() => { showOrphans = !showOrphans; rerender(); }}>
       <span style="font-size:11px;">◌</span>
     </button>
     <div class="filter-group">
-      <select bind:value={filterType} on:change={rerender}>
+      <select bind:value={filterType} onchange={rerender}>
         <option value="all">Todo</option>
         <option value="notes">Notas</option>
         <option value="tags">Tags</option>

--- a/frontend/src/lib/components/KnowledgeGraphForce.svelte
+++ b/frontend/src/lib/components/KnowledgeGraphForce.svelte
@@ -534,7 +534,7 @@
       class="settings-toggle-btn" 
       class:panel-open={showSettingsPanel} 
       title="Ajustes del Grafo" 
-      on:click={() => showSettingsPanel = !showSettingsPanel}
+      onclick={() => showSettingsPanel = !showSettingsPanel}
     >
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="gear-icon"><circle cx="12" cy="12" r="3"></circle><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path></svg>
     </button>
@@ -543,14 +543,14 @@
     <div class="settings-sidebar" class:open={showSettingsPanel}>
       <div class="sidebar-header">
         <h4>Ajustes del Grafo</h4>
-        <button class="close-panel-btn" on:click={() => showSettingsPanel = false}>×</button>
+        <button class="close-panel-btn" onclick={() => showSettingsPanel = false}>×</button>
       </div>
 
       <div class="sidebar-scroll">
         <!-- 1. FILTROS -->
         <div class="accordion-item" class:active={activeSection === 'filters'}>
           <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-          <div class="accordion-header" on:click={() => toggleSection('filters')}>
+          <div class="accordion-header" onclick={() => toggleSection('filters')}>
             <span class="chevron" class:expanded={activeSection === 'filters'}>›</span>
             <h5>Filtros</h5>
           </div>
@@ -562,17 +562,17 @@
                   type="text"
                   placeholder="Buscar notas o tags..."
                   bind:value={searchQuery}
-                  on:input={applyStyling}
+                  oninput={applyStyling}
                 />
                 {#if searchQuery}
-                  <button class="panel-search-clear" on:click={() => { searchQuery = ''; applyStyling(); }}>×</button>
+                  <button class="panel-search-clear" onclick={() => { searchQuery = ''; applyStyling(); }}>×</button>
                 {/if}
               </div>
 
               <label class="toggle-control">
                 <span>Archivos</span>
                 <span class="switch">
-                  <input type="checkbox" bind:checked={showNotes} on:change={rebuildGraph} />
+                  <input type="checkbox" bind:checked={showNotes} onchange={rebuildGraph} />
                   <span class="slider"></span>
                 </span>
               </label>
@@ -580,7 +580,7 @@
               <label class="toggle-control">
                 <span>Etiquetas</span>
                 <span class="switch">
-                  <input type="checkbox" bind:checked={showTags} on:change={rebuildGraph} />
+                  <input type="checkbox" bind:checked={showTags} onchange={rebuildGraph} />
                   <span class="slider"></span>
                 </span>
               </label>
@@ -588,7 +588,7 @@
               <label class="toggle-control">
                 <span>Archivos no existentes</span>
                 <span class="switch">
-                  <input type="checkbox" bind:checked={showUnresolved} on:change={rebuildGraph} />
+                  <input type="checkbox" bind:checked={showUnresolved} onchange={rebuildGraph} />
                   <span class="slider"></span>
                 </span>
               </label>
@@ -596,7 +596,7 @@
               <label class="toggle-control">
                 <span>Adjuntos</span>
                 <span class="switch">
-                  <input type="checkbox" bind:checked={showAttachments} on:change={rebuildGraph} />
+                  <input type="checkbox" bind:checked={showAttachments} onchange={rebuildGraph} />
                   <span class="slider"></span>
                 </span>
               </label>
@@ -604,7 +604,7 @@
               <label class="toggle-control">
                 <span>Huérfanos</span>
                 <span class="switch">
-                  <input type="checkbox" bind:checked={showOrphans} on:change={rebuildGraph} />
+                  <input type="checkbox" bind:checked={showOrphans} onchange={rebuildGraph} />
                   <span class="slider"></span>
                 </span>
               </label>
@@ -612,7 +612,7 @@
               <label class="toggle-control">
                 <span>Co-ocurrencias de etiquetas</span>
                 <span class="switch">
-                  <input type="checkbox" bind:checked={showCooccurrences} on:change={rebuildGraph} />
+                  <input type="checkbox" bind:checked={showCooccurrences} onchange={rebuildGraph} />
                   <span class="slider"></span>
                 </span>
               </label>
@@ -623,7 +623,7 @@
         <!-- 2. GRUPOS DE COLOR -->
         <div class="accordion-item" class:active={activeSection === 'groups'}>
           <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-          <div class="accordion-header" on:click={() => toggleSection('groups')}>
+          <div class="accordion-header" onclick={() => toggleSection('groups')}>
             <span class="chevron" class:expanded={activeSection === 'groups'}>›</span>
             <h5>Grupos de color</h5>
           </div>
@@ -638,21 +638,21 @@
                       type="color" 
                       class="color-picker-input" 
                       bind:value={group.color} 
-                      on:change={saveGroups} 
+                      onchange={saveGroups} 
                     />
                     <input 
                       type="text" 
                       class="group-query-input" 
                       placeholder="tag:idea o palabra clave..." 
                       bind:value={group.query} 
-                      on:input={saveGroups} 
+                      oninput={saveGroups} 
                     />
-                    <button class="group-delete-btn" title="Eliminar regla" on:click={() => removeColorGroup(idx)}>×</button>
+                    <button class="group-delete-btn" title="Eliminar regla" onclick={() => removeColorGroup(idx)}>×</button>
                   </div>
                 {/each}
               </div>
 
-              <button class="btn btn-ghost add-group-btn" on:click={addColorGroup}>
+              <button class="btn btn-ghost add-group-btn" onclick={addColorGroup}>
                 + Añadir grupo
               </button>
             </div>
@@ -662,7 +662,7 @@
         <!-- 3. VISUALIZACIÓN -->
         <div class="accordion-item" class:active={activeSection === 'display'}>
           <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-          <div class="accordion-header" on:click={() => toggleSection('display')}>
+          <div class="accordion-header" onclick={() => toggleSection('display')}>
             <span class="chevron" class:expanded={activeSection === 'display'}>›</span>
             <h5>Visualización</h5>
           </div>
@@ -671,7 +671,7 @@
               <label class="toggle-control">
                 <span>Mostrar etiquetas de texto</span>
                 <span class="switch">
-                  <input type="checkbox" bind:checked={showLabels} on:change={applyStyling} />
+                  <input type="checkbox" bind:checked={showLabels} onchange={applyStyling} />
                   <span class="slider"></span>
                 </span>
               </label>
@@ -697,7 +697,7 @@
                   <span>Tamaño del nodo</span>
                   <span>{nodeSizeScale.toFixed(1)}x</span>
                 </div>
-                <input type="range" min="0.5" max="3.0" step="0.1" bind:value={nodeSizeScale} on:input={applyStyling} />
+                <input type="range" min="0.5" max="3.0" step="0.1" bind:value={nodeSizeScale} oninput={applyStyling} />
               </div>
 
               <div class="slider-control">
@@ -705,7 +705,7 @@
                   <span>Grosor de línea</span>
                   <span>{linkThicknessScale.toFixed(1)}x</span>
                 </div>
-                <input type="range" min="0.1" max="3.0" step="0.1" bind:value={linkThicknessScale} on:input={applyStyling} />
+                <input type="range" min="0.1" max="3.0" step="0.1" bind:value={linkThicknessScale} oninput={applyStyling} />
               </div>
 
               <div class="slider-control">
@@ -713,7 +713,7 @@
                   <span>Escala del texto</span>
                   <span>{textScale.toFixed(1)}x</span>
                 </div>
-                <input type="range" min="0.5" max="2.0" step="0.1" bind:value={textScale} on:input={applyStyling} />
+                <input type="range" min="0.5" max="2.0" step="0.1" bind:value={textScale} oninput={applyStyling} />
               </div>
 
               <div class="slider-control">
@@ -721,7 +721,7 @@
                   <span>Umbral de desvanecimiento</span>
                   <span>{labelThreshold.toFixed(1)}</span>
                 </div>
-                <input type="range" min="0.2" max="2.5" step="0.1" bind:value={labelThreshold} on:input={applyStyling} />
+                <input type="range" min="0.2" max="2.5" step="0.1" bind:value={labelThreshold} oninput={applyStyling} />
               </div>
             </div>
           {/if}
@@ -730,7 +730,7 @@
         <!-- 4. FUERZAS FÍSICAS -->
         <div class="accordion-item" class:active={activeSection === 'forces'}>
           <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-          <div class="accordion-header" on:click={() => toggleSection('forces')}>
+          <div class="accordion-header" onclick={() => toggleSection('forces')}>
             <span class="chevron" class:expanded={activeSection === 'forces'}>›</span>
             <h5>Fuerzas</h5>
           </div>
@@ -760,7 +760,7 @@
                 <input type="range" min="0.1" max="2.0" step="0.1" bind:value={linkForce} />
               </div>
 
-              <button class="btn btn-ghost reset-btn" on:click={resetForces}>
+              <button class="btn btn-ghost reset-btn" onclick={resetForces}>
                 Reestablecer fuerzas predeterminadas
               </button>
             </div>
@@ -771,19 +771,19 @@
 
     <!-- PERSISTENT RIGHT TOOLBAR CONTROLS (FIT, ZOOM, MINIMAP) -->
     <div class="graph-quick-actions">
-      <button class="quick-btn" title="Acercar" on:click={zoomIn}>
+      <button class="quick-btn" title="Acercar" onclick={zoomIn}>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="action-icon"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="16"></line><line x1="8" y1="12" x2="16" y2="12"></line></svg>
       </button>
-      <button class="quick-btn" title="Alejar" on:click={zoomOut}>
+      <button class="quick-btn" title="Alejar" onclick={zoomOut}>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="action-icon"><circle cx="12" cy="12" r="10"></circle><line x1="8" y1="12" x2="16" y2="12"></line></svg>
       </button>
-      <button class="quick-btn" title="Ajustar a pantalla" on:click={zoomToFit}>
+      <button class="quick-btn" title="Ajustar a pantalla" onclick={zoomToFit}>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="action-icon"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="9" x2="15" y2="15"></line><line x1="15" y1="9" x2="9" y2="15"></line></svg>
       </button>
-      <button class="quick-btn" title="Centrar" on:click={resetView}>
+      <button class="quick-btn" title="Centrar" onclick={resetView}>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="action-icon"><circle cx="12" cy="12" r="10"></circle><circle cx="12" cy="12" r="3"></circle></svg>
       </button>
-      <button class="quick-btn" title="Limpiar selección" on:click={clearHighlights}>
+      <button class="quick-btn" title="Limpiar selección" onclick={clearHighlights}>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="action-icon"><path d="M21 4H8l-7 8 7 8h13a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2z"></path><line x1="18" y1="9" x2="12" y2="15"></line><line x1="12" y1="9" x2="18" y2="15"></line></svg>
       </button>
     </div>

--- a/frontend/src/lib/components/Login.svelte
+++ b/frontend/src/lib/components/Login.svelte
@@ -46,7 +46,7 @@
     <div class="logo mono">JOIDY</div>
     <p class="subtitle">Conocimiento Gamificado</p>
     
-    <form on:submit|preventDefault={handleLogin}>
+    <form onsubmit={(e) => { e.preventDefault(); handleLogin(); }}>
       <div class="field">
         <label for="username">Usuario</label>
         <input id="username" type="text" bind:value={username} class="input" />

--- a/frontend/src/lib/components/Modal.svelte
+++ b/frontend/src/lib/components/Modal.svelte
@@ -14,7 +14,7 @@
   }
 </script>
 
-<svelte:window on:keydown={handleKeydown} />
+<svelte:window onkeydown={handleKeydown} />
 
 {#if $uiModal.isOpen}
   <div
@@ -24,8 +24,8 @@
     aria-label={title || 'Diálogo'}
     tabindex="-1"
     transition:fade={{ duration: 150 }}
-    on:click|self={closeModal}
-    on:keydown={(e) => e.key === 'Escape' && closeModal()}
+    onclick={(e) => e.target === e.currentTarget && closeModal()}
+    onkeydown={(e) => e.key === 'Escape' && closeModal()}
   >
     <div
       class="modal modal-{size}"
@@ -34,7 +34,7 @@
     >
       <div class="modal-header">
         <h3 class="modal-title">{title}</h3>
-        <button class="modal-close" on:click={closeModal}>
+        <button class="modal-close" onclick={closeModal}>
           <X size={18} />
         </button>
       </div>

--- a/frontend/src/lib/components/NoteCard.svelte
+++ b/frontend/src/lib/components/NoteCard.svelte
@@ -63,7 +63,7 @@
   class="note-card"
   class:active
   class:bulk-selected={selected}
-  on:click={() => bulkMode ? dispatch('toggleSelect', note.id) : dispatch('select', note)}
+  onclick={() => bulkMode ? dispatch('toggleSelect', note.id) : dispatch('select', note)}
 >
   <div class="note-header">
     {#if bulkMode}
@@ -71,15 +71,15 @@
         type="checkbox"
         class="note-checkbox"
         checked={selected}
-        on:click|stopPropagation
-        on:change={() => dispatch('toggleSelect', note.id)}
+        onclick={(e) => e.stopPropagation()}
+        onchange={() => dispatch('toggleSelect', note.id)}
       />
     {/if}
     <div class="note-icon"><DynamicIcon name={meta.icon} size={12} color={meta.color} pack={meta.pack} /></div>
     <span class="note-title truncate">{note.title}</span>
     <span class="note-date caption">{formatDate(note.created_at)}</span>
     {#if !bulkMode}
-      <button type="button" class="note-settings-btn" title="Personalizar" on:click={onCustomize}>
+      <button type="button" class="note-settings-btn" title="Personalizar" onclick={onCustomize}>
         <Settings size={10} />
       </button>
     {/if}
@@ -87,7 +87,7 @@
   {#if showTags && note.tags.length > 0}
     <div class="note-tags">
       {#each note.tags.slice(0, 4) as tag}
-        <TagChip {tag} on:click={(e) => {
+        <TagChip {tag} onclick={(e) => {
           const linkedNote = findNoteByTitle(e.detail);
           if (linkedNote) {
             goto(`/notes?id=${linkedNote.id}`);

--- a/frontend/src/lib/components/NoteSearch.svelte
+++ b/frontend/src/lib/components/NoteSearch.svelte
@@ -28,7 +28,7 @@
       bind:value={searchInput}
     />
     {#if searchInput || $noteSearchTag}
-      <button class="clear-btn" on:click={clearSearch}>✕</button>
+      <button class="clear-btn" onclick={clearSearch}>✕</button>
     {/if}
   </div>
 
@@ -37,7 +37,7 @@
       <button
         class="tag-chip"
         class:active={$noteSearchTag === null}
-        on:click={() => noteSearchTag.set(null)}
+        onclick={() => noteSearchTag.set(null)}
       >
         Todo
       </button>
@@ -45,7 +45,7 @@
         <button
           class="tag-chip"
           class:active={$noteSearchTag === tag}
-          on:click={() => noteSearchTag.set($noteSearchTag === tag ? null : tag)}
+          onclick={() => noteSearchTag.set($noteSearchTag === tag ? null : tag)}
         >
           {tag}
         </button>

--- a/frontend/src/lib/components/PomodoroWidget.svelte
+++ b/frontend/src/lib/components/PomodoroWidget.svelte
@@ -65,11 +65,11 @@
   </div>
 
   <div class="controls-row">
-    <button class="ctrl-main" class:active={$running} on:click={toggleTimer}>
+    <button class="ctrl-main" class:active={$running} onclick={toggleTimer}>
       {$running ? 'Pausar' : 'Iniciar'}
     </button>
-    <button class="ctrl-icon" on:click={resetTimer} title="Reiniciar"><RotateCcw size={11}/></button>
-    <button class="ctrl-icon" on:click={skipTimer}  title="Saltar"><SkipForward size={11}/></button>
+    <button class="ctrl-icon" onclick={resetTimer} title="Reiniciar"><RotateCcw size={11}/></button>
+    <button class="ctrl-icon" onclick={skipTimer}  title="Saltar"><SkipForward size={11}/></button>
   </div>
 
   <div class="duration-row">

--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -336,15 +336,15 @@
   }
 </script>
 
-<svelte:window on:keydown={onKeydown} />
+<svelte:window onkeydown={onKeydown} />
 
 {#if open}
   <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-  <div class="backdrop" on:click={onBackdropClick}>
+  <div class="backdrop" onclick={onBackdropClick}>
     <div class="panel">
       <div class="panel-header">
         <span class="mono" style="font-size:12px; letter-spacing:0.08em;">AJUSTES</span>
-        <button class="close-btn" on:click={close}><DynamicIcon name="X" size={14} /></button>
+        <button class="close-btn" onclick={close}><DynamicIcon name="X" size={14} /></button>
       </div>
 
       <div class="panel-body">
@@ -357,7 +357,7 @@
               {#if $darkMode}<DynamicIcon name="Moon" size={13} />{:else}<DynamicIcon name="Sun" size={13} />{/if}
               <span>Tema</span>
             </div>
-            <button class="toggle" on:click={toggleTheme}>
+            <button class="toggle" onclick={toggleTheme}>
               <span class:active={$darkMode}>oscuro</span>
               <span class="divider">|</span>
               <span class:active={!$darkMode}>claro</span>
@@ -369,7 +369,7 @@
               <DynamicIcon name="Clock3" size={13} />
               <span>Formato de hora</span>
             </div>
-            <button class="toggle" on:click={() => use24HourClock.toggle()}>
+            <button class="toggle" onclick={() => use24HourClock.toggle()}>
               <span class:active={$use24HourClock}>24h</span>
               <span class="sep">/</span>
               <span class:active={!$use24HourClock}>12h</span>
@@ -381,7 +381,7 @@
           <div 
             class="gradient-preview" 
             style="background: {gradientPreview}; cursor: grab;"
-            on:mousedown={onGradientMouseDown}
+            onmousedown={onGradientMouseDown}
             class:dragging={isDragging}
           ></div>
           <p class="color-limit-note mono">Máximo {MAX_COLORS} colores</p>
@@ -395,18 +395,18 @@
                   type="color"
                   class="color-swatch"
                   value={color}
-                  on:input={(e) => onColorPicker(i, e)}
+                  oninput={(e) => onColorPicker(i, e)}
                 />
                 <input
                   type="text"
                   class="hex-input mono"
                   maxlength="7"
                   value={color}
-                  on:input={(e) => onHex(i, e)}
+                  oninput={(e) => onHex(i, e)}
                   placeholder="#c8a96e"
                 />
                 {#if $accentColors.length > 1}
-                  <button class="color-rm" on:click={() => accentColors.removeColor(i)} title="Quitar">
+                  <button class="color-rm" onclick={() => accentColors.removeColor(i)} title="Quitar">
                     <DynamicIcon name="Minus" size={10} />
                   </button>
                 {/if}
@@ -415,7 +415,7 @@
           </div>
 
           {#if $accentColors.length < MAX_COLORS}
-            <button class="add-color-btn mono" on:click={() => accentColors.addColor()}>
+            <button class="add-color-btn mono" onclick={() => accentColors.addColor()}>
               <DynamicIcon name="Plus" size={10} /> agregar color
             </button>
           {/if}
@@ -443,7 +443,7 @@
               <DynamicIcon name="Code" size={13} />
               <span>Metadatos (YAML)</span>
             </div>
-            <button class="toggle" on:click={() => showFrontmatter.toggle()}>
+            <button class="toggle" onclick={() => showFrontmatter.toggle()}>
               <span class:active={!$showFrontmatter}>oculto</span>
               <span class="sep">/</span>
               <span class:active={$showFrontmatter}>visible</span>
@@ -455,7 +455,7 @@
               <DynamicIcon name="EyeOff" size={13} />
               <span>Carpetas Ocultas</span>
             </div>
-            <button class="toggle" on:click={() => showHiddenFiles.toggle()}>
+            <button class="toggle" onclick={() => showHiddenFiles.toggle()}>
               <span class:active={!$showHiddenFiles}>oculto</span>
               <span class="sep">/</span>
               <span class:active={$showHiddenFiles}>visible</span>
@@ -467,7 +467,7 @@
               <DynamicIcon name="Trash2" size={13} />
               <span>Mostrar Papelera</span>
             </div>
-            <button class="toggle" on:click={() => showTrash.toggle()}>
+            <button class="toggle" onclick={() => showTrash.toggle()}>
               <span class:active={!$showTrash}>oculto</span>
               <span class="sep">/</span>
               <span class:active={$showTrash}>visible</span>
@@ -479,7 +479,7 @@
               <DynamicIcon name="Tag" size={13} />
               <span>Línea de Etiquetas</span>
             </div>
-            <button class="toggle" on:click={() => hideTagsLine.toggle()}>
+            <button class="toggle" onclick={() => hideTagsLine.toggle()}>
               <span class:active={$hideTagsLine}>oculta</span>
               <span class="sep">/</span>
               <span class:active={!$hideTagsLine}>visible</span>
@@ -517,7 +517,7 @@
               <DynamicIcon name="FolderRoot" size={13} />
               <span>Escribir en Vault nativo</span>
             </div>
-            <button class="toggle" on:click={() => writeInObsidian.toggle()}>
+            <button class="toggle" onclick={() => writeInObsidian.toggle()}>
               <span class:active={!$writeInObsidian}>aislado</span>
               <span class="sep">/</span>
               <span class:active={$writeInObsidian}>nativo</span>
@@ -553,10 +553,10 @@
             {:else if githubConnected}
               <div style="display:flex; align-items:center; gap:8px;">
                 <span class="mono" style="font-size:12px; color: var(--xp);">{githubUsername}</span>
-                <button class="link-btn" on:click={disconnectGithub} style="background:var(--border); color:var(--text-secondary);">Desconectar</button>
+                <button class="link-btn" onclick={disconnectGithub} style="background:var(--border); color:var(--text-secondary);">Desconectar</button>
               </div>
             {:else}
-              <button class="link-btn" on:click={startGithubAuth} disabled={githubAuthLoading}>Enlazar</button>
+              <button class="link-btn" onclick={startGithubAuth} disabled={githubAuthLoading}>Enlazar</button>
             {/if}
           </div>
           {#if githubAuthLoading && githubUserCode}
@@ -637,7 +637,7 @@
             </div>
             <div class="row" style="flex-direction: column; align-items: stretch; gap: 8px;">
               <p class="hint" style="margin-top: 0;">Instala Joidy en tu dispositivo para acceso rápido y sin conexión.</p>
-              <button class="save-config-btn" style="background: var(--xp);" on:click={async () => {
+              <button class="save-config-btn" style="background: var(--xp);" onclick={async () => {
                 $deferredPrompt.prompt();
                 const { outcome } = await $deferredPrompt.userChoice;
                 if (outcome === 'accepted') {
@@ -707,7 +707,7 @@
               <DynamicIcon name="Wrench" size={13} />
               <span>Modo Desarrollo</span>
             </div>
-            <button class="toggle" on:click={() => devMode.toggle()}>
+            <button class="toggle" onclick={() => devMode.toggle()}>
               <span class:active={!$devMode}>off</span>
               <span class="sep">/</span>
               <span class:active={$devMode}>on</span>
@@ -723,7 +723,7 @@
       <div class="panel-footer">
         <button
           class="save-config-btn fixed-save"
-          on:click={saveConfig}
+          onclick={saveConfig}
           disabled={configSaving}
         >
           {#if configSaving}

--- a/frontend/src/lib/components/SetupWizard.svelte
+++ b/frontend/src/lib/components/SetupWizard.svelte
@@ -47,14 +47,14 @@
         </div>
         <h2 class="title">¡Bienvenido a Joidy!</h2>
         <p class="desc">Parece que es tu primera vez aquí. Vamos a realizar una configuración rápida para asegurar tu sistema antes de comenzar.</p>
-        <button class="btn btn-primary" on:click={() => step = 2}>Comenzar Setup</button>
+        <button class="btn btn-primary" onclick={() => step = 2}>Comenzar Setup</button>
       </div>
     {:else if step === 2}
       <div class="step-content slide-in">
         <h2 class="title">Asegura tu sistema</h2>
         <p class="desc">Define una contraseña maestra. Esta será la única forma de acceder a Joidy.</p>
         
-        <form on:submit|preventDefault={() => { if(password && confirmPassword) step = 3; }}>
+        <form onsubmit={(e) => { e.preventDefault(); if(password && confirmPassword) step = 3; }}>
           <div class="field">
             <label for="pwd">Contraseña Maestra</label>
             <input id="pwd" type="password" bind:value={password} class="input" required autofocus />
@@ -65,7 +65,7 @@
           </div>
           
           <div class="actions">
-            <button type="button" class="btn btn-ghost" on:click={() => step = 1}>Atrás</button>
+            <button type="button" class="btn btn-ghost" onclick={() => step = 1}>Atrás</button>
             <button type="submit" class="btn btn-primary" disabled={!password || !confirmPassword}>Siguiente</button>
           </div>
         </form>
@@ -75,14 +75,14 @@
         <h2 class="title">Conecta tu Vault (Opcional)</h2>
         <p class="desc">Si usas Obsidian, introduce la ruta absoluta a tu bóveda. Si no, déjalo en blanco y Joidy usará su almacenamiento interno.</p>
         
-        <form on:submit|preventDefault={handleSetup}>
+        <form onsubmit={(e) => { e.preventDefault(); handleSetup(); }}>
           <div class="field">
             <label for="vault">Ruta Absoluta (Ej. home/user/Documents/Vault)</label>
             <input id="vault" type="text" bind:value={vaultPath} class="input mono" placeholder="home/usuario/Documents/Vault" />
           </div>
           
           <div class="actions">
-            <button type="button" class="btn btn-ghost" on:click={() => step = 2} disabled={loading}>Atrás</button>
+            <button type="button" class="btn btn-ghost" onclick={() => step = 2} disabled={loading}>Atrás</button>
             <button type="submit" class="btn btn-primary" disabled={loading}>
               {loading ? 'Guardando...' : 'Finalizar Configuración'}
             </button>

--- a/frontend/src/lib/components/StreakCreateModal.svelte
+++ b/frontend/src/lib/components/StreakCreateModal.svelte
@@ -185,14 +185,14 @@
   }
 </script>
 
-<svelte:window on:keydown={onKey} />
+<svelte:window onkeydown={onKey} />
 
 {#if open}
-  <div class="modal-backdrop" on:click={onBackdrop}>
+  <div class="modal-backdrop" onclick={onBackdrop}>
     <div class="modal-panel">
       <div class="modal-header">
         <span class="modal-title mono">{isEdit ? 'EDITAR RACHA' : 'NUEVA RACHA'}</span>
-        <button class="close-btn" on:click={close}><X size={14} /></button>
+        <button class="close-btn" onclick={close}><X size={14} /></button>
       </div>
 
       <div class="modal-body">
@@ -223,10 +223,10 @@
         <div class="field">
           <label>Frecuencia</label>
           <div class="freq-row">
-            <button class="freq-btn" class:selected={frequency === 'daily'} on:click={() => { frequency = 'daily'; frequencyDays = 1; }}>Diaria</button>
-            <button class="freq-btn" class:selected={frequency === 'weekly'} on:click={() => { frequency = 'weekly'; frequencyDays = 1; }}>Semanal</button>
-            <button class="freq-btn" class:selected={frequency === 'monthly'} on:click={() => { frequency = 'monthly'; frequencyDays = 1; }}>Mensual</button>
-            <button class="freq-btn" class:selected={frequency === 'every_n'} on:click={() => { frequency = 'every_n'; }}>cada N</button>
+            <button class="freq-btn" class:selected={frequency === 'daily'} onclick={() => { frequency = 'daily'; frequencyDays = 1; }}>Diaria</button>
+            <button class="freq-btn" class:selected={frequency === 'weekly'} onclick={() => { frequency = 'weekly'; frequencyDays = 1; }}>Semanal</button>
+            <button class="freq-btn" class:selected={frequency === 'monthly'} onclick={() => { frequency = 'monthly'; frequencyDays = 1; }}>Mensual</button>
+            <button class="freq-btn" class:selected={frequency === 'every_n'} onclick={() => { frequency = 'every_n'; }}>cada N</button>
           </div>
         </div>
 
@@ -241,8 +241,8 @@
         <div class="field">
           <label>Icono</label>
           <div class="icon-toggle-row">
-            <button class="icon-type-btn" class:selected={!useIcon} on:click={() => useIcon = false}>Emoji</button>
-            <button class="icon-type-btn" class:selected={useIcon} on:click={() => { useIcon = true; if (!icon) icon = 'Flame'; }}>Icono</button>
+            <button class="icon-type-btn" class:selected={!useIcon} onclick={() => useIcon = false}>Emoji</button>
+            <button class="icon-type-btn" class:selected={useIcon} onclick={() => { useIcon = true; if (!icon) icon = 'Flame'; }}>Icono</button>
           </div>
         </div>
 
@@ -250,7 +250,7 @@
           <div class="field">
             <div class="emoji-grid">
               {#each EMOJIS as e}
-                <button class="emoji-btn" class:selected={emoji === e} on:click={() => emoji = e}>{e}</button>
+                <button class="emoji-btn" class:selected={emoji === e} onclick={() => emoji = e}>{e}</button>
               {/each}
             </div>
           </div>
@@ -268,7 +268,7 @@
                 class="color-btn"
                 class:selected={color === c.hex}
                 style="--btn-color: {c.hex}; background: {c.hex};"
-                on:click={() => color = c.hex}
+                onclick={() => color = c.hex}
               />
             {/each}
           </div>
@@ -278,7 +278,7 @@
           <label>Tema visual</label>
           <div class="theme-grid">
             {#each THEMES as t}
-              <button class="theme-btn" class:selected={theme === t.id} on:click={() => theme = t.id}>
+              <button class="theme-btn" class:selected={theme === t.id} onclick={() => theme = t.id}>
                 {t.label}
               </button>
             {/each}
@@ -312,13 +312,13 @@
 
       <div class="modal-footer" class:theme-sketch={theme === 'sketch'} class:theme-glow={theme === 'glow'} class:theme-gradient={theme === 'gradient'} class:theme-neon={theme === 'neon'}>
         {#if isEdit}
-          <button class="btn-archive" on:click={archive} title={editStreak?.is_archived ? 'Desarchivar racha' : 'Archivar racha'}>
+          <button class="btn-archive" onclick={archive} title={editStreak?.is_archived ? 'Desarchivar racha' : 'Archivar racha'}>
             <Archive size={14} />
             {editStreak?.is_archived ? 'Desarchivar' : 'Archivar'}
           </button>
         {/if}
-        <button class="btn-cancel" on:click={close}>Cancelar</button>
-        <button class="btn-save" disabled={!canSave} on:click={save} style="--btn-color: {color};">
+        <button class="btn-cancel" onclick={close}>Cancelar</button>
+        <button class="btn-save" disabled={!canSave} onclick={save} style="--btn-color: {color};">
           {isEdit ? 'Actualizar' : 'Crear Racha'}
         </button>
       </div>

--- a/frontend/src/lib/components/StreakListItem.svelte
+++ b/frontend/src/lib/components/StreakListItem.svelte
@@ -33,7 +33,7 @@
 >
   <button
     class="streak-item-main"
-    on:click={() => dispatch('select', streak.id)}
+    onclick={() => dispatch('select', streak.id)}
     aria-label="Seleccionar racha: {streak.name}"
   >
     <div class="item-icon">
@@ -68,7 +68,7 @@
   <div class="item-actions">
     <button
       class="item-action-btn"
-      on:click|stopPropagation={() => dispatch('edit', streak)}
+      onclick={(e) => { e.stopPropagation(); dispatch('edit', streak); }}
       title="Editar racha"
       aria-label="Editar racha: {streak.name}"
     >
@@ -76,7 +76,7 @@
     </button>
     <button
       class="item-action-btn danger"
-      on:click|stopPropagation={() => dispatch('delete', streak.id)}
+      onclick={(e) => { e.stopPropagation(); dispatch('delete', streak.id); }}
       title="Eliminar racha"
       aria-label="Eliminar racha: {streak.name}"
     >

--- a/frontend/src/lib/components/StreakListPanel.svelte
+++ b/frontend/src/lib/components/StreakListPanel.svelte
@@ -60,13 +60,13 @@
         <button
           class="header-action-btn"
           class:active={showArchived}
-          on:click={onToggleArchive}
+          onclick={onToggleArchive}
           title={showArchived ? 'Volver a activas' : 'Ver archivadas'}
           aria-label={showArchived ? 'Volver a rachas activas' : 'Ver rachas archivadas'}
         >
           <Archive size={13} />
         </button>
-        <button class="new-btn" on:click={onCreate} aria-label="Crear nueva racha">
+        <button class="new-btn" onclick={onCreate} aria-label="Crear nueva racha">
           <Plus size={13} />
         </button>
       </div>
@@ -91,7 +91,7 @@
       <div class="empty-state">
         <Flame size={24} style="opacity:.25; margin-bottom:8px;" />
         <p>No hay rachas. ¡Crea una para comenzar!</p>
-        <button class="link-btn" on:click={onCreate}>Crear una nueva</button>
+        <button class="link-btn" onclick={onCreate}>Crear una nueva</button>
       </div>
     {:else}
       {#each filteredStreaks as streak (streak.id)}

--- a/frontend/src/lib/components/TagChip.svelte
+++ b/frontend/src/lib/components/TagChip.svelte
@@ -34,8 +34,8 @@
 <span 
   class="tag-chip" 
   class:ai={isAI} 
-  on:click={handleClick}
-  on:keydown={handleKeydown}
+  onclick={handleClick}
+  onkeydown={handleKeydown}
   role="button"
   tabindex="0"
 >
@@ -44,7 +44,7 @@
     <span class="ai-badge" title="Sugerencia de IA">ia</span>
   {/if}
   {#if removable}
-    <button on:click={handleRemove} aria-label="Eliminar etiqueta {displayTagName(tag)}">×</button>
+    <button onclick={handleRemove} aria-label="Eliminar etiqueta {displayTagName(tag)}">×</button>
   {/if}
 </span>
 

--- a/frontend/src/lib/components/ThemePicker.svelte
+++ b/frontend/src/lib/components/ThemePicker.svelte
@@ -9,7 +9,7 @@
       <button
         class="theme-btn"
         class:active={$theme.id === t.id}
-        on:click={() => theme.setTheme(t)}
+        onclick={() => theme.setTheme(t)}
         title={t.name}
       >
         <div class="theme-preview">

--- a/frontend/src/lib/components/TimeWidget.svelte
+++ b/frontend/src/lib/components/TimeWidget.svelte
@@ -104,7 +104,7 @@
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions -->
-<svelte:window on:keydown={(e) => e.key === 'Escape' && (showTzPicker = false)} />
+<svelte:window onkeydown={(e) => e.key === 'Escape' && (showTzPicker = false)} />
 
 <div class="time-widget">
   <div class="clock-row">
@@ -115,21 +115,21 @@
             class="tz-input mono"
             bind:value={tzInput}
             placeholder="Chile, Europe/Madrid, UTC..."
-            on:keydown={(e) => e.key === 'Enter' && applyTzInput()}
+            onkeydown={(e) => e.key === 'Enter' && applyTzInput()}
             autofocus
           />
-          <button class="tz-close-ui" on:click={() => showTzPicker = false} title="Cerrar">✕</button>
+          <button class="tz-close-ui" onclick={() => showTzPicker = false} title="Cerrar">✕</button>
         </div>
         {#if tzError}<span class="tz-error">{tzError}</span>{/if}
         <div class="tz-presets">
           {#each TZ_PRESETS as [label, tz]}
-            <button class="tz-preset mono" on:click={() => setTimezone(tz)}>{label}</button>
+            <button class="tz-preset mono" onclick={() => setTimezone(tz)}>{label}</button>
           {/each}
         </div>
       </div>
     {:else}
       <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <span class="clock mono" on:click={() => showTzPicker = true} title="Cambiar zona horaria">
+      <span class="clock mono" onclick={() => showTzPicker = true} title="Cambiar zona horaria">
         {clockStr}
       </span>
     {/if}

--- a/frontend/src/lib/components/Toast.svelte
+++ b/frontend/src/lib/components/Toast.svelte
@@ -10,7 +10,7 @@
       <button 
         class="toast toast-{notif.type}"
         transition:fly={{ y: -20, duration: 200 }}
-        on:click={() => dismissNotification(notif.id)}
+        onclick={() => dismissNotification(notif.id)}
       >
         <DynamicIcon 
           name={notif.type === 'success' ? 'CheckCircle' : notif.type === 'level' ? 'TrendingUp' : notif.type === 'error' ? 'AlertTriangle' : 'Info'} 

--- a/frontend/src/lib/components/TreeContextMenu.svelte
+++ b/frontend/src/lib/components/TreeContextMenu.svelte
@@ -58,26 +58,26 @@
   });
 </script>
 
-<div class="ctx-menu" bind:this={menuEl} style={style} on:click|stopPropagation on:contextmenu|stopPropagation>
+<div class="ctx-menu" bind:this={menuEl} style={style} onclick={(e) => e.stopPropagation()} oncontextmenu={(e) => e.stopPropagation()}>
   {#if node.type === 'file'}
-    <button class="ctx-item" on:click={handleItem('rename')}>
+    <button class="ctx-item" onclick={handleItem('rename')}>
       <Edit size={12} /> Renombrar
     </button>
-    <button class="ctx-item" on:click={handleItem('move')}>
+    <button class="ctx-item" onclick={handleItem('move')}>
       <MoveRight size={12} /> Mover a...
     </button>
     <div class="ctx-divider"></div>
-    <button class="ctx-item ctx-danger" on:click={handleItem('deleteNote')}>
+    <button class="ctx-item ctx-danger" onclick={handleItem('deleteNote')}>
       <Trash2 size={12} /> Eliminar
     </button>
   {:else}
-    <button class="ctx-item" on:click={handleItem('newNoteInFolder')}>
+    <button class="ctx-item" onclick={handleItem('newNoteInFolder')}>
       <FilePlus size={12} /> Nueva nota aquí
     </button>
-    <button class="ctx-item" on:click={handleItem('rename')}>
+    <button class="ctx-item" onclick={handleItem('rename')}>
       <Edit size={12} /> Renombrar
     </button>
-    <button class="ctx-item ctx-danger" on:click={handleItem('deleteFolder')}>
+    <button class="ctx-item ctx-danger" onclick={handleItem('deleteFolder')}>
       <FolderX size={12} /> Eliminar carpeta
     </button>
   {/if}

--- a/frontend/src/lib/components/TutorialOverlay.svelte
+++ b/frontend/src/lib/components/TutorialOverlay.svelte
@@ -15,7 +15,7 @@
         <div class="progress-fill" style="width: {progress}%"></div>
       </div>
 
-      <button class="skip-btn" on:click={() => onboarding.skip()}>
+      <button class="skip-btn" onclick={() => onboarding.skip()}>
         Saltar
       </button>
 
@@ -35,14 +35,14 @@
 
       <div class="actions">
         {#if $onboarding.currentStep > 0}
-          <button class="btn btn-secondary" on:click={() => onboarding.prevStep()}>
+          <button class="btn btn-secondary" onclick={() => onboarding.prevStep()}>
             Anterior
           </button>
         {/if}
 
         <button
           class="btn btn-primary"
-          on:click={() => isLastStep ? onboarding.skip() : onboarding.nextStep()}
+          onclick={() => isLastStep ? onboarding.skip() : onboarding.nextStep()}
         >
           {isLastStep ? 'Comenzar' : 'Siguiente'}
         </button>

--- a/frontend/src/lib/components/VirtualList.svelte
+++ b/frontend/src/lib/components/VirtualList.svelte
@@ -124,7 +124,7 @@
   }
 </script>
 
-<div class="virtual-container" bind:this={containerEl} on:scroll={onScroll}>
+<div class="virtual-container" bind:this={containerEl} onscroll={onScroll}>
   <div class="virtual-spacer" style="height: {totalHeight}px;">
     <div class="virtual-content" style="transform: translateY({offsetY}px);">
       {#each visibleItems as item, i (getKey(item, startIndex + i))}

--- a/frontend/src/lib/components/WeatherWidget.svelte
+++ b/frontend/src/lib/components/WeatherWidget.svelte
@@ -140,7 +140,7 @@
       <span class="weather-icon">{getEmoji(weather.code, weather.isDay)}</span>
       <span class="weather-temp">{weather.temp}°</span>
       <span class="weather-location">{weather.location}</span>
-      <button class="weather-refresh" on:click={fetchWeather} title="Actualizar">↻</button>
+      <button class="weather-refresh" onclick={fetchWeather} title="Actualizar">↻</button>
     </div>
   {/if}
 </div>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -401,7 +401,7 @@
         <DynamicIcon name="DownloadCloud" size={13} />
         <span>Instala Joidy para acceso rápido</span>
         <div class="pwa-actions">
-          <button class="pwa-btn pwa-install" on:click={async () => {
+          <button class="pwa-btn pwa-install" onclick={async () => {
             if ($deferredPrompt) {
               $deferredPrompt.prompt();
               const { outcome } = await $deferredPrompt.userChoice;
@@ -411,7 +411,7 @@
               deferredPrompt.set(null);
             }
           }}>Instalar</button>
-          <button class="pwa-btn pwa-dismiss" on:click={() => {
+          <button class="pwa-btn pwa-dismiss" onclick={() => {
             showInstallBanner.set(false);
             localStorage.setItem('joidy-pwa-dismissed', 'true');
           }}>
@@ -450,7 +450,7 @@
       class="btn btn-ghost btn-icon"
       title="Ajustes"
       style="color: var(--text-muted);"
-      on:click={() => window.dispatchEvent(new CustomEvent('joidy:open-settings'))}
+      onclick={() => window.dispatchEvent(new CustomEvent('joidy:open-settings'))}
     >
       <DynamicIcon name="Settings" size={14} />
     </button>
@@ -481,7 +481,7 @@
 
   <!-- Status bar -->
   <footer class="app-statusbar">
-    <span style="color: var(--text-muted); cursor: pointer;" title="Click para notificación de prueba" on:click={() => { showNotification('Notificación de prueba - Info', 'info'); setTimeout(() => showNotification('Notificación de prueba - Success', 'success'), 600); setTimeout(() => showNotification('Notificación de prueba - Level up!', 'level'), 1200); }}>joidy v0.1</span>
+    <span style="color: var(--text-muted); cursor: pointer;" title="Click para notificación de prueba" onclick={() => { showNotification('Notificación de prueba - Info', 'info'); setTimeout(() => showNotification('Notificación de prueba - Success', 'success'), 600); setTimeout(() => showNotification('Notificación de prueba - Level up!', 'level'), 1200); }}>joidy v0.1</span>
 
     <div class="status-live" title="Estado actual">
       <span class="status-pill status-time mono">{currentTime}</span>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -284,9 +284,9 @@
           <div class="widget-centered">
             <!-- Module navigation -->
             <div class="module-nav">
-              <button class="nav-arrow" on:click={prevModule} title="Anterior"><DynamicIcon name="ChevronLeft" size={14}/></button>
+              <button class="nav-arrow" onclick={prevModule} title="Anterior"><DynamicIcon name="ChevronLeft" size={14}/></button>
               <span class="module-label mono">{MODULES[moduleIdx].label.toUpperCase()}</span>
-              <button class="nav-arrow" on:click={nextModule} title="Siguiente"><DynamicIcon name="ChevronRight" size={14}/></button>
+              <button class="nav-arrow" onclick={nextModule} title="Siguiente"><DynamicIcon name="ChevronRight" size={14}/></button>
             </div>
 
             <!-- Module viewport -->
@@ -313,7 +313,7 @@
               {#each MODULES as _, idx}
                 <button
                   class="dot" class:active={idx === moduleIdx}
-                  on:click={() => { slideDir = idx > moduleIdx ? 1 : -1; moduleIdx = idx; }}
+                  onclick={() => { slideDir = idx > moduleIdx ? 1 : -1; moduleIdx = idx; }}
                   aria-label={MODULES[idx].label}
                 ></button>
               {/each}
@@ -442,9 +442,9 @@
         {:else if wid === 'plant-carousel'}
           <div class="widget-centered">
             <div class="module-nav">
-              <button class="nav-arrow" on:click={prevModule}><DynamicIcon name="ChevronLeft" size={14}/></button>
+              <button class="nav-arrow" onclick={prevModule}><DynamicIcon name="ChevronLeft" size={14}/></button>
               <span class="module-label mono">{MODULES[moduleIdx].label.toUpperCase()}</span>
-              <button class="nav-arrow" on:click={nextModule}><DynamicIcon name="ChevronRight" size={14}/></button>
+              <button class="nav-arrow" onclick={nextModule}><DynamicIcon name="ChevronRight" size={14}/></button>
             </div>
             <div class="module-viewport">
               {#key moduleIdx}

--- a/frontend/src/routes/goals/[id]/+page.svelte
+++ b/frontend/src/routes/goals/[id]/+page.svelte
@@ -198,8 +198,8 @@
 </div>
 
 {#if showSettings}
-  <div class="goal-settings-backdrop" on:click={() => showSettings = false} role="dialog" tabindex="-1">
-    <div class="goal-settings-panel slide-down" on:click|stopPropagation>
+  <div class="goal-settings-backdrop" onclick={() => showSettings = false} role="dialog" tabindex="-1">
+    <div class="goal-settings-panel slide-down" onclick={(e) => e.stopPropagation()}>
       <div class="goal-settings-header">
         <div class="goal-settings-title-row">
           <div class="goal-settings-icon-wrap">
@@ -210,14 +210,14 @@
             <span class="goal-settings-sub">Ajusta los detalles de este objetivo</span>
           </div>
         </div>
-        <button class="history-close-btn" on:click={() => showSettings = false} title="Cerrar">×</button>
+        <button class="history-close-btn" onclick={() => showSettings = false} title="Cerrar">×</button>
       </div>
 
       <div class="goal-settings-body">
         <div class="ng-tabs-container">
-          <button class="ng-tab" class:active={settingsSection === 'basics'} on:click={() => settingsSection = 'basics'}>Basico</button>
-          <button class="ng-tab" class:active={settingsSection === 'appearance'} on:click={() => settingsSection = 'appearance'}>Apariencia</button>
-          <button class="ng-tab" class:active={settingsSection === 'advanced'} on:click={() => settingsSection = 'advanced'}>Avanzado</button>
+          <button class="ng-tab" class:active={settingsSection === 'basics'} onclick={() => settingsSection = 'basics'}>Basico</button>
+          <button class="ng-tab" class:active={settingsSection === 'appearance'} onclick={() => settingsSection = 'appearance'}>Apariencia</button>
+          <button class="ng-tab" class:active={settingsSection === 'advanced'} onclick={() => settingsSection = 'advanced'}>Avanzado</button>
         </div>
 
         <div class="ng-content-area">
@@ -235,7 +235,7 @@
                 <label class="label">Frecuencia</label>
                 <div class="ng-freq-grid">
                   {#each TEMPORALITIES as temp}
-                    <button class="ng-freq-btn" class:active={editTemporality === temp} on:click={() => editTemporality = temp}>
+                    <button class="ng-freq-btn" class:active={editTemporality === temp} onclick={() => editTemporality = temp}>
                       {temp === 'DAILY' ? 'Diario' : temp === 'WEEKLY' ? 'Semanal' : temp === 'MONTHLY' ? 'Mensual' : 'Anual'}
                     </button>
                   {/each}
@@ -250,14 +250,14 @@
                 <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:8px;">
                   <label class="label" style="margin:0;">Icono / Emoji de Fallo</label>
                   <div class="icon-toggle-row">
-                    <button class="icon-type-btn" class:selected={!editUseFailIcon} on:click={() => editUseFailIcon = false}>Emoji</button>
-                    <button class="icon-type-btn" class:selected={editUseFailIcon} on:click={() => editUseFailIcon = true}>Icono</button>
+                    <button class="icon-type-btn" class:selected={!editUseFailIcon} onclick={() => editUseFailIcon = false}>Emoji</button>
+                    <button class="icon-type-btn" class:selected={editUseFailIcon} onclick={() => editUseFailIcon = true}>Icono</button>
                   </div>
                 </div>
                 {#if !editUseFailIcon}
                   <div class="emoji-grid ng-large-grid">
                     {#each EMOJIS as e}
-                      <button class="emoji-btn" class:selected={editFailEmoji === e} on:click={() => editFailEmoji = e}>{e}</button>
+                      <button class="emoji-btn" class:selected={editFailEmoji === e} onclick={() => editFailEmoji = e}>{e}</button>
                     {/each}
                   </div>
                 {:else}
@@ -271,7 +271,7 @@
                 <label class="label">Color de Identidad</label>
                 <div class="color-presets ng-expanded-presets">
                   {#each COLOR_PRESETS as c}
-                    <button class="color-dot" class:selected={editColor === c.hex} style="background: {c.hex}; color: {c.hex};" on:click={() => editColor = c.hex}></button>
+                    <button class="color-dot" class:selected={editColor === c.hex} style="background: {c.hex}; color: {c.hex};" onclick={() => editColor = c.hex}></button>
                   {/each}
                   <div class="color-custom" style="background: {editColor};">
                     <input type="color" bind:value={editColor} class="color-picker" />
@@ -305,15 +305,15 @@
               <div class="form-field adv-fail">
                 <label class="label">Politica de fallo</label>
                 <div class="ng-fail-options">
-                  <button class="ng-fail-btn" class:active={editFailConfig === 'STATIC'} on:click={() => editFailConfig = 'STATIC'}>
+                  <button class="ng-fail-btn" class:active={editFailConfig === 'STATIC'} onclick={() => editFailConfig = 'STATIC'}>
                     <strong>Estatico</strong>
                     <span>Se reinicia a cero cada periodo</span>
                   </button>
-                  <button class="ng-fail-btn" class:active={editFailConfig === 'ROLLOVER'} on:click={() => editFailConfig = 'ROLLOVER'}>
+                  <button class="ng-fail-btn" class:active={editFailConfig === 'ROLLOVER'} onclick={() => editFailConfig = 'ROLLOVER'}>
                     <strong>Traspaso</strong>
                     <span>La meta pendiente pasa al siguiente dia</span>
                   </button>
-                  <button class="ng-fail-btn" class:active={editFailConfig === 'SNOWBALL'} on:click={() => editFailConfig = 'SNOWBALL'}>
+                  <button class="ng-fail-btn" class:active={editFailConfig === 'SNOWBALL'} onclick={() => editFailConfig = 'SNOWBALL'}>
                     <strong>Acumulativo</strong>
                     <span>La deuda se acumula exponencialmente</span>
                   </button>
@@ -369,8 +369,8 @@
       <div class="goal-settings-footer">
         <span></span>
         <div class="new-goal-actions">
-          <button class="btn btn-ghost" on:click={() => showSettings = false}>Cancelar</button>
-          <button class="btn btn-primary" on:click={saveSettings} disabled={savingSettings || !editTitle.trim()}>
+          <button class="btn btn-ghost" onclick={() => showSettings = false}>Cancelar</button>
+          <button class="btn btn-primary" onclick={saveSettings} disabled={savingSettings || !editTitle.trim()}>
             {savingSettings ? 'Guardando...' : 'Guardar cambios'}
           </button>
         </div>

--- a/frontend/src/routes/graph/+page.svelte
+++ b/frontend/src/routes/graph/+page.svelte
@@ -47,7 +47,7 @@
       </span>
     </div>
     {#if $selectedTag !== null}
-      <button class="btn btn-ghost" on:click={() => selectedTag.set(null)}>
+      <button class="btn btn-ghost" onclick={() => selectedTag.set(null)}>
         Limpiar seleccion
       </button>
     {/if}

--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -587,7 +587,7 @@
   }
 </script>
 
-<svelte:window on:click={() => { if (showSortMenu) showSortMenu = false; }} on:keydown={(e) => e.key === 'Escape' && (deleteConfirm = false)} />
+<svelte:window onclick={() => { if (showSortMenu) showSortMenu = false; }} onkeydown={(e) => e.key === 'Escape' && (deleteConfirm = false)} />
 
 <div
   class="notes-page"
@@ -598,26 +598,26 @@
   <aside class="notes-list">
     <div class="tree-actions-bar">
       <div class="actions-left">
-        <button class="icon-btn" title="Crear nota" on:click={openNew}><FileEdit size={13} /></button>
-        <button class="icon-btn" title="Crear carpeta" on:click={handleCreateFolder}><FolderPlus size={13} /></button>
+        <button class="icon-btn" title="Crear nota" onclick={openNew}><FileEdit size={13} /></button>
+        <button class="icon-btn" title="Crear carpeta" onclick={handleCreateFolder}><FolderPlus size={13} /></button>
         <div class="sort-wrapper">
-          <button class="icon-btn" title="Cambiar orden" on:click|stopPropagation={() => showSortMenu = !showSortMenu}>
+          <button class="icon-btn" title="Cambiar orden" onclick={(e) => { e.stopPropagation(); showSortMenu = !showSortMenu; }}>
             <ArrowUpDown size={13} />
           </button>
           {#if showSortMenu}
-            <div class="sort-menu" on:click|stopPropagation>
-              <button class="sort-btn" class:active={sortMode==='az'} on:click={() => setSortMode('az')}>Ordenar por nombre (A-Z)</button>
-              <button class="sort-btn" class:active={sortMode==='za'} on:click={() => setSortMode('za')}>Ordenar por nombre (Z-A)</button>
+            <div class="sort-menu" onclick={(e) => e.stopPropagation()}>
+              <button class="sort-btn" class:active={sortMode==='az'} onclick={() => setSortMode('az')}>Ordenar por nombre (A-Z)</button>
+              <button class="sort-btn" class:active={sortMode==='za'} onclick={() => setSortMode('za')}>Ordenar por nombre (Z-A)</button>
               <div class="sort-divider"></div>
-              <button class="sort-btn" class:active={sortMode==='edit-new'} on:click={() => setSortMode('edit-new')}>Editar (más reciente) {#if sortMode==='edit-new'}✓{/if}</button>
-              <button class="sort-btn" class:active={sortMode==='edit-old'} on:click={() => setSortMode('edit-old')}>Editar (más antiguo) {#if sortMode==='edit-old'}✓{/if}</button>
+              <button class="sort-btn" class:active={sortMode==='edit-new'} onclick={() => setSortMode('edit-new')}>Editar (más reciente) {#if sortMode==='edit-new'}✓{/if}</button>
+              <button class="sort-btn" class:active={sortMode==='edit-old'} onclick={() => setSortMode('edit-old')}>Editar (más antiguo) {#if sortMode==='edit-old'}✓{/if}</button>
               <div class="sort-divider"></div>
-              <button class="sort-btn" class:active={sortMode==='create-new'} on:click={() => setSortMode('create-new')}>Creado (nuevo-antiguo) {#if sortMode==='create-new'}✓{/if}</button>
-              <button class="sort-btn" class:active={sortMode==='create-old'} on:click={() => setSortMode('create-old')}>Creado (antiguo-nuevo) {#if sortMode==='create-old'}✓{/if}</button>
+              <button class="sort-btn" class:active={sortMode==='create-new'} onclick={() => setSortMode('create-new')}>Creado (nuevo-antiguo) {#if sortMode==='create-new'}✓{/if}</button>
+              <button class="sort-btn" class:active={sortMode==='create-old'} onclick={() => setSortMode('create-old')}>Creado (antiguo-nuevo) {#if sortMode==='create-old'}✓{/if}</button>
             </div>
           {/if}
         </div>
-        <button class="icon-btn" title={allCollapsed ? "Expandir todo" : "Comprimir todo"} on:click={toggleCollapseAll}>
+        <button class="icon-btn" title={allCollapsed ? "Expandir todo" : "Comprimir todo"} onclick={toggleCollapseAll}>
           <ChevronsUpDown size={13} />
         </button>
       </div>
@@ -629,12 +629,12 @@
         <Search size={11} style="color: var(--text-muted); flex-shrink:0;" />
         <input class="search-input" bind:value={search} placeholder="Buscar..." />
         {#if search}
-          <button class="icon-btn" on:click={() => search = ''} title="Limpiar">
+          <button class="icon-btn" onclick={() => search = ''} title="Limpiar">
             <X size={10} />
           </button>
         {/if}
       </div>
-      <button class="toolbar-btn bulk-toggle" class:active={$bulkMode} on:click={() => { bulkMode.set(!$bulkMode); clearNoteSelection(); }}>
+      <button class="toolbar-btn bulk-toggle" class:active={$bulkMode} onclick={() => { bulkMode.set(!$bulkMode); clearNoteSelection(); }}>
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/></svg>
       </button>
     </div>
@@ -643,7 +643,7 @@
       <span>{ $bulkMode ? `${$selectedNoteIds.size} seleccionadas` : `${$notes.length} notas` }</span>
       {#if search}<span class="sep">·</span><span>{filtered.length} resultados</span>{/if}
       {#if $bulkMode}
-        <button class="toolbar-btn select-all" on:click={$selectedNoteIds.size === filtered.length ? clearNoteSelection : selectAllNotes}>
+        <button class="toolbar-btn select-all" onclick={$selectedNoteIds.size === filtered.length ? clearNoteSelection : selectAllNotes}>
           {$selectedNoteIds.size === filtered.length ? 'Deseleccionar todo' : 'Seleccionar todo'}
         </button>
       {/if}
@@ -652,25 +652,25 @@
     {#if $bulkMode && $selectedNoteIds.size > 0}
       <div class="bulk-actions">
         <span class="bulk-count">{$selectedNoteIds.size} nota{#if $selectedNoteIds.size !== 1}s{/if}</span>
-        <button class="bulk-btn danger" on:click={() => { if (confirm(`¿Eliminar ${$selectedNoteIds.size} nota(s)?`)) deleteSelectedNotes(); }}>
+        <button class="bulk-btn danger" onclick={() => { if (confirm(`¿Eliminar ${$selectedNoteIds.size} nota(s)?`)) deleteSelectedNotes(); }}>
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
           Eliminar
         </button>
-        <button class="bulk-btn" on:click={() => { const t = prompt('Tags a añadir (separadas por coma):'); if (t) tagSelectedNotes(t.split(',').map(s => s.trim()).filter(Boolean)); }}>
+        <button class="bulk-btn" onclick={() => { const t = prompt('Tags a añadir (separadas por coma):'); if (t) tagSelectedNotes(t.split(',').map(s => s.trim()).filter(Boolean)); }}>
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
           Etiquetar
         </button>
-        <button class="bulk-btn" on:click={() => { const t = prompt('Tags a quitar (separadas por coma):'); if (t) untagSelectedNotes(t.split(',').map(s => s.trim()).filter(Boolean)); }}>
+        <button class="bulk-btn" onclick={() => { const t = prompt('Tags a quitar (separadas por coma):'); if (t) untagSelectedNotes(t.split(',').map(s => s.trim()).filter(Boolean)); }}>
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
           Desetiquetar
         </button>
-        <button class="bulk-btn" on:click={() => clearNoteSelection()}>
+        <button class="bulk-btn" onclick={() => clearNoteSelection()}>
           Cancelar
         </button>
       </div>
     {/if}
 
-    <div class="list-scroll" bind:this={listScrollEl} on:scroll={onListScroll}>
+    <div class="list-scroll" bind:this={listScrollEl} onscroll={onListScroll}>
       {#if $notesLoading}
         <div class="empty-msg">Cargando...</div>
 
@@ -684,15 +684,15 @@
                 <div
                   class="tree-row folder-row"
                   style="padding-left: {8 + item.depth * 14}px"
-                  on:click={() => toggleFolder(item.path)}
-                  on:contextmenu={(e) => handleContextMenu(e, item)}
+                  onclick={() => toggleFolder(item.path)}
+                  oncontextmenu={(e) => handleContextMenu(e, item)}
                 >
                   <span class="chevron" class:open={!collapsed.has(item.path)}>
                     <ChevronRight size={11} />
                   </span>
                   <div class="t-icon"><DynamicIcon name={item.icon} size={13} color={item.color} pack={item.pack} /></div>
                   <span class="t-name folder-name">{item.name}</span>
-                  <button class="folder-settings-btn" title="Personalizar carpeta" on:click|stopPropagation={() => openFolderCustomizer(item)}>
+                  <button class="folder-settings-btn" title="Personalizar carpeta" onclick={(e) => { e.stopPropagation(); openFolderCustomizer(item); }}>
                     <Settings size={10} />
                   </button>
                   <span class="t-count">{item.childCount}</span>
@@ -703,12 +703,12 @@
                   class="tree-row file-row"
                   class:active={item.note?.id === selectedNote?.id}
                   style="padding-left: {20 + item.depth * 14}px"
-                  on:click={() => item.note && openNote(item.note)}
-                  on:contextmenu={(e) => handleContextMenu(e, item)}
+                  onclick={() => item.note && openNote(item.note)}
+                  oncontextmenu={(e) => handleContextMenu(e, item)}
                 >
                   <div class="t-icon file-icon"><DynamicIcon name={item.icon} size={11} color={item.color} pack={item.pack} /></div>
                   <span class="t-name file-name">{item.name}</span>
-                  <button class="folder-settings-btn" title="Personalizar nota" on:click|stopPropagation={() => openFolderCustomizer({ path: item.note?.source_path || item.path, icon: item.icon, color: item.color, note: item.note })}>
+                  <button class="folder-settings-btn" title="Personalizar nota" onclick={(e) => { e.stopPropagation(); openFolderCustomizer({ path: item.note?.source_path || item.path, icon: item.icon, color: item.color, note: item.note }); }}>
                     <Settings size={10} />
                   </button>
                 </div>
@@ -722,15 +722,15 @@
                 <div
                   class="tree-row folder-row"
                   style="padding-left: {8 + node.depth * 14}px"
-                  on:click={() => toggleFolder(node.path)}
-                  on:contextmenu={(e) => handleContextMenu(e, node)}
+                  onclick={() => toggleFolder(node.path)}
+                  oncontextmenu={(e) => handleContextMenu(e, node)}
                 >
                   <span class="chevron" class:open={!collapsed.has(node.path)}>
                     <ChevronRight size={11} />
                   </span>
                   <div class="t-icon"><DynamicIcon name={node.icon} size={13} color={node.color} pack={node.pack} /></div>
                   <span class="t-name folder-name">{node.name}</span>
-                  <button class="folder-settings-btn" title="Personalizar carpeta" on:click|stopPropagation={() => openFolderCustomizer(node)}>
+                  <button class="folder-settings-btn" title="Personalizar carpeta" onclick={(e) => { e.stopPropagation(); openFolderCustomizer(node); }}>
                     <Settings size={10} />
                   </button>
                   <span class="t-count">{node.childCount}</span>
@@ -741,12 +741,12 @@
                   class="tree-row file-row"
                   class:active={node.note?.id === selectedNote?.id}
                   style="padding-left: {20 + node.depth * 14}px"
-                  on:click={() => node.note && openNote(node.note)}
-                  on:contextmenu={(e) => handleContextMenu(e, node)}
+                  onclick={() => node.note && openNote(node.note)}
+                  oncontextmenu={(e) => handleContextMenu(e, node)}
                 >
                   <div class="t-icon file-icon"><DynamicIcon name={node.icon} size={11} color={node.color} pack={node.pack} /></div>
                   <span class="t-name file-name">{node.name}</span>
-                  <button class="folder-settings-btn" title="Personalizar nota" on:click|stopPropagation={() => openFolderCustomizer({ path: node.note?.source_path || node.path, icon: node.icon, color: node.color, note: node.note })}>
+                  <button class="folder-settings-btn" title="Personalizar nota" onclick={(e) => { e.stopPropagation(); openFolderCustomizer({ path: node.note?.source_path || node.path, icon: node.icon, color: node.color, note: node.note }); }}>
                     <Settings size={10} />
                   </button>
                 </div>
@@ -774,8 +774,8 @@
   <!-- Folder customize modal -->
   <!-- Create folder modal -->
   {#if creatingFolder}
-    <div class="folder-modal-backdrop" on:click={() => creatingFolder = false}>
-      <div class="folder-modal" on:click|stopPropagation>
+    <div class="folder-modal-backdrop" onclick={() => creatingFolder = false}>
+      <div class="folder-modal" onclick={(e) => e.stopPropagation()}>
         <h3 class="folder-modal-title">Crear carpeta</h3>
         
         <div style="display:flex; flex-direction:column; gap:4px; margin-bottom:12px;">
@@ -805,8 +805,8 @@
         </div>
         
         <div class="folder-modal-btns">
-          <button on:click={() => creatingFolder = false}>Cancelar</button>
-          <button class="primary" disabled={!newFolderName.trim()} on:click={async () => {
+          <button onclick={() => creatingFolder = false}>Cancelar</button>
+          <button class="primary" disabled={!newFolderName.trim()} onclick={async () => {
             if (!newFolderName.trim()) return;
             const targetPath = newFolderParent ? `${newFolderParent}/${newFolderName.trim()}` : newFolderName.trim();
             try {
@@ -839,13 +839,13 @@
   {/key}
 
   {#if renamingNode}
-    <div class="folder-modal-backdrop" on:click={() => renamingNode = null}>
-      <div class="folder-modal" on:click|stopPropagation>
+    <div class="folder-modal-backdrop" onclick={() => renamingNode = null}>
+      <div class="folder-modal" onclick={(e) => e.stopPropagation()}>
         <h3 class="folder-modal-title">Renombrar</h3>
-        <input type="text" class="input mono" bind:value={renameValue} style="width:100%; box-sizing:border-box; margin-bottom:12px;" on:keydown={(e) => e.key === 'Enter' && confirmRename()} />
+        <input type="text" class="input mono" bind:value={renameValue} style="width:100%; box-sizing:border-box; margin-bottom:12px;" onkeydown={(e) => e.key === 'Enter' && confirmRename()} />
         <div class="folder-modal-btns">
-          <button on:click={() => renamingNode = null}>Cancelar</button>
-          <button class="primary" disabled={!renameValue.trim()} on:click={confirmRename}>Guardar</button>
+          <button onclick={() => renamingNode = null}>Cancelar</button>
+          <button class="primary" disabled={!renameValue.trim()} onclick={confirmRename}>Guardar</button>
         </div>
       </div>
     </div>
@@ -860,8 +860,8 @@
   {/if}
 
   {#if editingFolder}
-    <div class="folder-modal-backdrop" on:click={() => editingFolder = null}>
-      <div class="folder-modal" on:click|stopPropagation>
+    <div class="folder-modal-backdrop" onclick={() => editingFolder = null}>
+      <div class="folder-modal" onclick={(e) => e.stopPropagation()}>
         <h3 class="folder-modal-title">Personalizar carpeta</h3>
         
         <!-- Color bar -->
@@ -878,8 +878,8 @@
         </div>
         
         <div class="folder-modal-btns">
-          <button on:click={() => editingFolder = null}>Cancelar</button>
-          <button on:click={async () => { 
+          <button onclick={() => editingFolder = null}>Cancelar</button>
+          <button onclick={async () => { 
             if (editingFolder) {
               updateFolderMeta(editingFolder, { icon: folderIcon, color: folderColor });
               if (editingFolderNote) {
@@ -914,7 +914,7 @@
 
   <!-- ── Resize handle ─────────────────────────────────────────────────────── -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
-  <div class="resize-handle" on:mousedown={startResize}></div>
+  <div class="resize-handle" onmousedown={startResize}></div>
 
   <!-- ── Editor panel ──────────────────────────────────────────────────────── -->
   <div class="editor-panel">
@@ -923,8 +923,8 @@
         <span class="delete-confirm-text">¿Eliminar esta nota?</span>
         <span class="delete-confirm-hint">Esta acción no se puede deshacer.</span>
         <div class="delete-confirm-actions">
-          <button class="btn-cancel" on:click={() => deleteConfirm = false}>Cancelar</button>
-          <button class="btn-danger" on:click={handleDelete}>Eliminar</button>
+          <button class="btn-cancel" onclick={() => deleteConfirm = false}>Cancelar</button>
+          <button class="btn-danger" onclick={handleDelete}>Eliminar</button>
         </div>
       </div>
     {/if}
@@ -959,16 +959,16 @@
           <div class="dash-widget quick-note-widget">
             <div class="dash-widget-title"><DynamicIcon name="PenTool" size={13}/> Acciones Rápidas</div>
             <div class="dash-action-buttons">
-              <button class="dash-btn primary-dash-btn" on:click={openNew}>
+              <button class="dash-btn primary-dash-btn" onclick={openNew}>
                 <FileEdit size={16} /> Crear nota nueva
               </button>
-              <button class={`dash-btn secondary-dash-btn daily-note-btn ${dailyNotesConfigured ? '' : 'daily-note-muted'}`} on:click={openDaily}>
+              <button class={`dash-btn secondary-dash-btn daily-note-btn ${dailyNotesConfigured ? '' : 'daily-note-muted'}`} onclick={openDaily}>
                 <span class="daily-note-main">
                   <DynamicIcon name="Calendar" size={16} /> Nota Diaria
                 </span>
                 <span class="daily-note-hint">Configurar ruta de nota diaria</span>
               </button>
-              <button class="dash-btn secondary-dash-btn momentary-btn" on:click={openMomentary}>
+              <button class="dash-btn secondary-dash-btn momentary-btn" onclick={openMomentary}>
                 <Plus size={16} /> Nota Momentánea
               </button>
             </div>
@@ -978,7 +978,7 @@
             <div class="recent-list">
               {#each $notes.slice(0, 3) as note}
                 {@const vis = getNoteVisual(note)}
-                <button class="recent-item" on:click={() => openNote(note)}>
+                <button class="recent-item" onclick={() => openNote(note)}>
                   <DynamicIcon name={vis.icon} size={12} color={vis.color || 'var(--text-disabled)'} pack={vis.pack} />
                   <span class="recent-name" use:autoScrollTitle={note.title}>
                     <span class="recent-name-text">{note.title}</span>

--- a/frontend/src/routes/streaks/+page.svelte
+++ b/frontend/src/routes/streaks/+page.svelte
@@ -342,7 +342,7 @@
           >
             <button
               class="detail-exit-btn"
-              on:click={() => selectedId = null}
+              onclick={() => selectedId = null}
               title="Volver al menú"
               aria-label="Volver al menú"
             >
@@ -363,7 +363,7 @@
                   <button
                     class="counter-ring"
                     style="--ring-color: {isStreakCompleted(selected) ? '#10b981' : (selected.color || 'var(--xp)')};"
-                    on:click={() => !selected.is_archived && !selected.today_checked && !isStreakCompleted(selected) && checkin(selected.id)}
+                    onclick={() => !selected.is_archived && !selected.today_checked && !isStreakCompleted(selected) && checkin(selected.id)}
                     disabled={selected.is_archived || selected.today_checked || busy.has(selected.id) || isStreakCompleted(selected)}
                     title={isStreakCompleted(selected) ? 'Racha completada' : (selected.today_checked ? 'Ya hiciste check-in hoy' : 'Hacer check-in')}
                     aria-label={isStreakCompleted(selected) ? 'Racha completada' : (selected.today_checked ? 'Ya hiciste check-in hoy' : 'Hacer check-in')}
@@ -437,7 +437,7 @@
               <div class="no-selection-actions">
                 <button
                   class="action-pill"
-                  on:click={checkinAllCurrent}
+                  onclick={checkinAllCurrent}
                   disabled={activeCheckinCandidates.length === 0}
                   title="Hacer check-in de todas las rachas activas"
                 >
@@ -446,7 +446,7 @@
                 </button>
                 <button
                   class="action-pill"
-                  on:click={openRandomStreak}
+                  onclick={openRandomStreak}
                   disabled={filteredStreaks.length === 0}
                   title="Entrar a una racha random"
                 >
@@ -468,7 +468,7 @@
 </div>
 
 <!-- Delete confirmation modal -->
-<svelte:window on:keydown={(e) => e.key === 'Escape' && (deleteConfirm = null)} />
+<svelte:window onkeydown={(e) => e.key === 'Escape' && (deleteConfirm = null)} />
 {#if deleteConfirm !== null}
   <div class="modal-backdrop">
     <div 
@@ -491,8 +491,8 @@
         <p class="delete-modal-warning">Esta acción no se puede deshacer.</p>
       </div>
       <div class="delete-modal-buttons">
-        <button class="btn-cancel" on:click={cancelDelete}>Cancelar</button>
-        <button class="btn-danger" on:click={() => deleteConfirm !== null && deleteStreak(deleteConfirm)}>Eliminar</button>
+        <button class="btn-cancel" onclick={cancelDelete}>Cancelar</button>
+        <button class="btn-danger" onclick={() => deleteConfirm !== null && deleteStreak(deleteConfirm)}>Eliminar</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Migrated all Svelte 4 event syntax (`on:click`, `on:keydown`, etc.) to Svelte 5 syntax (`onclick`, `onkeydown`, etc.) across 33 files.

Event modifiers migrated to Svelte 5 patterns:
- `on:click|stopPropagation` → `onclick={(e) => e.stopPropagation()}`
- `on:click|self` → `onclick={(e) => e.target === e.currentTarget && handler()}`
- `on:submit|preventDefault` → `onsubmit={(e) => { e.preventDefault(); handler(); }}`

Events migrated: click, keydown, keyup, keypress, input, change, focus, blur, submit, scroll, mouseenter, mouseleave, mousedown, mouseup, mousemove, dblclick, contextmenu, dragstart, drag, dragend, dragover, drop, touchstart, touchmove, touchend, wheel, transitionend

#### Test plan
- [x] svelte-check: 0 errors (was 7 before fixes)
- [x] No `on:` event syntax remaining in .svelte files
- [ ] Manual smoke test of all interactive elements

Closes #258

Generated with [Devin](https://devin.ai)