### PR TITLE
feat(install): add Windows PowerShell installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,16 @@ docker compose up -d
 
 ### curl
 
+**Linux / macOS:**
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Axel-DaMage/joidy/main/scripts/install.sh | bash
+```
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://raw.githubusercontent.com/Axel-DaMage/joidy/main/scripts/install.ps1 | iex
 ```
 
 ### Homebrew

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,27 @@
+# Joidy installer for Windows (PowerShell)
+# Mirrors scripts/install.sh
+$ErrorActionPreference = "Stop"
+
+$Repo = "https://github.com/Axel-DaMage/joidy.git"
+$Dir = if ($env:JOIDY_DIR) { $env:JOIDY_DIR } else { Join-Path $HOME "joidy" }
+
+if (Test-Path $Dir) {
+  Write-Host "Joidy already exists at $Dir"
+  Write-Host "To update: cd $Dir ; git pull ; docker compose pull ; docker compose up -d"
+  exit 1
+}
+
+Write-Host "Downloading Joidy to $Dir..."
+git clone --depth 1 $Repo $Dir
+Set-Location $Dir
+Copy-Item .env.example .env
+
+Write-Host ""
+Write-Host "Done!"
+Write-Host ""
+Write-Host "Next steps:"
+Write-Host "  1. Edit $Dir\.env with your credentials"
+Write-Host "  2. Run: cd $Dir ; docker compose up -d"
+Write-Host "  3. Open http://localhost:3000"
+Write-Host ""
+Write-Host "For updates: cd $Dir ; git pull ; docker compose pull ; docker compose up -d"


### PR DESCRIPTION
## Summary
- The `curl | bash` installer only worked on Unix (requires `bash`, `cp`, `$HOME`), so Windows users had to use WSL/Git Bash.
- Adds `scripts/install.ps1` — a PowerShell mirror of `install.sh` (uses `Test-Path`, `Copy-Item`, `Set-Location`, `$env:JOIDY_DIR`, `$ErrorActionPreference = "Stop"`).
- Updates the README `### curl` section to show both commands:
  - Linux/macOS: `curl -fsSL ... | bash` (unchanged)
  - Windows: `irm ... | iex` (idiomatic PowerShell, works on Win10+)

#### Test plan
- [ ] On Linux/macOS: run `curl -fsSL https://raw.githubusercontent.com/Axel-DaMage/joidy/feat/windows-install/scripts/install.sh | bash` and verify clone + `.env` copy.
- [ ] On Windows PowerShell: run `irm https://raw.githubusercontent.com/Axel-DaMage/joidy/feat/windows-install/scripts/install.ps1 | iex` and verify clone + `.env` copy.
- [ ] Verify `JOIDY_DIR` override works on both scripts.
- [ ] Verify re-run on existing dir prints the "already exists" message on both.

Generated with [Devin](https://devin.ai)