### PR TITLE
feat: WYSIWYG markdown editor with TipTap (#6)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,12 +9,25 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@tiptap/core": "^3.29.2",
+        "@tiptap/extension-code-block-lowlight": "^3.29.2",
+        "@tiptap/extension-image": "^3.29.2",
+        "@tiptap/extension-link": "^3.29.2",
+        "@tiptap/extension-placeholder": "^3.29.2",
+        "@tiptap/extension-strike": "^3.29.2",
+        "@tiptap/extension-task-item": "^3.29.2",
+        "@tiptap/extension-task-list": "^3.29.2",
+        "@tiptap/extension-underline": "^3.29.2",
+        "@tiptap/pm": "^3.29.2",
+        "@tiptap/starter-kit": "^3.29.2",
+        "@types/turndown": "^5.0.6",
         "d3": "^7.9.0",
         "dompurify": "^3.4.12",
         "force-graph": "^1.47.0",
         "highlight.js": "^11.11.1",
         "lucide-svelte": "^0.468.0",
-        "marked": "^12.0.0"
+        "marked": "^12.0.0",
+        "turndown": "^7.2.4"
       },
       "devDependencies": {
         "@sveltejs/adapter-node": "^5.2.9",
@@ -770,6 +783,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "dev": true,
@@ -1394,6 +1413,444 @@
         "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.29.2.tgz",
+      "integrity": "sha512-oKUkiPUB7noilVYxI9lNzUD4rX17sHub+PYjMfHMWHG9A3nvIy+FdePIVIIhThKWF7ijhr3eIqHY51Bn+GAFtw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.29.2.tgz",
+      "integrity": "sha512-ca4OzKDh0yaxg2+Z56bC2QnWsNsFp2YMRfVig1PDXyMVFMNJpLcnhxgq/9btn+xYAlYrj8RymOeCTYREOR6Zjg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.29.2.tgz",
+      "integrity": "sha512-elYbGxJsYnBb4leqrcjdIJuiG380BcOgN+UUzvOv+qEjfGVzHodFOMBl3qnmD6urYHNu5/qQK2S0qSSRXKCLNQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.29.2.tgz",
+      "integrity": "sha512-3bWcCUPbCHv0XttlMdnAtXLNYWx2pblByMgxmGsaP9FU0QnslGXty6A6gHCqI33ygRg1vrA6U5Wtpwbi5aKu5g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.29.2.tgz",
+      "integrity": "sha512-c6W5UGuB7WNLpYocsgRzpO2OOTI4QjaI9jjHRMuty9z+s9DtaYM/HrRLNwVh6MopkHb+i/89Wkv8gCS34fftig==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.29.2.tgz",
+      "integrity": "sha512-w153ct8g6dLiPTdXQ6SOIMxX4SEo5Q50AmjdEEEcJ7ZcYUcde/ScSskLHfOYmyt5ZFAiyEwr121+pux+p3/oAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block-lowlight": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block-lowlight/-/extension-code-block-lowlight-3.29.2.tgz",
+      "integrity": "sha512-iUtg33uSlbnU0y6c3nUSWdw8ILmbuc+HeAouqZ7Vl4leYddLf7wLP4s+RJ8PKDJe8m1r6GTK6VVpCOUK5eIFzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/extension-code-block": "3.29.2",
+        "@tiptap/pm": "3.29.2",
+        "highlight.js": "^11",
+        "lowlight": "^2 || ^3"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.29.2.tgz",
+      "integrity": "sha512-YUamvefLnsqu6124GavVTI7nqcFlQJ12ROB0oSwG69eSBZYNjg1tIs05LFrBxkwf4Xgqd6YzfJ9+FeG428RvzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.29.2.tgz",
+      "integrity": "sha512-KKno7cU9r1HdR48CRrsDu69/1UjZdoslq/UcE+Kx+tdhAv/aljXMkRSNzGMrBNOBDmHRgS1+58zm21WQWdQzwA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.29.2.tgz",
+      "integrity": "sha512-8Q39UR4/Tit759IeW9xZIe3NMwN11GsuA3FLheDyyGn7RrW02HD3HhUDlazE54Ki4HoosjFmChPlN4Ik2ubdRQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.29.2.tgz",
+      "integrity": "sha512-eUW3LN3fq8rXnjEUeI3D2QONYdLsU3yYQm4jxlErs2h4cfwrFjgf19VSUFVmm6LrFbbQ0OnDVPeVLL6iOwDw2w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.29.2.tgz",
+      "integrity": "sha512-6W4aIy70Mh7BNlbG9zZ5FBLhJhU2UUEzgZJ/jwYSCcB30o8McLxJSEjhtoHiX8R78Ah2/JzBGvIe5olZlbeE4A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.29.2.tgz",
+      "integrity": "sha512-8/ZPzbB9X85Mc9/7xVLZupQKBr2UVcQTGr512xtqMW+XkCQRHCph46tRo828YE13IMWI5fWn/FaNCqXG9cULSw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-image": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.29.2.tgz",
+      "integrity": "sha512-F+S4iru247mNVZdkNwNDZHeb281DkjsBJinaOGsOyJTvXY+KU5Uq7vY1LQTn493dTfU48Z0yMBUXwJffCT92Mg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.29.2.tgz",
+      "integrity": "sha512-iH63V/5wsaMnY4Jz0+meaAGhaec4AiOzOduzl6ZZr5IyGhZ1kthyW84ELt0dyLI3hNceAUhaNWc+I7+vX0aoXA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.29.2.tgz",
+      "integrity": "sha512-DcVer5SqrexKCEP6Ip1UPxJUMvcRCCItSv0wxoGytanrimBh2smvcg6X0DWnjlsi5H0updhyl+atYCmmQXUIXA==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.29.2.tgz",
+      "integrity": "sha512-WPZ9BHAPT6QeIm1vdVkuoOWvy9a8/EZeJwV2VhU8LXyTAttvzyj4rsbbHyJWvYWlUSTt/QF2AZ2zhKo7u1w3/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.29.2.tgz",
+      "integrity": "sha512-s8vBVHHFT0Qpu7CzAZ7S1kYmSiVaDvUNvMNcZUWnxj6VPfiwmx0eXd9FsjePrRCMoM5tFmPnhFTHDxY3D/eZeQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.29.2.tgz",
+      "integrity": "sha512-R+3k8OLnxdCH7Xy9ieOwUt5m2Je74u8mikothGmsYVO2Zyq48fIbmZ+X6RBPCu7DBOI2FIUhHEFbKQeDWvDNmA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.29.2.tgz",
+      "integrity": "sha512-ndCunC+UsYOpkOtL7vGnDz21UNa45WUlcO9wMT1fbuYow2QnRhsuMlCWENXI52YPPARWuQ0RDgN7q6TaxPERBg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.29.2.tgz",
+      "integrity": "sha512-7qJj5YTr11vvjNgjDN1ypOfwTovc0QOCYcit/rskeuVgnmQZOZQzC/BbyKLLG7UGnpRLemU/mEGbW9pAqjAXkQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.29.2.tgz",
+      "integrity": "sha512-/BlpPIq2JZk6zLaeYVOXazi6dmd0iRriTymNEnFn1doManN1y5HED9LsMeb/AhNhauL5AgmcHgpvAjbsN9k4SA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.29.2.tgz",
+      "integrity": "sha512-aEvLAbddUQZ+FukCreV3q4G2HfNI+odE7E9U+wbq6XsSWKyo8/pDu1muz+TFKNre4blSMOQ3JQmw5UeHDKy+fg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-task-item": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-item/-/extension-task-item-3.29.2.tgz",
+      "integrity": "sha512-mi5p2/FbUO9LFl7qPmRBThME+bFpd0vyeOD6IiWnD32hYZ720/N5VDkDypPmz+IaxTFaiLeGVmGC1SxGtxksKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-task-list": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-list/-/extension-task-list-3.29.2.tgz",
+      "integrity": "sha512-7ZkVoMcM3FAuvilZs3XliRRowPVMrVoKhfklfbNkTj9nVOvVToM+xcXKCcsZnf1mjMAyjw65m8doXJQKGCH7DA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.29.2.tgz",
+      "integrity": "sha512-Ubko45JWWHe8glBt2PiGNF8hcbys/JNalFhiR7Y1X4iOOtAxAKJJxh3+eq+//NTlGuBPdWGp7zw8EEUp7anjKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.29.2.tgz",
+      "integrity": "sha512-K7XwH/xS/5AIREWQ00VTEf/W5U0olp7j6wwit7cdd/8nHv6h6AGr1+iEApHKoLXWQZLfGQKzJlT9W61LAl+fHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.29.2.tgz",
+      "integrity": "sha512-BCz+FCAChSYtUe4BFj97HEO+nSK+J7GxbJgZG4Hg7DT/gI+hRyeNndU8efiQAx3WGdzsFi3UxRpcF1tTQM7iMQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.29.2.tgz",
+      "integrity": "sha512-GCOme7xHaS+DSoaA4CDcAD3l6JyBlvZhvCyfsy2Vp6j8tEoBkZWio7soYVosmlyn7zq8/64VeFZP5s47yfG7fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.4.1",
+        "prosemirror-commands": "^1.7.1",
+        "prosemirror-dropcursor": "^1.8.2",
+        "prosemirror-gapcursor": "^1.4.1",
+        "prosemirror-history": "^1.5.0",
+        "prosemirror-inputrules": "^1.5.1",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.11",
+        "prosemirror-schema-list": "^1.5.1",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-tables": "^1.8.5",
+        "prosemirror-transform": "^1.12.0",
+        "prosemirror-view": "^1.41.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.29.2.tgz",
+      "integrity": "sha512-oTu0tysiqk4zgjEtxRHjAQgxUKaAevZwueOWwSWubHdokqp7SpcbE5n9USJv89HKuTUDm3GjnQH6q8HNn/2DsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.29.2",
+        "@tiptap/extension-blockquote": "^3.29.2",
+        "@tiptap/extension-bold": "^3.29.2",
+        "@tiptap/extension-bullet-list": "^3.29.2",
+        "@tiptap/extension-code": "^3.29.2",
+        "@tiptap/extension-code-block": "^3.29.2",
+        "@tiptap/extension-document": "^3.29.2",
+        "@tiptap/extension-dropcursor": "^3.29.2",
+        "@tiptap/extension-gapcursor": "^3.29.2",
+        "@tiptap/extension-hard-break": "^3.29.2",
+        "@tiptap/extension-heading": "^3.29.2",
+        "@tiptap/extension-horizontal-rule": "^3.29.2",
+        "@tiptap/extension-italic": "^3.29.2",
+        "@tiptap/extension-link": "^3.29.2",
+        "@tiptap/extension-list": "^3.29.2",
+        "@tiptap/extension-list-item": "^3.29.2",
+        "@tiptap/extension-list-keymap": "^3.29.2",
+        "@tiptap/extension-ordered-list": "^3.29.2",
+        "@tiptap/extension-paragraph": "^3.29.2",
+        "@tiptap/extension-strike": "^3.29.2",
+        "@tiptap/extension-text": "^3.29.2",
+        "@tiptap/extension-underline": "^3.29.2",
+        "@tiptap/extensions": "^3.29.2",
+        "@tiptap/pm": "^3.29.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
@@ -1735,6 +2192,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/highlight.js": {
       "version": "9.12.4",
       "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.4.tgz",
@@ -1760,6 +2227,19 @@
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "license": "MIT"
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
@@ -2477,7 +2957,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2488,6 +2967,20 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
       "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -2849,6 +3342,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/linkifyjs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
+      "license": "MIT"
+    },
     "node_modules/locate-character": {
       "version": "3.0.0",
       "license": "MIT"
@@ -2858,6 +3357,22 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/lru-cache": {
       "version": "11.5.2",
@@ -2963,6 +3478,12 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.1",
@@ -3089,6 +3610,145 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
+      "integrity": "sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.11",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
+      "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.42.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
+      "integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.8",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3194,6 +3854,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/rw": {
       "version": "1.3.3",
@@ -3493,6 +4159,19 @@
         "node": ">=20"
       }
     },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "dev": true,
@@ -3704,6 +4383,12 @@
           "optional": false
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,12 +33,25 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
+    "@tiptap/core": "^3.29.2",
+    "@tiptap/extension-code-block-lowlight": "^3.29.2",
+    "@tiptap/extension-image": "^3.29.2",
+    "@tiptap/extension-link": "^3.29.2",
+    "@tiptap/extension-placeholder": "^3.29.2",
+    "@tiptap/extension-strike": "^3.29.2",
+    "@tiptap/extension-task-item": "^3.29.2",
+    "@tiptap/extension-task-list": "^3.29.2",
+    "@tiptap/extension-underline": "^3.29.2",
+    "@tiptap/pm": "^3.29.2",
+    "@tiptap/starter-kit": "^3.29.2",
+    "@types/turndown": "^5.0.6",
     "d3": "^7.9.0",
     "dompurify": "^3.4.12",
     "force-graph": "^1.47.0",
     "highlight.js": "^11.11.1",
     "lucide-svelte": "^0.468.0",
-    "marked": "^12.0.0"
+    "marked": "^12.0.0",
+    "turndown": "^7.2.4"
   },
   "type": "module"
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -223,6 +223,15 @@ export interface StreakStats {
 
 // ── Notes ─────────────────────────────────────────────────────────────────────
 
+export interface SyncConflict {
+  note_id: number;
+  title: string;
+  source_path: string;
+  local_mtime: string | null;
+  remote_mtime: string | null;
+  last_synced_at: string | null;
+}
+
 export const api = {
   auth: {
     login: (password: string, username = 'user') => 
@@ -448,5 +457,12 @@ github: {
       req<{ status: string }>('POST', '/push/unsubscribe'),
     test: (title: string, body: string) =>
       req<{ status: string }>('POST', '/push/test', { title, body }),
+  },
+
+  sync: {
+    conflicts: () =>
+      req<{ conflicts: SyncConflict[]; count: number }>('GET', '/sync/conflicts'),
+    resolve: (noteId: number, resolution: string, mergedContent?: string) =>
+      req<{ status: string; note_id: number; resolution: string }>('POST', `/sync/resolve/${noteId}`, { resolution, merged_content: mergedContent ?? null }),
   },
 };

--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -16,6 +16,7 @@
   import { extractFrontmatter, getFileIcon } from '$lib/utils/fileTree';
   import { downloadMarkdown, downloadHTML, copyNoteAsMarkdown } from '$lib/utils/export';
   import { showNotification } from '$lib/stores/gamification';
+  import WysiwygEditor from './WysiwygEditor.svelte';
 
   const AUTOSAVE_DELAY = 2000;
   const DRAFT_PREFIX = 'joidy-draft-';
@@ -118,6 +119,8 @@
   let saving = $state(false);
   let saved = $state(false);
   let previewMode = $state(false);
+  let wysiwygMode = $state(false);
+  let wysiwygRef = $state<WysiwygEditor | undefined>();
   let aiTimeout: ReturnType<typeof setTimeout>;
   let autosaveTimer: ReturnType<typeof setTimeout> | undefined;
   let hasUnsavedChanges = $state(false);
@@ -370,6 +373,25 @@
     }, 2000);
   }
 
+  function handleWysiwygChange(e: CustomEvent<string>) {
+    const md = e.detail;
+    scheduleSnapshot();
+    let nextContent = md;
+
+    if ($hideTagsLine && tags.length > 0 && currentTagsLine) {
+      if (!nextContent.includes(currentTagsLine)) {
+        nextContent = nextContent.trim() + '\n\n' + currentTagsLine;
+      }
+    }
+
+    if (!$showFrontmatter && rawFrontmatter) {
+      nextContent = rawFrontmatter + '\n\n' + nextContent.trim();
+    }
+
+    content = nextContent;
+    onContentChange();
+  }
+
   function acceptSuggestion(tag: string) {
     addTag(tag);
     aiSuggestions.update(s => s.filter(x => x.tag !== tag));
@@ -489,6 +511,10 @@
       e.preventDefault();
       previewMode = !previewMode;
     }
+    if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === 'v') {
+      e.preventDefault();
+      wysiwygMode = !wysiwygMode;
+    }
     if ((e.ctrlKey || e.metaKey) && e.key === 'z') {
       if (e.shiftKey) {
         e.preventDefault();
@@ -566,6 +592,25 @@
   };
 
   function formatMarkdown(type: string) {
+    if (wysiwygMode && wysiwygRef) {
+      switch (type) {
+        case 'bold': wysiwygRef.toggleBold(); break;
+        case 'italic': wysiwygRef.toggleItalic(); break;
+        case 'strikethrough': wysiwygRef.toggleStrike(); break;
+        case 'h1': wysiwygRef.toggleH1(); break;
+        case 'h2': wysiwygRef.toggleH2(); break;
+        case 'h3': wysiwygRef.toggleH3(); break;
+        case 'ul': wysiwygRef.toggleBulletList(); break;
+        case 'ol': wysiwygRef.toggleOrderedList(); break;
+        case 'link':
+          const url = prompt('URL del enlace:');
+          if (url) wysiwygRef.setLink(url);
+          break;
+        case 'quote': wysiwygRef.toggleBlockquote(); break;
+        case 'code': wysiwygRef.toggleCodeBlock(); break;
+      }
+      return;
+    }
     if (!textareaEl) return;
     const { selectionStart, selectionEnd } = textareaEl;
     const selected = content.substring(selectionStart, selectionEnd);
@@ -604,6 +649,10 @@
   }
 
   function insertAtCursor(text: string) {
+    if (wysiwygMode && wysiwygRef) {
+      wysiwygRef.insertContent(text);
+      return;
+    }
     if (!textareaEl) return;
     const { selectionStart, selectionEnd } = textareaEl;
     const before = content.substring(0, selectionStart);
@@ -819,6 +868,16 @@
 
       <button
         class="toolbar-btn"
+        class:active={wysiwygMode}
+        onclick={() => wysiwygMode = !wysiwygMode}
+        title="Editor visual (WYSIWYG)"
+      >
+        <Eye size={14} />
+        <span>{wysiwygMode ? 'Raw' : 'Visual'}</span>
+      </button>
+
+      <button
+        class="toolbar-btn"
         class:active={previewMode}
         onclick={() => previewMode = !previewMode}
         title="Alternar preview (Ctrl+P)"
@@ -966,6 +1025,14 @@
           </div>
         {/if}
       </div>
+    {:else if wysiwygMode}
+      <WysiwygEditor
+        bind:this={wysiwygRef}
+        content={visibleEditorContent}
+        placeholder="Escribe algo... (Ctrl+S para guardar)"
+        oncontentchange={handleWysiwygChange}
+        onsave={handleSave}
+      />
     {:else}
       <div class="editor-container">
         <div class="line-gutter" bind:this={lineGutterEl} aria-hidden="true">

--- a/frontend/src/lib/components/WysiwygEditor.svelte
+++ b/frontend/src/lib/components/WysiwygEditor.svelte
@@ -1,0 +1,273 @@
+<script lang="ts">
+  import { onMount, onDestroy, createEventDispatcher } from 'svelte';
+  import { Editor } from '@tiptap/core';
+  import StarterKit from '@tiptap/starter-kit';
+  import Link from '@tiptap/extension-link';
+  import Image from '@tiptap/extension-image';
+  import Placeholder from '@tiptap/extension-placeholder';
+  import TaskList from '@tiptap/extension-task-list';
+  import TaskItem from '@tiptap/extension-task-item';
+  import Underline from '@tiptap/extension-underline';
+  import { marked } from 'marked';
+  import TurndownService from 'turndown';
+  import DOMPurify from 'dompurify';
+
+  const dispatch = createEventDispatcher<{
+    contentchange: string;
+    save: void;
+  }>();
+
+  interface Props {
+    content: string;
+    placeholder?: string;
+    oncontentchange?: (e: CustomEvent<string>) => void;
+    onsave?: (e: CustomEvent<void>) => void;
+  }
+
+  let { content = '', placeholder = 'Escribe algo...', oncontentchange, onsave }: Props = $props();
+
+  let editor: Editor | null = null;
+  let editorElement: HTMLElement | null = null;
+
+  const turndown = new TurndownService({
+    headingStyle: 'atx',
+    codeBlockStyle: 'fenced',
+    bulletListMarker: '-',
+  });
+
+  // Convert markdown → HTML for TipTap
+  function markdownToHtml(md: string): string {
+    if (!md.trim()) return '';
+    const html = marked.parse(md, { gfm: true, breaks: true });
+    return DOMPurify.sanitize(String(html));
+  }
+
+  // Convert TipTap HTML → markdown
+  function htmlToMarkdown(html: string): string {
+    return turndown.turndown(html);
+  }
+
+  onMount(() => {
+    if (!editorElement) return;
+
+    editor = new Editor({
+      element: editorElement,
+      extensions: [
+        StarterKit.configure({
+          codeBlock: false,
+        }),
+        Underline,
+        Link.configure({
+          openOnClick: false,
+          HTMLAttributes: { class: 'tiptap-link' },
+        }),
+        Image.configure({
+          inline: false,
+          HTMLAttributes: { class: 'tiptap-image' },
+        }),
+        Placeholder.configure({ placeholder }),
+        TaskList,
+        TaskItem.configure({ nested: true }),
+      ],
+      content: markdownToHtml(content),
+      onUpdate: ({ editor }) => {
+        const md = htmlToMarkdown(editor.getHTML());
+        dispatch('contentchange', md);
+      },
+      editorProps: {
+        attributes: {
+          class: 'tiptap-prose',
+          spellcheck: 'false',
+        },
+        handleKeyDown: (_view, event) => {
+          if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+            event.preventDefault();
+            dispatch('save');
+            return true;
+          }
+          return false;
+        },
+      },
+    });
+  });
+
+  // Sync external content changes (e.g. note switch)
+  $effect(() => {
+    if (editor && content !== undefined) {
+      const currentMd = htmlToMarkdown(editor.getHTML());
+      if (currentMd !== content) {
+        editor.commands.setContent(markdownToHtml(content), { emitUpdate: false });
+      }
+    }
+  });
+
+  onDestroy(() => {
+    editor?.destroy();
+    editor = null;
+  });
+
+  // Toolbar actions
+  export function toggleBold() { editor?.chain().focus().toggleBold().run(); }
+  export function toggleItalic() { editor?.chain().focus().toggleItalic().run(); }
+  export function toggleUnderline() { editor?.chain().focus().toggleUnderline().run(); }
+  export function toggleStrike() { editor?.chain().focus().toggleStrike().run(); }
+  export function toggleH1() { editor?.chain().focus().toggleHeading({ level: 1 }).run(); }
+  export function toggleH2() { editor?.chain().focus().toggleHeading({ level: 2 }).run(); }
+  export function toggleH3() { editor?.chain().focus().toggleHeading({ level: 3 }).run(); }
+  export function toggleBulletList() { editor?.chain().focus().toggleBulletList().run(); }
+  export function toggleOrderedList() { editor?.chain().focus().toggleOrderedList().run(); }
+  export function toggleTaskList() { editor?.chain().focus().toggleTaskList().run(); }
+  export function toggleBlockquote() { editor?.chain().focus().toggleBlockquote().run(); }
+  export function toggleCodeBlock() { editor?.chain().focus().toggleCodeBlock().run(); }
+  export function setLink(url: string) {
+    if (url === '') {
+      editor?.chain().focus().unsetLink().run();
+    } else {
+      editor?.chain().focus().setLink({ href: url }).run();
+    }
+  }
+  export function insertImage(src: string, alt: string = '') {
+    editor?.chain().focus().setImage({ src, alt }).run();
+  }
+  export function insertContent(text: string) {
+    const html = markdownToHtml(text);
+    editor?.chain().focus().insertContent(html).run();
+  }
+</script>
+
+<div bind:this={editorElement} class="wysiwyg-editor"></div>
+
+<style>
+  :global(.wysiwyg-editor .tiptap-prose) {
+    outline: none;
+    min-height: 300px;
+    padding: 16px 20px;
+    font-size: 14px;
+    line-height: 1.7;
+    color: var(--text-primary);
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose:empty::before) {
+    content: attr(data-placeholder);
+    color: var(--text-muted);
+    pointer-events: none;
+    float: left;
+    height: 0;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose h1) {
+    font-size: 1.5em;
+    font-weight: 700;
+    margin: 0.8em 0 0.4em;
+    color: var(--md-h1, var(--xp));
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose h2) {
+    font-size: 1.3em;
+    font-weight: 600;
+    margin: 0.7em 0 0.3em;
+    color: var(--md-h2, var(--xp));
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose h3) {
+    font-size: 1.15em;
+    font-weight: 600;
+    margin: 0.6em 0 0.3em;
+    color: var(--md-h3, var(--xp));
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose p) {
+    margin: 0.4em 0;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose ul),
+  :global(.wysiwyg-editor .tiptap-prose ol) {
+    padding-left: 1.5em;
+    margin: 0.4em 0;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose ul) {
+    list-style: disc;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose ol) {
+    list-style: decimal;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose ul[data-type="taskList"]) {
+    list-style: none;
+    padding-left: 0;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose ul[data-type="taskList"] li) {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose ul[data-type="taskList"] li > label) {
+    flex-shrink: 0;
+    user-select: none;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose blockquote) {
+    border-left: 3px solid var(--border);
+    padding-left: 12px;
+    margin: 0.6em 0;
+    color: var(--text-secondary);
+    font-style: italic;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose pre) {
+    background: var(--elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 12px 16px;
+    overflow-x: auto;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    margin: 0.6em 0;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose code) {
+    background: var(--elevated);
+    border-radius: 3px;
+    padding: 0 4px;
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    color: var(--md-h1, var(--xp));
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose pre code) {
+    background: none;
+    padding: 0;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose a.tiptap-link) {
+    color: var(--md-h2, var(--xp));
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose img.tiptap-image) {
+    max-width: 100%;
+    border-radius: var(--r);
+    margin: 0.6em 0;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose hr) {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 1em 0;
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose strong) {
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+
+  :global(.wysiwyg-editor .tiptap-prose em) {
+    font-style: italic;
+    color: var(--text-secondary);
+  }
+</style>

--- a/frontend/src/lib/stores/sync.ts
+++ b/frontend/src/lib/stores/sync.ts
@@ -33,7 +33,7 @@ function createSyncStore() {
   async function checkConflicts(): Promise<void> {
     update(s => ({ ...s, loading: true }));
     try {
-      const data = await api<{ conflicts: SyncConflict[]; count: number }>('GET', '/sync/conflicts');
+      const data = await api.sync.conflicts();
       update(s => ({
         conflicts: data.conflicts,
         loading: false,
@@ -57,10 +57,7 @@ function createSyncStore() {
     mergedContent?: string
   ): Promise<boolean> {
     try {
-      await api('POST', `/sync/resolve/${noteId}`, {
-        resolution,
-        merged_content: mergedContent ?? null,
-      });
+      await api.sync.resolve(noteId, resolution, mergedContent);
       update(s => ({
         ...s,
         conflicts: s.conflicts.filter(c => c.note_id !== noteId),


### PR DESCRIPTION
## Issue #6: WYSIWYG Markdown Editor

## Summary

Adds a visual WYSIWYG markdown editor using TipTap, with a toggle between visual and raw markdown modes.

## Changes

### New: `frontend/src/lib/components/WysiwygEditor.svelte`
- TipTap-based editor with StarterKit, Link, Image, Placeholder, TaskList, Underline extensions
- Markdown ↔ HTML conversion: `marked` for md→html, `turndown` for html→md
- DOMPurify sanitization on input
- Exported methods: toggleBold, toggleItalic, toggleH1-3, toggleBulletList, toggleOrderedList, toggleBlockquote, toggleCodeBlock, setLink, insertImage, insertContent
- Ctrl+S keyboard shortcut for save
- CSS styled with project CSS variables (no hardcoded colors)

### Modified: `frontend/src/lib/components/NoteEditor.svelte`
- Toggle button in toolbar: **Visual** / **Raw** mode
- Keyboard shortcut: **Ctrl+Shift+V** to toggle WYSIWYG
- When WYSIWYG active: renders `WysiwygEditor` instead of textarea/backdrop
- Toolbar format buttons (bold, italic, headers, lists, link, quote, code) delegate to WYSIWYG methods
- `insertAtCursor` delegates to `wysiwygRef.insertContent` in WYSIWYG mode
- `handleWysiwygChange` syncs content back with frontmatter/tags line handling

### Dependencies added
- `@tiptap/core`, `@tiptap/starter-kit`, `@tiptap/pm`
- `@tiptap/extension-link`, `@tiptap/extension-image`, `@tiptap/extension-placeholder`
- `@tiptap/extension-task-list`, `@tiptap/extension-task-item`
- `@tiptap/extension-code-block-lowlight`, `@tiptap/extension-strike`, `@tiptap/extension-underline`
- `turndown`, `@types/turndown` (HTML→markdown conversion)

### Bugfix: `frontend/src/lib/stores/sync.ts` + `frontend/src/lib/api.ts`
- Fix sync store to use `api.sync.conflicts()` and `api.sync.resolve()` instead of calling `api` as a function
- Add `SyncConflict` interface and `sync` namespace to `api` object

## Testing

```bash
cd frontend && npm run check
```

**0 errors, 164 preexisting warnings (a11y, unused CSS — all from existing code)**

Closes #6