### PR TITLE
fix(worker): track and cancel in-flight tasks to prevent orphaned vault processes

### DIFF
--- a/worker/watchers/vault_watcher.py
+++ b/worker/watchers/vault_watcher.py
@@ -257,6 +257,7 @@ async def _consume_vault_events(
     client: httpx.AsyncClient,
     token: str,
 ):
+    _in_flight: set[asyncio.Task] = set()
     while True:
         try:
             first_event = await queue.get()
@@ -280,10 +281,22 @@ async def _consume_vault_events(
                 except Exception:
                     logger.exception("[vault] Failed to process %s (%s)", path, change_type)
 
-            await asyncio.gather(*(process(path, change_type) for path, change_type in pending.items()), return_exceptions=True)
+            batch_tasks = [
+                asyncio.ensure_future(process(path, change_type))
+                for path, change_type in pending.items()
+            ]
+            _in_flight.update(batch_tasks)
+            await asyncio.gather(*batch_tasks, return_exceptions=True)
+            _in_flight.difference_update(batch_tasks)
         except TimeoutError:
             continue
         except asyncio.CancelledError:
+            # Cancel and await any in-flight process tasks before exiting
+            for task in _in_flight:
+                task.cancel()
+            if _in_flight:
+                await asyncio.gather(*_in_flight, return_exceptions=True)
+                logger.info("[vault] Cancelled %d in-flight task(s) on shutdown", len(_in_flight))
             # Drain remaining queue items before exiting
             drained = 0
             while not queue.empty():


### PR DESCRIPTION
## Problem

The `_consume_vault_events` function used `asyncio.gather` with `return_exceptions=True` on bare coroutines. When the consumer was cancelled mid-batch (e.g. on shutdown), the child `process` tasks were not cancelled — they became orphaned and continued running without supervision.

## Fix

- Track in-flight process tasks in a `set[asyncio.Task]`
- On `CancelledError`: cancel all in-flight tasks, await them with `return_exceptions=True`, then drain the queue
- Clean up completed tasks from the tracking set after each batch

## Known issue
Fixes known issue #7 from AGENTS.md: *Vault watcher can leave orphaned tasks in edge cases*