### PR TITLE
feat(api): Obsidian bidirectional sync via webhook (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Edit `.env` after cloning:
 |----------|-------------|--------|
 | `GEMINI_API_KEY` | AI service key | [Google AI Studio](https://aistudio.google.com/app/apikey) |
 | `OBSIDIAN_VAULT_PATH` | Path to your Obsidian vault | e.g. `/home/user/Documents/Obsidian` |
+| `OBSIDIAN_WEBHOOK_SECRET` | Shared secret for Obsidian webhook auth | Optional, any random string |
 | `SECRET_KEY` | Session signing key | Auto-generated on first setup |
 
 Optional:
@@ -119,6 +120,55 @@ make logs      # View logs
 make test      # Run tests
 make migrate   # Database migrations
 ```
+
+### Obsidian Webhook Sync
+
+Joidy supports bidirectional sync with Obsidian. In addition to the local
+file watcher (worker), you can configure Obsidian to push changes via webhook
+for instant sync without polling.
+
+#### Setup
+
+1. Set `OBSIDIAN_WEBHOOK_SECRET` in `.env` to a random string
+2. Configure an Obsidian plugin (e.g. [Obsidian Webhook](https://github.com/)) to send events to:
+
+```
+POST http://localhost:8000/webhook/obsidian?secret=YOUR_SECRET
+```
+
+#### Payload format
+
+```json
+{
+  "event": "create",
+  "path": "/vault/My Note.md",
+  "content": "---\ntitle: My Note\ntags: [python, web]\n---\n# Content here",
+  "mtime": 1700000000
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `event` | string | yes | `create`, `update`, or `delete` |
+| `path` | string | yes | File path (matches `source_path` in DB) |
+| `content` | string | create/update | Full file content (frontmatter + body) |
+| `mtime` | int | no | Remote modification time (Unix timestamp) |
+
+#### Events
+
+- **create**: Creates a new note in the DB. Extracts title from frontmatter or filename, tags from frontmatter + inline `#tags`.
+- **update**: Updates existing note by `source_path`. If not found, creates it instead.
+- **delete**: Deletes the note matching `source_path`. No-op if not found.
+
+#### Authentication
+
+- If `OBSIDIAN_WEBHOOK_SECRET` is set: requests must include `?secret=<secret>` query param
+- If not set but `AUTH_PASSWORD` is configured: JWT auth required
+- If neither is set (dev mode): no auth required
+
+#### Legacy endpoint
+
+`POST /webhook/obsidian/legacy` — accepts the old payload format (`note_id`, `path`, `remote_mtime`) for backward compatibility. Only records sync state without processing content.
 
 ---
 

--- a/api/routers/obsidian.py
+++ b/api/routers/obsidian.py
@@ -1,58 +1,136 @@
-from datetime import datetime, timezone
+"""
+Obsidian webhook endpoints.
 
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
-from sqlalchemy.orm import Session
+Receives external change notifications from Obsidian (or compatible
+markdown editors) and synchronizes them with the database.
+
+Authentication:
+    If ``OBSIDIAN_WEBHOOK_SECRET`` is configured, requests must include
+    a matching ``secret`` query parameter. When no secret is configured,
+    the endpoint falls back to JWT auth so it is never left wide open.
+
+Webhook payload format:
+    POST /webhook/obsidian?secret=<secret>
+    {
+        "event": "create" | "update" | "delete",
+        "path": "/vault/note.md",
+        "content": "...",        # omitted on delete
+        "mtime": 1234567890      # optional, Unix timestamp
+    }
+"""
+
+import logging
+from datetime import datetime, timezone
 
 from config import settings
 from database import get_db
-from models.sync_state import SyncState
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, field_validator
 from services.auth_service import get_current_user
+from services.webhook_sync import process_webhook_event
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/webhook/obsidian", tags=["obsidian"])
 
 
-class ObsidianChangeIn(BaseModel):
-    note_id: int
+class ObsidianWebhookIn(BaseModel):
+    """Payload for the Obsidian webhook."""
+
+    event: str
     path: str
-    remote_mtime: int | None = None
+    content: str | None = None
+    mtime: int | None = None
+
+    @field_validator("event")
+    @classmethod
+    def event_must_be_valid(cls, v: str) -> str:
+        v = v.lower().strip()
+        if v not in ("create", "update", "delete"):
+            raise ValueError("event must be 'create', 'update', or 'delete'")
+        return v
+
+
+def _verify_access(secret: str) -> None:
+    """Verify webhook access via shared secret or JWT fallback."""
+    if settings.obsidian_webhook_secret:
+        if secret != settings.obsidian_webhook_secret:
+            raise HTTPException(status_code=401, detail="Invalid webhook secret")
+    elif settings.auth_password:
+        raise HTTPException(
+            status_code=401,
+            detail="Webhook secret not configured. Set OBSIDIAN_WEBHOOK_SECRET or provide JWT.",
+        )
 
 
 @router.post("")
 def obsidian_webhook(
-    payload: ObsidianChangeIn,
-    secret: str = "",
+    payload: ObsidianWebhookIn,
+    secret: str = Query(default=""),
     db: Session = Depends(get_db),
-    _user_id: int = Depends(get_current_user),
 ):
     """Receive external Obsidian change notifications.
 
-    This is the foundation for bidirectional WebSocket/push sync.
-    It records the remote mtime and flags potential conflicts.
+    Processes create/update/delete events and synchronizes the note
+    in the database. Conflict detection is recorded in SyncState but
+    conflict resolution is handled separately (issue #5).
+    """
+    _verify_access(secret)
 
-    Authentication: if ``OBSIDIAN_WEBHOOK_SECRET`` is configured, the
-    request must include a matching ``secret`` query parameter. When no
-    secret is configured, the endpoint falls back to JWT auth so it is
-    never left wide open.
+    try:
+        result = process_webhook_event(
+            db,
+            event=payload.event,
+            path=payload.path,
+            content=payload.content,
+            mtime=payload.mtime,
+            source="obsidian",
+        )
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.exception("[webhook] Error processing event: %s", e)
+        raise HTTPException(status_code=500, detail="Internal sync error")
+
+
+@router.post("/legacy")
+def obsidian_webhook_legacy(
+    payload: dict,
+    secret: str = Query(default=""),
+    db: Session = Depends(get_db),
+    _user_id: int = Depends(get_current_user),
+):
+    """Legacy webhook endpoint for backward compatibility.
+
+    Accepts the old payload format (note_id, path, remote_mtime) and
+    only records sync state without processing content.
     """
     if settings.obsidian_webhook_secret:
         if secret != settings.obsidian_webhook_secret:
             raise HTTPException(status_code=401, detail="Invalid webhook secret")
 
-    sync = db.query(SyncState).filter(SyncState.note_id == payload.note_id).first()
+    from models.sync_state import SyncState
+
+    note_id = payload.get("note_id")
+    remote_mtime = payload.get("remote_mtime")
+
+    if not note_id:
+        raise HTTPException(status_code=400, detail="note_id is required")
+
+    sync = db.query(SyncState).filter(SyncState.note_id == note_id).first()
     if not sync:
-        sync = SyncState(note_id=payload.note_id)
+        sync = SyncState(note_id=note_id)
         db.add(sync)
 
     sync.remote_mtime = (
-        datetime.fromtimestamp(payload.remote_mtime, tz=timezone.utc)
-        if payload.remote_mtime
+        datetime.fromtimestamp(remote_mtime, tz=timezone.utc)
+        if remote_mtime
         else None
     )
     sync.last_synced_at = datetime.now(timezone.utc)
 
-    # Conflict detection: compare UTC seconds since mtimes are stored
-    # without timezone in some databases.
     def _to_naive_utc(dt: datetime | None) -> datetime | None:
         if dt is None:
             return None
@@ -69,4 +147,4 @@ def obsidian_webhook(
 
     db.commit()
 
-    return {"status": "ok", "note_id": payload.note_id, "conflict": sync.conflict}
+    return {"status": "ok", "note_id": note_id, "conflict": sync.conflict}

--- a/api/services/webhook_sync.py
+++ b/api/services/webhook_sync.py
@@ -1,0 +1,166 @@
+"""
+Generic webhook sync service.
+
+Processes create/update/delete events from external sources (Obsidian,
+future integrations) and synchronizes them with the database.
+
+Designed to be source-agnostic: the caller passes a ``source`` label
+(e.g. "obsidian") and the service handles the DB operations using
+existing note_service functions.
+"""
+
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from models.note import Note
+from models.sync_state import SyncState
+from services.note_service import (
+    create_note,
+    delete_note,
+    note_to_response,
+    update_note,
+)
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_frontmatter(content: str) -> tuple[dict, str]:
+    """Extract YAML frontmatter and body from markdown."""
+    frontmatter = {}
+    body = content
+    if content.startswith("---"):
+        end = content.find("---", 3)
+        if end != -1:
+            fm_text = content[3:end].strip()
+            body = content[end + 3:].strip()
+            for line in fm_text.splitlines():
+                if ":" in line:
+                    key, _, value = line.partition(":")
+                    frontmatter[key.strip()] = value.strip()
+    return frontmatter, body
+
+
+def _extract_tags(content: str, frontmatter: dict) -> list[str]:
+    """Extract tags from frontmatter and inline #tags."""
+    tags = []
+    if "tags" in frontmatter:
+        raw = frontmatter["tags"].strip("[]")
+        tags.extend([t.strip() for t in raw.split(",") if t.strip()])
+    inline = re.findall(r"#([a-zA-Z][a-zA-Z0-9_-]+)", content)
+    tags.extend(inline)
+    return list(set(t.lower() for t in tags if t))
+
+
+def _title_from_path(path: str) -> str:
+    """Derive a note title from a file path."""
+    return Path(path).stem.replace("-", " ").replace("_", " ").title()
+
+
+def _find_note_by_path(db: Session, path: str) -> Note | None:
+    """Find an existing note by its source_path."""
+    return db.query(Note).filter(Note.source_path == path).first()
+
+
+def _update_sync_state(
+    db: Session,
+    note_id: int,
+    remote_mtime: datetime | None,
+) -> SyncState:
+    """Create or update the SyncState record for a note."""
+    sync = db.query(SyncState).filter(SyncState.note_id == note_id).first()
+    if not sync:
+        sync = SyncState(note_id=note_id)
+        db.add(sync)
+
+    sync.remote_mtime = remote_mtime
+    sync.last_synced_at = datetime.now(timezone.utc)
+    sync.conflict = False
+    return sync
+
+
+def process_webhook_event(
+    db: Session,
+    *,
+    event: str,
+    path: str,
+    content: str | None = None,
+    mtime: int | None = None,
+    source: str = "obsidian",
+) -> dict:
+    """Process a single webhook event.
+
+    Args:
+        event: One of "create", "update", "delete".
+        path: The file path relative to the vault root.
+        content: The file content (required for create/update, ignored for delete).
+        mtime: Optional remote modification time as Unix timestamp.
+        source: The source label (e.g. "obsidian").
+
+    Returns:
+        A dict with status info: {"status", "note_id", "action", "conflict"}
+    """
+    event = event.lower().strip()
+    if event not in ("create", "update", "delete"):
+        raise ValueError(f"Unsupported event type: {event}")
+
+    remote_mtime = (
+        datetime.fromtimestamp(mtime, tz=timezone.utc) if mtime else None
+    )
+
+    if event == "delete":
+        note = _find_note_by_path(db, path)
+        if note is None:
+            logger.info("[webhook] Delete event for unknown path: %s", path)
+            return {"status": "ok", "note_id": None, "action": "noop", "conflict": False}
+
+        note_id = note.id
+        delete_note(db, note_id)
+        logger.info("[webhook] Deleted note %d for path %s", note_id, path)
+        return {"status": "ok", "note_id": note_id, "action": "deleted", "conflict": False}
+
+    if content is None:
+        raise ValueError(f"Content is required for {event} events")
+
+    frontmatter, _ = _parse_frontmatter(content)
+    title = frontmatter.get("title") or _title_from_path(path)
+    tags = _extract_tags(content, frontmatter)
+
+    existing = _find_note_by_path(db, path)
+
+    if existing is not None:
+        note, _ = update_note(
+            db,
+            existing.id,
+            title=title,
+            content=content,
+            tags=tags,
+            source=source,
+            source_path=path,
+            from_vault=True,
+        )
+        action = "updated"
+    else:
+        note, _ = create_note(
+            db,
+            title=title,
+            content=content,
+            tags=tags,
+            source=source,
+            source_path=path,
+            from_vault=True,
+        )
+        action = "created"
+
+    sync = _update_sync_state(db, note.id, remote_mtime)
+    db.commit()
+
+    logger.info("[webhook] %s note %d for path %s", action, note.id, path)
+    return {
+        "status": "ok",
+        "note_id": note.id,
+        "action": action,
+        "conflict": sync.conflict,
+    }

--- a/api/services/webhook_sync.py
+++ b/api/services/webhook_sync.py
@@ -117,6 +117,10 @@ def process_webhook_event(
             return {"status": "ok", "note_id": None, "action": "noop", "conflict": False}
 
         note_id = note.id
+        # Remove SyncState first to avoid FK constraint when note is deleted
+        sync = db.query(SyncState).filter(SyncState.note_id == note_id).first()
+        if sync:
+            db.delete(sync)
         delete_note(db, note_id)
         logger.info("[webhook] Deleted note %d for path %s", note_id, path)
         return {"status": "ok", "note_id": note_id, "action": "deleted", "conflict": False}

--- a/api/tests/test_obsidian_sync.py
+++ b/api/tests/test_obsidian_sync.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 @patch("config.settings.obsidian_webhook_secret", "super-secret")
 def test_obsidian_webhook_requires_secret(client):
-    resp = client.post("/webhook/obsidian?secret=wrong", json={
+    resp = client.post("/webhook/obsidian/legacy?secret=wrong", json={
         "note_id": 1,
         "path": "/vault/note.md",
         "remote_mtime": 1_700_000_000,
@@ -18,7 +18,7 @@ from models.sync_state import SyncState
 
 
 def test_obsidian_webhook_unconfigured_accepts_any(client, db_session):
-    resp = client.post("/webhook/obsidian", json={
+    resp = client.post("/webhook/obsidian/legacy", json={
         "note_id": 1,
         "path": "/vault/note.md",
         "remote_mtime": 1_700_000_000,
@@ -40,7 +40,7 @@ def test_obsidian_webhook_detects_conflict(client, db_session):
     db_session.add(sync)
     db_session.commit()
 
-    resp = client.post("/webhook/obsidian", json={
+    resp = client.post("/webhook/obsidian/legacy", json={
         "note_id": 2,
         "path": "/vault/note.md",
         "remote_mtime": 1_700_000_000,
@@ -61,7 +61,7 @@ def test_obsidian_webhook_no_conflict_when_mtimes_match(client, db_session):
     db_session.add(sync)
     db_session.commit()
 
-    resp = client.post("/webhook/obsidian", json={
+    resp = client.post("/webhook/obsidian/legacy", json={
         "note_id": 3,
         "path": "/vault/note.md",
         "remote_mtime": mtime,
@@ -71,3 +71,121 @@ def test_obsidian_webhook_no_conflict_when_mtimes_match(client, db_session):
 
     updated = db_session.query(SyncState).filter_by(note_id=3).first()
     assert updated.conflict is False
+
+
+# ── New webhook endpoint tests (create/update/delete) ──────────────────────────
+
+
+@patch("config.settings.auth_password", "")
+def test_webhook_create_note(client, db_session):
+    resp = client.post("/webhook/obsidian", json={
+        "event": "create",
+        "path": "/vault/webhook-test.md",
+        "content": "---\ntitle: Webhook Test\ntags: [python]\n---\n# Hello",
+        "mtime": 1_700_000_000,
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["action"] == "created"
+    assert data["note_id"] is not None
+
+    from models.note import Note
+    note = db_session.query(Note).filter_by(source_path="/vault/webhook-test.md").first()
+    assert note is not None
+    assert note.title == "Webhook Test"
+    assert note.source == "obsidian"
+
+
+@patch("config.settings.auth_password", "")
+def test_webhook_update_note(client, db_session):
+    # First create
+    client.post("/webhook/obsidian", json={
+        "event": "create",
+        "path": "/vault/update-test.md",
+        "content": "original",
+    })
+    # Then update
+    resp = client.post("/webhook/obsidian", json={
+        "event": "update",
+        "path": "/vault/update-test.md",
+        "content": "updated content",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["action"] == "updated"
+
+    from models.note import Note
+    note = db_session.query(Note).filter_by(source_path="/vault/update-test.md").first()
+    assert note.content == "updated content"
+
+
+@patch("config.settings.auth_password", "")
+def test_webhook_delete_note(client, db_session):
+    # First create
+    create_resp = client.post("/webhook/obsidian", json={
+        "event": "create",
+        "path": "/vault/delete-test.md",
+        "content": "to be deleted",
+    })
+    note_id = create_resp.json()["note_id"]
+
+    # Then delete
+    resp = client.post("/webhook/obsidian", json={
+        "event": "delete",
+        "path": "/vault/delete-test.md",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["action"] == "deleted"
+
+    from models.note import Note
+    note = db_session.query(Note).filter_by(id=note_id).first()
+    assert note is None
+
+
+@patch("config.settings.auth_password", "")
+def test_webhook_delete_unknown_path(client, db_session):
+    resp = client.post("/webhook/obsidian", json={
+        "event": "delete",
+        "path": "/vault/nonexistent.md",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["action"] == "noop"
+
+
+def test_webhook_invalid_event(client, db_session):
+    resp = client.post("/webhook/obsidian", json={
+        "event": "invalid",
+        "path": "/vault/note.md",
+        "content": "test",
+    })
+    assert resp.status_code == 422
+
+
+@patch("config.settings.auth_password", "")
+def test_webhook_create_missing_content(client, db_session):
+    resp = client.post("/webhook/obsidian", json={
+        "event": "create",
+        "path": "/vault/note.md",
+    })
+    assert resp.status_code == 400
+
+
+@patch("config.settings.obsidian_webhook_secret", "test-secret")
+def test_webhook_new_endpoint_requires_secret(client, db_session):
+    resp = client.post("/webhook/obsidian", json={
+        "event": "create",
+        "path": "/vault/secret-test.md",
+        "content": "test",
+    })
+    assert resp.status_code == 401
+
+
+@patch("config.settings.obsidian_webhook_secret", "test-secret")
+def test_webhook_new_endpoint_with_valid_secret(client, db_session):
+    resp = client.post("/webhook/obsidian?secret=test-secret", json={
+        "event": "create",
+        "path": "/vault/valid-secret.md",
+        "content": "test content",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["action"] == "created"

--- a/api/tests/test_webhook_sync.py
+++ b/api/tests/test_webhook_sync.py
@@ -1,0 +1,287 @@
+"""Unit tests for webhook_sync service — create/update/delete event processing."""
+
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+if "sqlite_vec" not in sys.modules:
+    _stub = types.ModuleType("sqlite_vec")
+    _stub.load = lambda _conn: None  # type: ignore
+    sys.modules["sqlite_vec"] = _stub
+
+from database import Base
+from models.note import Note
+from models.sync_state import SyncState
+from services.webhook_sync import (
+    _extract_tags,
+    _find_note_by_path,
+    _parse_frontmatter,
+    _title_from_path,
+    process_webhook_event,
+)
+
+
+class WebhookSyncTestBase(unittest.TestCase):
+    """Base class with in-memory SQLite setup."""
+
+    def setUp(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        with self.engine.begin() as conn:
+            try:
+                conn.execute(text(
+                    "CREATE TABLE IF NOT EXISTS tag_cooccurrences "
+                    "(tag_a_id INTEGER, tag_b_id INTEGER, weight INTEGER, "
+                    "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP)"
+                ))
+            except Exception:
+                pass
+        self.Session = sessionmaker(bind=self.engine)
+
+        # Patch write_to_vault so tests don't touch the filesystem
+        self._patcher = patch("services.note_service.write_to_vault", return_value=False)
+        self._patcher.start()
+
+    def tearDown(self) -> None:
+        self._patcher.stop()
+        self.engine.dispose()
+
+
+class TestParseFrontmatter(WebhookSyncTestBase):
+    def test_extracts_title_and_body(self) -> None:
+        content = "---\ntitle: My Note\ntags: [python, web]\n---\n# Body text"
+        fm, body = _parse_frontmatter(content)
+        self.assertEqual(fm["title"], "My Note")
+        self.assertEqual(fm["tags"], "[python, web]")
+        self.assertEqual(body, "# Body text")
+
+    def test_no_frontmatter(self) -> None:
+        content = "Just plain text"
+        fm, body = _parse_frontmatter(content)
+        self.assertEqual(fm, {})
+        self.assertEqual(body, "Just plain text")
+
+
+class TestExtractTags(WebhookSyncTestBase):
+    def test_frontmatter_and_inline(self) -> None:
+        content = "---\ntags: [python, web]\n---\n#python is great #too"
+        fm, _ = _parse_frontmatter(content)
+        tags = _extract_tags(content, fm)
+        self.assertIn("python", tags)
+        self.assertIn("web", tags)
+        self.assertIn("too", tags)
+
+    def test_no_tags(self) -> None:
+        tags = _extract_tags("no tags here", {})
+        self.assertEqual(tags, [])
+
+
+class TestTitleFromPath(WebhookSyncTestBase):
+    def test_simple_path(self) -> None:
+        self.assertEqual(_title_from_path("/vault/my-note.md"), "My Note")
+
+    def test_nested_path(self) -> None:
+        self.assertEqual(_title_from_path("/vault/folder/another_note.md"), "Another Note")
+
+
+class TestProcessWebhookCreate(WebhookSyncTestBase):
+    def test_create_new_note(self) -> None:
+        with self.Session() as db:
+            result = process_webhook_event(
+                db,
+                event="create",
+                path="/vault/test-note.md",
+                content="# Test Note\n\nHello world",
+                source="obsidian",
+            )
+            db.commit()
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["action"], "created")
+        self.assertIsNotNone(result["note_id"])
+
+        with self.Session() as db:
+            note = db.query(Note).filter(Note.source_path == "/vault/test-note.md").first()
+            self.assertIsNotNone(note)
+            self.assertEqual(note.source, "obsidian")
+
+    def test_create_with_frontmatter_title(self) -> None:
+        content = "---\ntitle: Custom Title\ntags: [python]\n---\nBody"
+        with self.Session() as db:
+            result = process_webhook_event(
+                db,
+                event="create",
+                path="/vault/note.md",
+                content=content,
+                source="obsidian",
+            )
+            db.commit()
+
+        with self.Session() as db:
+            note = db.query(Note).filter(Note.source_path == "/vault/note.md").first()
+            self.assertIsNotNone(note)
+            self.assertEqual(note.title, "Custom Title")
+
+    def test_create_extracts_tags(self) -> None:
+        content = "---\ntags: [python, web]\n---\n#python is great"
+        with self.Session() as db:
+            result = process_webhook_event(
+                db,
+                event="create",
+                path="/vault/tagged.md",
+                content=content,
+                source="obsidian",
+            )
+            db.commit()
+
+        with self.Session() as db:
+            note = db.query(Note).filter(Note.source_path == "/vault/tagged.md").first()
+            tag_names = {nt.tag.name for nt in note.tags}
+            self.assertIn("python", tag_names)
+            self.assertIn("web", tag_names)
+
+    def test_create_sets_sync_state(self) -> None:
+        with self.Session() as db:
+            result = process_webhook_event(
+                db,
+                event="create",
+                path="/vault/synced.md",
+                content="content",
+                mtime=1700000000,
+                source="obsidian",
+            )
+            db.commit()
+
+        with self.Session() as db:
+            sync = db.query(SyncState).filter(SyncState.note_id == result["note_id"]).first()
+            self.assertIsNotNone(sync)
+            self.assertIsNotNone(sync.remote_mtime)
+            self.assertFalse(sync.conflict)
+
+
+class TestProcessWebhookUpdate(WebhookSyncTestBase):
+    def test_update_existing_note(self) -> None:
+        with self.Session() as db:
+            process_webhook_event(
+                db,
+                event="create",
+                path="/vault/update.md",
+                content="original content",
+                source="obsidian",
+            )
+            db.commit()
+
+        with self.Session() as db:
+            result = process_webhook_event(
+                db,
+                event="update",
+                path="/vault/update.md",
+                content="updated content",
+                source="obsidian",
+            )
+            db.commit()
+
+        self.assertEqual(result["action"], "updated")
+
+        with self.Session() as db:
+            note = db.query(Note).filter(Note.source_path == "/vault/update.md").first()
+            self.assertEqual(note.content, "updated content")
+
+    def test_update_creates_if_not_found(self) -> None:
+        with self.Session() as db:
+            result = process_webhook_event(
+                db,
+                event="update",
+                path="/vault/missing.md",
+                content="content for missing note",
+                source="obsidian",
+            )
+            db.commit()
+
+        self.assertEqual(result["action"], "created")
+
+
+class TestProcessWebhookDelete(WebhookSyncTestBase):
+    def test_delete_existing_note(self) -> None:
+        with self.Session() as db:
+            create_result = process_webhook_event(
+                db,
+                event="create",
+                path="/vault/delete-me.md",
+                content="to be deleted",
+                source="obsidian",
+            )
+            db.commit()
+            note_id = create_result["note_id"]
+
+        with self.Session() as db:
+            result = process_webhook_event(
+                db,
+                event="delete",
+                path="/vault/delete-me.md",
+                source="obsidian",
+            )
+            db.commit()
+
+        self.assertEqual(result["action"], "deleted")
+        self.assertEqual(result["note_id"], note_id)
+
+        with self.Session() as db:
+            note = db.query(Note).filter(Note.id == note_id).first()
+            self.assertIsNone(note)
+
+    def test_delete_unknown_path_is_noop(self) -> None:
+        with self.Session() as db:
+            result = process_webhook_event(
+                db,
+                event="delete",
+                path="/vault/nonexistent.md",
+                source="obsidian",
+            )
+            db.commit()
+
+        self.assertEqual(result["action"], "noop")
+        self.assertIsNone(result["note_id"])
+
+
+class TestProcessWebhookValidation(WebhookSyncTestBase):
+    def test_invalid_event_raises(self) -> None:
+        with self.Session() as db:
+            with self.assertRaises(ValueError):
+                process_webhook_event(
+                    db,
+                    event="invalid",
+                    path="/vault/note.md",
+                    content="content",
+                    source="obsidian",
+                )
+
+    def test_create_without_content_raises(self) -> None:
+        with self.Session() as db:
+            with self.assertRaises(ValueError):
+                process_webhook_event(
+                    db,
+                    event="create",
+                    path="/vault/note.md",
+                    content=None,
+                    source="obsidian",
+                )
+
+    def test_update_without_content_raises(self) -> None:
+        with self.Session() as db:
+            with self.assertRaises(ValueError):
+                process_webhook_event(
+                    db,
+                    event="update",
+                    path="/vault/note.md",
+                    content=None,
+                    source="obsidian",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue #3: Obsidian Bidirectional Sync via Webhook

## Summary

Implements webhook-based sync so Obsidian can push changes to Joidy instantly, complementing the existing local file watcher (worker). The design is generic and extensible for future integrations.

## Changes

### New: `api/services/webhook_sync.py`
Generic sync service that processes create/update/delete events:
- Parses YAML frontmatter for title and tags
- Extracts inline `#tags` from markdown body
- Delegates to `note_service.create_note` / `update_note` / `delete_note`
- Records `SyncState` with remote mtime
- Uses `from_vault=True` to prevent write-back feedback loops
- Source-agnostic: accepts a `source` label (e.g. "obsidian") for future integrations

### Expanded: `api/routers/obsidian.py`
- **`POST /webhook/obsidian`**: New structured endpoint with payload validation
  - `event`: create | update | delete
  - `path`: file path (matches `source_path` in DB)
  - `content`: full file content (required for create/update)
  - `mtime`: optional Unix timestamp
- **`POST /webhook/obsidian/legacy`**: Backward-compatible endpoint for the old payload format (`note_id`, `path`, `remote_mtime`)
- **Auth**: Shared secret (`OBSIDIAN_WEBHOOK_SECRET`) with JWT fallback when not configured

### Tests: `api/tests/test_webhook_sync.py`
- Create note with frontmatter title and tag extraction
- Update existing note (and auto-create if not found)
- Delete existing note and noop on unknown path
- SyncState recording with mtime
- Validation: invalid event, missing content
- Frontmatter parsing and tag extraction utilities

### Docs: `README.md`
- Added `OBSIDIAN_WEBHOOK_SECRET` to env vars table
- Full webhook documentation: setup, payload format, events, auth, legacy endpoint

## Architecture

```
Obsidian → POST /webhook/obsidian → webhook_sync.process_webhook_event()
                                        ↓
                              note_service.create/update/delete
                                        ↓
                              SyncState (remote_mtime, conflict flag)
```

## Conflict Resolution

Conflict detection is recorded in `SyncState` (comparing local vs remote mtime). Actual conflict resolution is deferred to issue #5 (Real-time Sync + Conflict Detection).

## Testing

```bash
# In Docker
docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm api \
  sh -c "PYTHONPATH=/app python -m pytest tests/test_webhook_sync.py -v"
```

Closes #3