### PR TITLE
feat: real-time sync conflict detection and resolution (#5)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -28,6 +28,7 @@ from routers import (
     push,
     skills,
     stats,
+    sync,
     tags,
     upload,
     vault,
@@ -173,6 +174,7 @@ app.include_router(obsidian.router)
 app.include_router(auth.router)
 app.include_router(export.router, dependencies=[Depends(get_current_user)])
 app.include_router(stats.router, dependencies=[Depends(get_current_user)])
+app.include_router(sync.router, dependencies=[Depends(get_current_user)])
 app.include_router(upload.router, dependencies=[Depends(get_current_user)])
 
 # Ensure the upload directory exists before serving it.

--- a/api/routers/sync.py
+++ b/api/routers/sync.py
@@ -1,0 +1,66 @@
+"""
+Sync conflict management endpoints.
+
+Provides endpoints to list and resolve sync conflicts between
+Joidy and external sources (e.g. Obsidian).
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, field_validator
+from services.sync_service import list_conflicts, resolve_conflict
+from sqlalchemy.orm import Session
+
+from database import get_db
+
+router = APIRouter(prefix="/sync", tags=["sync"])
+
+
+class ResolveConflictIn(BaseModel):
+    resolution: str
+    merged_content: str | None = None
+
+    @field_validator("resolution")
+    @classmethod
+    def resolution_must_be_valid(cls, v: str) -> str:
+        v = v.lower().strip()
+        if v not in ("keep_local", "keep_remote", "merge"):
+            raise ValueError("resolution must be 'keep_local', 'keep_remote', or 'merge'")
+        return v
+
+
+@router.get("/conflicts")
+def get_conflicts(db: Session = Depends(get_db)):
+    """List all notes with unresolved sync conflicts."""
+    conflicts = list_conflicts(db)
+    return {"conflicts": conflicts, "count": len(conflicts)}
+
+
+@router.post("/resolve/{note_id}")
+def resolve_note_conflict(
+    note_id: int,
+    payload: ResolveConflictIn,
+    db: Session = Depends(get_db),
+):
+    """Resolve a sync conflict for a specific note.
+
+    - ``keep_local``: Discard remote changes, keep DB content.
+    - ``keep_remote``: Read vault file and overwrite DB with its content.
+    - ``merge``: Use ``merged_content`` as the new content for both.
+    """
+    if payload.resolution == "merge" and not payload.merged_content:
+        raise HTTPException(
+            status_code=400,
+            detail="merged_content is required for merge resolution",
+        )
+
+    result = resolve_conflict(
+        db,
+        note_id=note_id,
+        resolution=payload.resolution,
+        merged_content=payload.merged_content,
+    )
+
+    if result["status"] == "error":
+        raise HTTPException(status_code=400, detail=result["message"])
+
+    return result

--- a/api/services/note_service.py
+++ b/api/services/note_service.py
@@ -137,6 +137,9 @@ def create_note(
         sync_skills_for_tags(db, touched_tag_ids)
     if source_path and not from_vault:
         write_to_vault(note)
+        from services.sync_service import update_local_mtime
+        update_local_mtime(db, note.id)
+        db.commit()
     clear_api_caches()
 
     try:
@@ -207,6 +210,9 @@ def update_note(
         sync_skills_for_tags(db, touched_tag_ids)
     if content is not None and not from_vault:
         write_to_vault(note)
+        from services.sync_service import update_local_mtime
+        update_local_mtime(db, note.id)
+        db.commit()
     clear_api_caches()
 
     try:

--- a/api/services/sync_service.py
+++ b/api/services/sync_service.py
@@ -1,0 +1,170 @@
+"""
+Sync conflict detection and resolution service.
+
+Detects simultaneous changes to the same note from Joidy (local) and
+Obsidian (remote), and provides resolution strategies.
+
+Conflict detection is timestamp-based: if ``local_mtime`` and
+``remote_mtime`` differ beyond a tolerance window, the note is flagged
+as conflicted. Resolution options:
+  - ``keep_local``: discard remote changes, keep DB content
+  - ``keep_remote``: accept remote content, overwrite DB
+  - ``merge``: manually provided content overrides both
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Literal
+
+from config import settings
+from models.note import Note
+from models.sync_state import SyncState
+from services.note_service import update_note
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+ConflictResolution = Literal["keep_local", "keep_remote", "merge"]
+
+# Tolerance in seconds — mtimes within this window are considered equal
+CONFLICT_TOLERANCE_SECONDS = 2
+
+
+def detect_conflict(
+    local_mtime: datetime | None,
+    remote_mtime: datetime | None,
+) -> bool:
+    """Return True if local and remote mtimes differ beyond tolerance."""
+    if local_mtime is None or remote_mtime is None:
+        return False
+
+    def _to_utc(dt: datetime) -> datetime:
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    diff = abs((_to_utc(local_mtime) - _to_utc(remote_mtime)).total_seconds())
+    return diff > CONFLICT_TOLERANCE_SECONDS
+
+
+def list_conflicts(db: Session) -> list[dict]:
+    """Return all notes with unresolved sync conflicts."""
+    rows = (
+        db.query(SyncState, Note)
+        .join(Note, SyncState.note_id == Note.id)
+        .filter(SyncState.conflict.is_(True))
+        .all()
+    )
+    return [
+        {
+            "note_id": note.id,
+            "title": note.title,
+            "source_path": note.source_path,
+            "local_mtime": sync.local_mtime.isoformat() + "Z" if sync.local_mtime else None,
+            "remote_mtime": sync.remote_mtime.isoformat() + "Z" if sync.remote_mtime else None,
+            "last_synced_at": sync.last_synced_at.isoformat() + "Z" if sync.last_synced_at else None,
+        }
+        for sync, note in rows
+    ]
+
+
+def resolve_conflict(
+    db: Session,
+    note_id: int,
+    resolution: ConflictResolution,
+    merged_content: str | None = None,
+) -> dict:
+    """Resolve a sync conflict for a note.
+
+    Args:
+        note_id: The ID of the conflicted note.
+        resolution: How to resolve — keep_local, keep_remote, or merge.
+        merged_content: Required for "merge" resolution. The manually
+            merged content that overrides both local and remote.
+
+    Returns:
+        Dict with resolution status.
+    """
+    sync = db.query(SyncState).filter(SyncState.note_id == note_id).first()
+    note = db.query(Note).filter(Note.id == note_id).first()
+
+    if sync is None or note is None:
+        return {"status": "error", "message": "Note or sync state not found"}
+
+    if not sync.conflict:
+        return {"status": "ok", "message": "No conflict to resolve", "note_id": note_id}
+
+    if resolution == "keep_local":
+        # Keep DB content as-is, just clear the conflict flag
+        sync.conflict = False
+        sync.last_synced_at = datetime.now(timezone.utc)
+        db.commit()
+        logger.info("[sync] Resolved conflict for note %d: keep_local", note_id)
+
+    elif resolution == "keep_remote":
+        # Accept remote content — read from the vault file
+        vault_path = settings.obsidian_vault_path
+        if not vault_path or not note.source_path:
+            return {"status": "error", "message": "Cannot read remote: vault path or source_path missing"}
+
+        full_path = os.path.abspath(note.source_path)
+        vault = os.path.abspath(vault_path)
+        if not full_path.startswith(vault):
+            return {"status": "error", "message": "Source path outside vault"}
+
+        try:
+            with open(full_path, "r", encoding="utf-8") as f:
+                remote_content = f.read()
+        except Exception as e:
+            return {"status": "error", "message": f"Cannot read vault file: {e}"}
+
+        update_note(
+            db,
+            note_id,
+            content=remote_content,
+            from_vault=True,
+            rebuild_derived_data=False,
+        )
+        sync.conflict = False
+        sync.local_mtime = sync.remote_mtime
+        sync.last_synced_at = datetime.now(timezone.utc)
+        db.commit()
+        logger.info("[sync] Resolved conflict for note %d: keep_remote", note_id)
+
+    elif resolution == "merge":
+        if merged_content is None:
+            return {"status": "error", "message": "merged_content is required for merge resolution"}
+
+        update_note(
+            db,
+            note_id,
+            content=merged_content,
+            from_vault=False,
+            rebuild_derived_data=False,
+        )
+        sync.conflict = False
+        now = datetime.now(timezone.utc)
+        sync.local_mtime = now
+        sync.remote_mtime = now
+        sync.last_synced_at = now
+        db.commit()
+        logger.info("[sync] Resolved conflict for note %d: merge", note_id)
+
+    else:
+        return {"status": "error", "message": f"Unknown resolution: {resolution}"}
+
+    return {"status": "ok", "note_id": note_id, "resolution": resolution}
+
+
+def update_local_mtime(db: Session, note_id: int) -> None:
+    """Record the current time as local_mtime for a note.
+
+    Called when a note is created or updated from Joidy (not from vault).
+    """
+    sync = db.query(SyncState).filter(SyncState.note_id == note_id).first()
+    if not sync:
+        sync = SyncState(note_id=note_id)
+        db.add(sync)
+    sync.local_mtime = datetime.now(timezone.utc)
+    db.flush()

--- a/api/services/webhook_sync.py
+++ b/api/services/webhook_sync.py
@@ -22,6 +22,7 @@ from services.note_service import (
     note_to_response,
     update_note,
 )
+from services.sync_service import detect_conflict
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -69,7 +70,10 @@ def _update_sync_state(
     note_id: int,
     remote_mtime: datetime | None,
 ) -> SyncState:
-    """Create or update the SyncState record for a note."""
+    """Create or update the SyncState record for a note.
+
+    Detects conflicts by comparing local_mtime vs remote_mtime.
+    """
     sync = db.query(SyncState).filter(SyncState.note_id == note_id).first()
     if not sync:
         sync = SyncState(note_id=note_id)
@@ -77,7 +81,7 @@ def _update_sync_state(
 
     sync.remote_mtime = remote_mtime
     sync.last_synced_at = datetime.now(timezone.utc)
-    sync.conflict = False
+    sync.conflict = detect_conflict(sync.local_mtime, remote_mtime)
     return sync
 
 

--- a/api/tests/test_sync_service.py
+++ b/api/tests/test_sync_service.py
@@ -1,0 +1,287 @@
+"""Unit tests for sync_service — conflict detection, listing, and resolution."""
+
+import sys
+import types
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+if "sqlite_vec" not in sys.modules:
+    _stub = types.ModuleType("sqlite_vec")
+    _stub.load = lambda _conn: None  # type: ignore
+    sys.modules["sqlite_vec"] = _stub
+
+from database import Base
+from models.note import Note
+from models.sync_state import SyncState
+from services.sync_service import (
+    CONFLICT_TOLERANCE_SECONDS,
+    detect_conflict,
+    list_conflicts,
+    resolve_conflict,
+    update_local_mtime,
+)
+
+
+class SyncServiceTestBase(unittest.TestCase):
+    """Base class with in-memory SQLite setup."""
+
+    def setUp(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        with self.engine.begin() as conn:
+            try:
+                conn.execute(text(
+                    "CREATE TABLE IF NOT EXISTS tag_cooccurrences "
+                    "(tag_a_id INTEGER, tag_b_id INTEGER, weight INTEGER, "
+                    "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP)"
+                ))
+            except Exception:
+                pass
+        self.Session = sessionmaker(bind=self.engine)
+
+        self._patcher = patch("services.note_service.write_to_vault", return_value=False)
+        self._patcher.start()
+
+    def tearDown(self) -> None:
+        self._patcher.stop()
+        self.engine.dispose()
+
+    def _create_note(self, db, title="Test Note", source_path="/vault/test.md") -> Note:
+        note = Note(title=title, content="content", source="obsidian", source_path=source_path)
+        db.add(note)
+        db.flush()
+        return note
+
+
+class TestDetectConflict(SyncServiceTestBase):
+    def test_no_conflict_when_both_none(self) -> None:
+        self.assertFalse(detect_conflict(None, None))
+
+    def test_no_conflict_when_local_none(self) -> None:
+        remote = datetime.now(timezone.utc)
+        self.assertFalse(detect_conflict(None, remote))
+
+    def test_no_conflict_when_remote_none(self) -> None:
+        local = datetime.now(timezone.utc)
+        self.assertFalse(detect_conflict(local, None))
+
+    def test_no_conflict_when_mtimes_close(self) -> None:
+        now = datetime.now(timezone.utc)
+        local = now
+        remote = now + timedelta(seconds=1)
+        self.assertFalse(detect_conflict(local, remote))
+
+    def test_conflict_when_mtimes_differ(self) -> None:
+        local = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        remote = datetime(2024, 1, 2, tzinfo=timezone.utc)
+        self.assertTrue(detect_conflict(local, remote))
+
+    def test_conflict_at_tolerance_boundary(self) -> None:
+        now = datetime.now(timezone.utc)
+        local = now
+        remote = now + timedelta(seconds=CONFLICT_TOLERANCE_SECONDS + 1)
+        self.assertTrue(detect_conflict(local, remote))
+
+    def test_no_conflict_within_tolerance(self) -> None:
+        now = datetime.now(timezone.utc)
+        local = now
+        remote = now + timedelta(seconds=CONFLICT_TOLERANCE_SECONDS)
+        self.assertFalse(detect_conflict(local, remote))
+
+    def test_handles_naive_datetimes(self) -> None:
+        local = datetime(2024, 1, 1)
+        remote = datetime(2024, 1, 2)
+        self.assertTrue(detect_conflict(local, remote))
+
+
+class TestListConflicts(SyncServiceTestBase):
+    def test_empty_when_no_conflicts(self) -> None:
+        with self.Session() as db:
+            self._create_note(db)
+            db.commit()
+            result = list_conflicts(db)
+            self.assertEqual(result, [])
+
+    def test_lists_only_conflicted_notes(self) -> None:
+        with self.Session() as db:
+            note1 = self._create_note(db, "Note 1", "/vault/n1.md")
+            note2 = self._create_note(db, "Note 2", "/vault/n2.md")
+            db.flush()
+
+            sync1 = SyncState(note_id=note1.id, conflict=False)
+            sync2 = SyncState(
+                note_id=note2.id,
+                conflict=True,
+                local_mtime=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                remote_mtime=datetime(2024, 1, 2, tzinfo=timezone.utc),
+            )
+            db.add_all([sync1, sync2])
+            db.commit()
+
+            result = list_conflicts(db)
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0]["note_id"], note2.id)
+            self.assertEqual(result[0]["title"], "Note 2")
+            self.assertEqual(result[0]["source_path"], "/vault/n2.md")
+
+    def test_includes_mtime_info(self) -> None:
+        with self.Session() as db:
+            note = self._create_note(db, "Note", "/vault/n.md")
+            db.flush()
+            sync = SyncState(
+                note_id=note.id,
+                conflict=True,
+                local_mtime=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                remote_mtime=datetime(2024, 1, 2, tzinfo=timezone.utc),
+            )
+            db.add(sync)
+            db.commit()
+
+            result = list_conflicts(db)
+            self.assertIsNotNone(result[0]["local_mtime"])
+            self.assertIsNotNone(result[0]["remote_mtime"])
+
+
+class TestResolveConflict(SyncServiceTestBase):
+    def test_keep_local_clears_conflict(self) -> None:
+        with self.Session() as db:
+            note = self._create_note(db, "Conflict Note", "/vault/conflict.md")
+            db.flush()
+            sync = SyncState(
+                note_id=note.id,
+                conflict=True,
+                local_mtime=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                remote_mtime=datetime(2024, 1, 2, tzinfo=timezone.utc),
+            )
+            db.add(sync)
+            db.commit()
+
+            result = resolve_conflict(db, note.id, "keep_local")
+            self.assertEqual(result["status"], "ok")
+
+            db.refresh(sync)
+            self.assertFalse(sync.conflict)
+
+    def test_keep_remote_reads_vault_file(self) -> None:
+        import tempfile
+        import os
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False, dir="/tmp") as f:
+            f.write("remote content from vault")
+            vault_path = f.name
+
+        try:
+            with self.Session() as db:
+                note = Note(
+                    title="Remote Note",
+                    content="local content",
+                    source="obsidian",
+                    source_path=vault_path,
+                )
+                db.add(note)
+                db.flush()
+                sync = SyncState(
+                    note_id=note.id,
+                    conflict=True,
+                    local_mtime=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    remote_mtime=datetime(2024, 1, 2, tzinfo=timezone.utc),
+                )
+                db.add(sync)
+                db.commit()
+
+                with patch("services.sync_service.settings.obsidian_vault_path", "/tmp"):
+                    result = resolve_conflict(db, note.id, "keep_remote")
+
+                self.assertEqual(result["status"], "ok")
+                db.refresh(note)
+                self.assertEqual(note.content, "remote content from vault")
+                db.refresh(sync)
+                self.assertFalse(sync.conflict)
+        finally:
+            os.unlink(vault_path)
+
+    def test_merge_updates_content(self) -> None:
+        with self.Session() as db:
+            note = self._create_note(db, "Merge Note", "/vault/merge.md")
+            note.content = "original"
+            db.flush()
+            sync = SyncState(
+                note_id=note.id,
+                conflict=True,
+                local_mtime=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                remote_mtime=datetime(2024, 1, 2, tzinfo=timezone.utc),
+            )
+            db.add(sync)
+            db.commit()
+
+            result = resolve_conflict(db, note.id, "merge", merged_content="merged content")
+            self.assertEqual(result["status"], "ok")
+
+            db.refresh(note)
+            self.assertEqual(note.content, "merged content")
+            db.refresh(sync)
+            self.assertFalse(sync.conflict)
+
+    def test_merge_without_content_returns_error(self) -> None:
+        with self.Session() as db:
+            note = self._create_note(db, "Merge Note", "/vault/merge.md")
+            db.flush()
+            sync = SyncState(note_id=note.id, conflict=True)
+            db.add(sync)
+            db.commit()
+
+            result = resolve_conflict(db, note.id, "merge", merged_content=None)
+            self.assertEqual(result["status"], "error")
+
+    def test_resolve_nonexistent_note_returns_error(self) -> None:
+        with self.Session() as db:
+            result = resolve_conflict(db, 99999, "keep_local")
+            self.assertEqual(result["status"], "error")
+
+    def test_resolve_no_conflict_returns_ok(self) -> None:
+        with self.Session() as db:
+            note = self._create_note(db, "No Conflict", "/vault/noconflict.md")
+            db.flush()
+            sync = SyncState(note_id=note.id, conflict=False)
+            db.add(sync)
+            db.commit()
+
+            result = resolve_conflict(db, note.id, "keep_local")
+            self.assertEqual(result["status"], "ok")
+
+
+class TestUpdateLocalMtime(SyncServiceTestBase):
+    def test_creates_sync_state_if_missing(self) -> None:
+        with self.Session() as db:
+            note = self._create_note(db)
+            db.commit()
+
+            update_local_mtime(db, note.id)
+            db.commit()
+
+            sync = db.query(SyncState).filter(SyncState.note_id == note.id).first()
+            self.assertIsNotNone(sync)
+            self.assertIsNotNone(sync.local_mtime)
+
+    def test_updates_existing_sync_state(self) -> None:
+        with self.Session() as db:
+            note = self._create_note(db)
+            db.flush()
+            old_time = datetime(2020, 1, 1, tzinfo=timezone.utc)
+            sync = SyncState(note_id=note.id, local_mtime=old_time)
+            db.add(sync)
+            db.commit()
+
+            update_local_mtime(db, note.id)
+            db.commit()
+
+            db.refresh(sync)
+            self.assertNotEqual(sync.local_mtime, old_time)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/lib/components/ConflictResolutionModal.svelte
+++ b/frontend/src/lib/components/ConflictResolutionModal.svelte
@@ -1,0 +1,268 @@
+<script lang="ts">
+  import { syncStore, type SyncConflict, type ConflictResolution } from '$lib/stores/sync';
+  import ModalDialog from './ModalDialog.svelte';
+  import { AlertTriangle, FileText, Upload, Download, GitMerge } from 'lucide-svelte';
+
+  let selectedConflict: SyncConflict | null = null;
+  let resolution: ConflictResolution | null = null;
+  let mergedContent = '';
+  let resolving = false;
+
+  // Auto-open modal when conflicts exist
+  $: if ($syncStore.conflicts.length > 0 && !selectedConflict) {
+    selectedConflict = $syncStore.conflicts[0];
+    resolution = null;
+    mergedContent = '';
+  }
+
+  $: if ($syncStore.conflicts.length === 0) {
+    selectedConflict = null;
+  }
+
+  async function handleResolve() {
+    if (!selectedConflict || !resolution) return;
+    resolving = true;
+    const ok = await syncStore.resolveConflict(
+      selectedConflict.note_id,
+      resolution,
+      resolution === 'merge' ? mergedContent : undefined
+    );
+    resolving = false;
+    if (ok) {
+      selectedConflict = null;
+      resolution = null;
+      mergedContent = '';
+    }
+  }
+
+  function handleSkip() {
+    selectedConflict = null;
+    resolution = null;
+    mergedContent = '';
+  }
+</script>
+
+{#if selectedConflict}
+  <ModalDialog
+    open={true}
+    title="Conflicto de Sincronización"
+    size="lg"
+    onClose={handleSkip}
+  >
+    <div class="conflict-info">
+      <div class="conflict-icon">
+        <AlertTriangle size={24} color="var(--warning)" />
+      </div>
+      <p class="conflict-desc">
+        Se detectaron cambios simultáneos en <strong>{selectedConflict.title}</strong>
+        desde Joidy y Obsidian. Elige cómo resolver el conflicto.
+      </p>
+    </div>
+
+    <div class="conflict-meta">
+      <div class="meta-item">
+        <span class="meta-label">Archivo</span>
+        <span class="meta-value">{selectedConflict.source_path}</span>
+      </div>
+      <div class="meta-row">
+        <div class="meta-item">
+          <span class="meta-label">Local (Joidy)</span>
+          <span class="meta-value">{selectedConflict.local_mtime ?? '—'}</span>
+        </div>
+        <div class="meta-item">
+          <span class="meta-label">Remoto (Obsidian)</span>
+          <span class="meta-value">{selectedConflict.remote_mtime ?? '—'}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="resolution-options">
+      <button
+        class="resolution-btn"
+        class:active={resolution === 'keep_local'}
+        onclick={() => resolution = 'keep_local'}
+      >
+        <FileText size={18} />
+        <div class="resolution-text">
+          <span class="resolution-title">Mantener Local</span>
+          <span class="resolution-desc">Descartar cambios de Obsidian, conservar Joidy</span>
+        </div>
+      </button>
+
+      <button
+        class="resolution-btn"
+        class:active={resolution === 'keep_remote'}
+        onclick={() => resolution = 'keep_remote'}
+      >
+        <Download size={18} />
+        <div class="resolution-text">
+          <span class="resolution-title">Mantener Remoto</span>
+          <span class="resolution-desc">Sobrescribir Joidy con el contenido de Obsidian</span>
+        </div>
+      </button>
+
+      <button
+        class="resolution-btn"
+        class:active={resolution === 'merge'}
+        onclick={() => resolution = 'merge'}
+      >
+        <GitMerge size={18} />
+        <div class="resolution-text">
+          <span class="resolution-title">Fusionar Manualmente</span>
+          <span class="resolution-desc">Editar el contenido combinado</span>
+        </div>
+      </button>
+    </div>
+
+    {#if resolution === 'merge'}
+      <div class="merge-editor">
+        <label class="label">Contenido fusionado</label>
+        <textarea
+          class="input w-full"
+          bind:value={mergedContent}
+          rows="10"
+          placeholder="Pega o edita el contenido combinado aquí..."
+        ></textarea>
+      </div>
+    {/if}
+
+    {#if $syncStore.conflicts.length > 1}
+      <p class="more-conflicts">
+        {$syncStore.conflicts.length - 1} conflicto(s) más pendiente(s)
+      </p>
+    {/if}
+
+    {#snippet footer()}
+      <button class="btn btn-ghost" onclick={handleSkip}>Saltar</button>
+      <button
+        class="btn btn-primary"
+        onclick={handleResolve}
+        disabled={!resolution || resolving || (resolution === 'merge' && !mergedContent.trim())}
+      >
+        {resolving ? 'Resolviendo...' : 'Resolver'}
+      </button>
+    {/snippet}
+  </ModalDialog>
+{/if}
+
+<style>
+  .conflict-info {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  .conflict-icon {
+    flex-shrink: 0;
+    padding: 8px;
+    background: color-mix(in srgb, var(--warning) 10%, transparent);
+    border-radius: var(--r);
+  }
+
+  .conflict-desc {
+    margin: 0;
+    font-size: 14px;
+    color: var(--text-primary);
+    line-height: 1.5;
+  }
+
+  .conflict-meta {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 12px;
+    margin-bottom: 16px;
+  }
+
+  .meta-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .meta-row {
+    display: flex;
+    gap: 20px;
+    margin-top: 8px;
+  }
+
+  .meta-label {
+    font-size: 11px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .meta-value {
+    font-size: 13px;
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    word-break: break-all;
+  }
+
+  .resolution-options {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  .resolution-btn {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    cursor: pointer;
+    text-align: left;
+    transition: all 0.15s ease;
+    color: var(--text-primary);
+  }
+
+  .resolution-btn:hover {
+    border-color: var(--accent);
+    background: var(--hover);
+  }
+
+  .resolution-btn.active {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 1px var(--accent);
+    background: color-mix(in srgb, var(--accent) 5%, transparent);
+  }
+
+  .resolution-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .resolution-title {
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  .resolution-desc {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+
+  .merge-editor {
+    margin-bottom: 16px;
+  }
+
+  .merge-editor textarea {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    resize: vertical;
+  }
+
+  .more-conflicts {
+    font-size: 12px;
+    color: var(--text-muted);
+    text-align: center;
+    margin: 0;
+  }
+</style>

--- a/frontend/src/lib/stores/sync.ts
+++ b/frontend/src/lib/stores/sync.ts
@@ -1,0 +1,99 @@
+import { writable } from 'svelte/store';
+import { api } from '$lib/api';
+import { showNotification } from './notifications';
+
+export interface SyncConflict {
+  note_id: number;
+  title: string;
+  source_path: string;
+  local_mtime: string | null;
+  remote_mtime: string | null;
+  last_synced_at: string | null;
+}
+
+export type ConflictResolution = 'keep_local' | 'keep_remote' | 'merge';
+
+interface SyncState {
+  conflicts: SyncConflict[];
+  loading: boolean;
+  lastChecked: number | null;
+}
+
+const POLL_INTERVAL = 30_000; // 30 seconds
+
+function createSyncStore() {
+  const { subscribe, set, update } = writable<SyncState>({
+    conflicts: [],
+    loading: false,
+    lastChecked: null,
+  });
+
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  async function checkConflicts(): Promise<void> {
+    update(s => ({ ...s, loading: true }));
+    try {
+      const data = await api<{ conflicts: SyncConflict[]; count: number }>('GET', '/sync/conflicts');
+      update(s => ({
+        conflicts: data.conflicts,
+        loading: false,
+        lastChecked: Date.now(),
+      }));
+
+      if (data.conflicts.length > 0) {
+        showNotification(
+          `${data.conflicts.length} conflicto(s) de sincronización pendiente(s)`,
+          'info'
+        );
+      }
+    } catch {
+      update(s => ({ ...s, loading: false }));
+    }
+  }
+
+  async function resolveConflict(
+    noteId: number,
+    resolution: ConflictResolution,
+    mergedContent?: string
+  ): Promise<boolean> {
+    try {
+      await api('POST', `/sync/resolve/${noteId}`, {
+        resolution,
+        merged_content: mergedContent ?? null,
+      });
+      update(s => ({
+        ...s,
+        conflicts: s.conflicts.filter(c => c.note_id !== noteId),
+      }));
+      showNotification('Conflicto resuelto', 'success');
+      return true;
+    } catch {
+      showNotification('Error al resolver conflicto', 'error');
+      return false;
+    }
+  }
+
+  function startPolling(): void {
+    if (pollTimer) return;
+    checkConflicts();
+    pollTimer = setInterval(checkConflicts, POLL_INTERVAL);
+  }
+
+  function stopPolling(): void {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  return {
+    subscribe,
+    checkConflicts,
+    resolveConflict,
+    startPolling,
+    stopPolling,
+    reset: () => set({ conflicts: [], loading: false, lastChecked: null }),
+  };
+}
+
+export const syncStore = createSyncStore();

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -27,6 +27,8 @@
   import { initConnectionStore } from '$lib/stores/connection';
   import { loadNotes } from '$lib/stores/notes';
   import { deferredPrompt, showInstallBanner, isAppInstalled } from '$lib/stores/pwa';
+  import { syncStore } from '$lib/stores/sync';
+  import ConflictResolutionModal from '$lib/components/ConflictResolutionModal.svelte';
 
   type NavItemStatus = 'ready' | 'dev' | 'placeholder';
 
@@ -261,6 +263,11 @@
     };
     requestAnimationFrame(() => init());
 
+    // Start sync conflict polling when authenticated
+    if ($isAuthenticated) {
+      syncStore.startPolling();
+    }
+
     // Global error handlers
     const handleOnerror = (
       _event: Event | string,
@@ -366,6 +373,7 @@
       if (wsReconnectTimeout) clearTimeout(wsReconnectTimeout);
       if (pillTimeout) clearTimeout(pillTimeout);
       if (cleanupTheme) cleanupTheme();
+      syncStore.stopPolling();
     };
   });
   let showConnectedPill = false;
@@ -509,6 +517,7 @@
 <CommandPalette />
 <Toast />
 <TutorialOverlay />
+<ConflictResolutionModal />
 {/if}
 
 <style>


### PR DESCRIPTION
## Issue #5: Advanced Real-time Obsidian Sync — Conflict Detection

## Summary

Implements bidirectional conflict detection between Joidy and Obsidian. When both sides modify the same note, the system detects the conflict via timestamp comparison and provides UI for manual resolution.

## Changes

### Backend

**New: `api/services/sync_service.py`**
- `detect_conflict()`: Timestamp-based comparison with 2s tolerance window
- `list_conflicts()`: Returns all notes with unresolved conflicts (joins SyncState + Note)
- `resolve_conflict()`: Three resolution strategies:
  - `keep_local`: Discard remote changes, keep DB content
  - `keep_remote`: Read vault file, overwrite DB
  - `merge`: Manually provided content overrides both, writes back to vault
- `update_local_mtime()`: Records current time as local_mtime when Joidy edits a note

**Modified: `api/services/webhook_sync.py`**
- `_update_sync_state()` now uses `detect_conflict()` to compare local vs remote mtime instead of always setting `conflict=False`

**Modified: `api/services/note_service.py`**
- `create_note()` and `update_note()` now call `update_local_mtime()` after writing to vault (when `from_vault=False`)

**New: `api/routers/sync.py`**
- `GET /sync/conflicts`: List all unresolved conflicts
- `POST /sync/resolve/{note_id}`: Resolve with keep_local / keep_remote / merge

**Tests: `api/tests/test_sync_service.py`** — 19 tests
- Conflict detection: tolerance boundary, naive/aware datetimes, None handling
- Listing: empty, filtered, with mtime info
- Resolution: keep_local, keep_remote (reads vault file), merge, error cases
- update_local_mtime: creates/updates SyncState

### Frontend

**New: `frontend/src/lib/stores/sync.ts`**
- Polls `/sync/conflicts` every 30s
- `resolveConflict()` calls the API and updates store
- `startPolling()` / `stopPolling()` lifecycle
- Shows notification when conflicts are detected

**New: `frontend/src/lib/components/ConflictResolutionModal.svelte`**
- Auto-opens when conflicts exist
- Shows note title, file path, local/remote mtimes
- Three resolution buttons: Mantener Local / Mantener Remoto / Fusionar
- Merge mode shows textarea for manual content editing
- Displays count of remaining conflicts

**Modified: `frontend/src/routes/+layout.svelte`**
- Starts sync polling when authenticated
- Stops polling on unmount
- Renders `ConflictResolutionModal`

## Architecture

```
Joidy edit → note_service.update_note() → update_local_mtime()
                                              ↓
                                    SyncState.local_mtime

Obsidian edit → webhook → webhook_sync._update_sync_state()
                                    ↓
                          detect_conflict(local, remote)
                                    ↓
                          SyncState.conflict = True/False

Frontend → polls GET /sync/conflicts → shows modal
         → POST /sync/resolve/{id} → clears conflict
```

## Testing

```bash
docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm api \
  sh -c "PYTHONPATH=/app python -m pytest tests/test_sync_service.py tests/test_webhook_sync.py tests/test_obsidian_sync.py -v"
```

**184 tests pass, 0 regressions.**

Closes #5