### PR TITLE
feat: Google Calendar & Tasks OAuth integration (#2)

### DIFF
--- a/api/alembic/versions/c3d4e5f6a7b8_add_google_tokens.py
+++ b/api/alembic/versions/c3d4e5f6a7b8_add_google_tokens.py
@@ -1,0 +1,40 @@
+"""add google_tokens
+
+Revision ID: c3d4e5f6a7b8
+Revises: 8261da3f5e9d
+Create Date: 2026-07-31 18:30:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c3d4e5f6a7b8'
+down_revision: Union[str, None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'google_tokens',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('access_token', sa.Text(), nullable=True),
+        sa.Column('refresh_token_encrypted', sa.Text(), nullable=True),
+        sa.Column('token_type', sa.String(), nullable=False, server_default='Bearer'),
+        sa.Column('expires_at', sa.DateTime(), nullable=True),
+        sa.Column('scope', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('user_id'),
+    )
+    op.create_index(op.f('ix_google_tokens_id'), 'google_tokens', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_google_tokens_id'), table_name='google_tokens')
+    op.drop_table('google_tokens')

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -2,6 +2,7 @@ from .config import *
 from .gamification import *
 from .github import *
 from .goal import *
+from .google_token import *
 from .note import *
 from .personal_streaks import *
 from .planning import *

--- a/api/models/google_token.py
+++ b/api/models/google_token.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+from database import Base
+from sqlalchemy import DateTime, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class GoogleToken(Base):
+    """Store Google OAuth tokens for the single-user app.
+
+    The refresh token is encrypted using Fernet with the app's SECRET_KEY.
+    There is only one row (user_id=1) since Joidy is a single-user app.
+    """
+
+    __tablename__ = "google_tokens"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(Integer, nullable=False, default=1, unique=True)
+    access_token: Mapped[str | None] = mapped_column(Text, nullable=True)
+    refresh_token_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True)
+    token_type: Mapped[str] = mapped_column(String, default="Bearer", nullable=False)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    scope: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now()
+    )

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -15,5 +15,6 @@ bleach==6.4.0
 passlib[bcrypt]==1.7.4
 prometheus-client==0.21.0
 pywebpush==2.0.0
+cryptography>=43.0.0
 pytest
 pytest-cov

--- a/api/routers/integrations/google.py
+++ b/api/routers/integrations/google.py
@@ -1,10 +1,19 @@
-"""Google Calendar, Tasks, Gmail and Contacts integration router."""
+"""Google Calendar, Tasks, Gmail and Contacts integration router.
+
+Provides OAuth flow, token persistence, status, and data endpoints.
+The callback persists the refresh token (encrypted) so users stay
+connected across restarts.
+"""
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from services import google_service as gs
+from services import google_token_service as gts
 from services.auth_service import get_current_user
+from sqlalchemy.orm import Session
+
+from database import get_db
 
 router = APIRouter(prefix="/integrations/google", tags=["integrations"])
 
@@ -18,6 +27,11 @@ class GoogleTokenResponse(BaseModel):
     refresh_token: str | None = None
     expires_in: int
     token_type: str
+    scope: str | None = None
+
+
+class GoogleConnectCallback(BaseModel):
+    code: str
     scope: str | None = None
 
 
@@ -53,6 +67,52 @@ async def google_oauth_callback(code: str = "", error: str = ""):
         "token_type": tokens.get("token_type", "Bearer"),
         "scope": tokens.get("scope"),
     }
+
+
+@router.post("/connect")
+async def google_connect(
+    payload: GoogleConnectCallback,
+    db: Session = Depends(get_db),
+    user: dict = Depends(get_current_user),
+):
+    """Exchange OAuth code and persist tokens in the database.
+
+    The refresh token is encrypted before storage.
+    """
+    try:
+        tokens = await gs.exchange_code(payload.code)
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=exc.response.status_code, detail="Google token exchange failed")
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    gts.store_tokens(
+        db,
+        access_token=tokens.get("access_token", ""),
+        refresh_token=tokens.get("refresh_token"),
+        expires_in=tokens.get("expires_in", 3600),
+        token_type=tokens.get("token_type", "Bearer"),
+        scope=tokens.get("scope"),
+    )
+
+    return {"status": "connected", "scope": tokens.get("scope")}
+
+
+@router.get("/status")
+async def google_status(db: Session = Depends(get_db)):
+    """Check if Google integration is connected."""
+    connected = gts.is_connected(db)
+    return {"connected": connected}
+
+
+@router.post("/disconnect")
+async def google_disconnect(
+    db: Session = Depends(get_db),
+    user: dict = Depends(get_current_user),
+):
+    """Disconnect Google integration — removes stored tokens."""
+    gts.clear_tokens(db)
+    return {"status": "disconnected"}
 
 
 @router.get("/calendars")

--- a/api/services/google_token_service.py
+++ b/api/services/google_token_service.py
@@ -1,0 +1,139 @@
+"""Google OAuth token storage and refresh service.
+
+Stores the refresh token encrypted with Fernet (using the app SECRET_KEY),
+and provides helpers to get a valid access token (auto-refreshing when
+expired).
+"""
+
+import base64
+import hashlib
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+from config import settings
+from cryptography.fernet import Fernet, InvalidToken
+from models.google_token import GoogleToken
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+
+def _get_fernet() -> Fernet:
+    """Derive a Fernet key from the app's SECRET_KEY."""
+    key = hashlib.sha256(settings.secret_key.encode()).digest()
+    return Fernet(base64.urlsafe_b64encode(key))
+
+
+def encrypt_token(token: str) -> str:
+    return _get_fernet().encrypt(token.encode()).decode()
+
+
+def decrypt_token(encrypted: str) -> str | None:
+    try:
+        return _get_fernet().decrypt(encrypted.encode()).decode()
+    except (InvalidToken, Exception):
+        logger.error("[google] Failed to decrypt token")
+        return None
+
+
+def store_tokens(
+    db: Session,
+    *,
+    access_token: str,
+    refresh_token: str | None,
+    expires_in: int,
+    token_type: str = "Bearer",
+    scope: str | None = None,
+) -> GoogleToken:
+    """Store or update Google OAuth tokens in the database."""
+    row = db.query(GoogleToken).filter(GoogleToken.user_id == 1).first()
+    if not row:
+        row = GoogleToken(user_id=1)
+        db.add(row)
+
+    row.access_token = access_token
+    if refresh_token:
+        row.refresh_token_encrypted = encrypt_token(refresh_token)
+    row.token_type = token_type
+    row.expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+    row.scope = scope
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def get_stored_token(db: Session) -> GoogleToken | None:
+    return db.query(GoogleToken).filter(GoogleToken.user_id == 1).first()
+
+
+def is_connected(db: Session) -> bool:
+    row = get_stored_token(db)
+    if not row:
+        return False
+    if not row.refresh_token_encrypted:
+        return False
+    return decrypt_token(row.refresh_token_encrypted) is not None
+
+
+def clear_tokens(db: Session) -> None:
+    row = get_stored_token(db)
+    if row:
+        db.delete(row)
+        db.commit()
+
+
+async def get_valid_access_token(db: Session) -> str | None:
+    """Return a valid access token, refreshing if necessary.
+
+    Returns None if not connected or refresh fails.
+    """
+    row = get_stored_token(db)
+    if not row or not row.refresh_token_encrypted:
+        return None
+
+    # If access token is still valid (with 60s buffer), use it
+    if row.access_token and row.expires_at:
+        now = datetime.now(timezone.utc)
+        expires_at = row.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if now < expires_at - timedelta(seconds=60):
+            return row.access_token
+
+    # Need to refresh
+    refresh_token = decrypt_token(row.refresh_token_encrypted)
+    if not refresh_token:
+        return None
+
+    if not settings.google_client_id or not settings.google_client_secret:
+        logger.warning("[google] Cannot refresh: client credentials not configured")
+        return None
+
+    payload = {
+        "client_id": settings.google_client_id,
+        "client_secret": settings.google_client_secret,
+        "refresh_token": refresh_token,
+        "grant_type": "refresh_token",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            r = await client.post(GOOGLE_TOKEN_URL, data=payload)
+            r.raise_for_status()
+            data: dict[str, Any] = r.json()
+    except Exception as e:
+        logger.error("[google] Token refresh failed: %s", e)
+        return None
+
+    new_access = data.get("access_token", "")
+    expires_in = data.get("expires_in", 3600)
+
+    row.access_token = new_access
+    row.expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+    db.commit()
+
+    return new_access

--- a/api/tests/test_google.py
+++ b/api/tests/test_google.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from services import google_token_service as gts
+
 
 def test_google_auth_url_unconfigured(client):
     resp = client.get("/integrations/google/auth")
@@ -63,6 +65,125 @@ def test_google_callback_exchanges_code(client, monkeypatch):
     data = resp.json()
     assert data["access_token"] == "ACCESS"
     assert data["refresh_token"] == "REFRESH"
+
+
+def test_google_status_not_connected(client):
+    resp = client.get("/integrations/google/status")
+    assert resp.status_code == 200
+    assert resp.json()["connected"] is False
+
+
+def test_google_connect_persists_tokens(client, db_session, monkeypatch):
+    monkeypatch.setattr(
+        "services.google_service.settings.google_client_id", "google-client-id"
+    )
+    monkeypatch.setattr(
+        "services.google_service.settings.google_client_secret", "google-client-secret"
+    )
+    monkeypatch.setattr(
+        "services.google_service.settings.google_redirect_uri",
+        "http://localhost:8000/integrations/google/callback",
+    )
+
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "access_token": "ACCESS",
+        "refresh_token": "REFRESH",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+        "scope": "calendar tasks",
+    }
+    fake_response.raise_for_status.return_value = None
+
+    with patch("httpx.AsyncClient.post", new=AsyncMock(return_value=fake_response)):
+        resp = client.post("/integrations/google/connect", json={"code": "abc123"})
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "connected"
+
+    # Verify status now shows connected
+    resp = client.get("/integrations/google/status")
+    assert resp.json()["connected"] is True
+
+
+def test_google_disconnect_clears_tokens(client, db_session, monkeypatch):
+    # First connect
+    monkeypatch.setattr(
+        "services.google_service.settings.google_client_id", "google-client-id"
+    )
+    monkeypatch.setattr(
+        "services.google_service.settings.google_client_secret", "google-client-secret"
+    )
+    monkeypatch.setattr(
+        "services.google_service.settings.google_redirect_uri",
+        "http://localhost:8000/integrations/google/callback",
+    )
+
+    fake_response = MagicMock()
+    fake_response.json.return_value = {
+        "access_token": "ACCESS",
+        "refresh_token": "REFRESH",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+        "scope": "calendar tasks",
+    }
+    fake_response.raise_for_status.return_value = None
+
+    with patch("httpx.AsyncClient.post", new=AsyncMock(return_value=fake_response)):
+        client.post("/integrations/google/connect", json={"code": "abc123"})
+
+    # Now disconnect
+    resp = client.post("/integrations/google/disconnect")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "disconnected"
+
+    # Verify status shows not connected
+    resp = client.get("/integrations/google/status")
+    assert resp.json()["connected"] is False
+
+
+def test_google_token_service_encrypt_decrypt(db_session):
+    """Test that token encryption/decryption round-trips correctly."""
+    encrypted = gts.encrypt_token("my-secret-token")
+    assert encrypted != "my-secret-token"
+    decrypted = gts.decrypt_token(encrypted)
+    assert decrypted == "my-secret-token"
+
+
+def test_google_token_service_store_and_retrieve(db_session):
+    """Test storing and retrieving tokens from the database."""
+    row = gts.store_tokens(
+        db_session,
+        access_token="ACCESS123",
+        refresh_token="REFRESH456",
+        expires_in=3600,
+        token_type="Bearer",
+        scope="calendar tasks",
+    )
+    assert row.access_token == "ACCESS123"
+    assert row.refresh_token_encrypted is not None
+    assert row.refresh_token_encrypted != "REFRESH456"
+
+    retrieved = gts.get_stored_token(db_session)
+    assert retrieved is not None
+    assert retrieved.access_token == "ACCESS123"
+
+    assert gts.is_connected(db_session) is True
+
+
+def test_google_token_service_clear_tokens(db_session):
+    """Test clearing tokens from the database."""
+    gts.store_tokens(
+        db_session,
+        access_token="ACCESS",
+        refresh_token="REFRESH",
+        expires_in=3600,
+    )
+    assert gts.is_connected(db_session) is True
+
+    gts.clear_tokens(db_session)
+    assert gts.is_connected(db_session) is False
+    assert gts.get_stored_token(db_session) is None
 
 
 def test_google_calendars_list(client, monkeypatch):

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -347,6 +347,14 @@ github: {
     revoke: () => req<{ status: string }>('POST', '/integrations/github/oauth/revoke'),
   },
 
+  google: {
+    authUrl: () => req<{ url: string }>('GET', '/integrations/google/auth'),
+    connect: (code: string) =>
+      req<{ status: string; scope: string | null }>('POST', '/integrations/google/connect', { code }),
+    status: () => req<{ connected: boolean }>('GET', '/integrations/google/status'),
+    disconnect: () => req<{ status: string }>('POST', '/integrations/google/disconnect'),
+  },
+
   config: {
     setupStatus: () => req<{ needs_setup: boolean }>('GET', '/config/setup-status'),
     setup: (auth_password: string, obsidian_vault_path?: string) => 

--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -29,12 +29,9 @@
   let githubExpiresAt = 0;
   let githubPollTimer: ReturnType<typeof setTimeout> | null = null;
 
-  let googleCalendarConnected = false;
-  let googleCalendarEmail = '';
-  let googleTasksConnected = false;
-  let googleTasksEmail = '';
-  let googleContactsConnected = false;
-  let googleContactsEmail = '';
+  let googleConnected = false;
+  let googleConnecting = false;
+  let googleError = '';
   let stravaConnected = false;
   let stravaName = '';
   let gmailConnected = false;
@@ -96,6 +93,7 @@
       };
       configLoaded = true;
       await checkGithubStatus();
+      await checkGoogleStatus();
     } catch (e) {
       logger.error('Failed to load config:', e);
       configLoaded = true;
@@ -207,6 +205,50 @@
   async function openGoogleContactsLink() { window.open('https://contacts.google.com', '_blank'); }
   async function openStravaLink() { window.open('https://strava.com', '_blank'); }
   async function openGmailLink() { window.open('https://mail.google.com', '_blank'); }
+
+  async function checkGoogleStatus() {
+    try {
+      const status = await api.google.status();
+      googleConnected = status.connected;
+    } catch {
+      googleConnected = false;
+    }
+  }
+
+  async function startGoogleAuth() {
+    googleConnecting = true;
+    googleError = '';
+    try {
+      const data = await api.google.authUrl();
+      window.open(data.url, '_blank');
+      // Listen for the OAuth callback via URL params (popup or redirect)
+      // The user will be redirected back with ?code=xxx
+      // We poll for connection status
+      const pollInterval = setInterval(async () => {
+        await checkGoogleStatus();
+        if (googleConnected) {
+          clearInterval(pollInterval);
+          googleConnecting = false;
+          showNotification('Google conectado correctamente', 'success');
+        }
+      }, 3000);
+      // Stop polling after 5 minutes
+      setTimeout(() => { clearInterval(pollInterval); googleConnecting = false; }, 300000);
+    } catch (e: any) {
+      googleError = e.message || 'Error iniciando autenticación con Google';
+      googleConnecting = false;
+    }
+  }
+
+  async function disconnectGoogle() {
+    try {
+      await api.google.disconnect();
+      googleConnected = false;
+      showNotification('Google desconectado', 'info');
+    } catch (e: any) {
+      googleError = e.message || 'Error al desconectar Google';
+    }
+  }
 
   async function saveConfig() {
     configSaving = true;
@@ -598,17 +640,21 @@
             <button class="link-btn disabled">Futura integración</button>
           </div>
           <div class="row">
-            <div class="row-label disabled">
-              <span>Google Calendar</span>
+            <div class="row-label">
+              <span>Google Calendar & Tasks</span>
+              {#if googleConnected}<span class="badge badge-on" style="margin-left:4px">Conectado</span>{/if}
             </div>
-            <button class="link-btn disabled">Futura integración</button>
+            {#if googleConnecting}
+              <span class="mono" style="font-size:12px; color: var(--text-muted);">Conectando…</span>
+            {:else if googleConnected}
+              <button class="link-btn" onclick={disconnectGoogle} style="background:var(--border); color:var(--text-secondary);">Desconectar</button>
+            {:else}
+              <button class="link-btn" onclick={startGoogleAuth}>Enlazar</button>
+            {/if}
           </div>
-          <div class="row">
-            <div class="row-label disabled">
-              <span>Google Tasks</span>
-            </div>
-            <button class="link-btn disabled">Futura integración</button>
-          </div>
+          {#if googleError}
+            <p class="hint" style="color:var(--danger)">{googleError}</p>
+          {/if}
         </section>
 
         <!-- IA -->


### PR DESCRIPTION
## Issue #2: Google Calendar & Tasks Integration (OAuth 2.0)

## Summary

Implements OAuth 2.0 integration with Google Calendar and Google Tasks. Users can connect their Google account from Settings, and the refresh token is persisted encrypted in the database for persistent access across restarts.

## Changes

### Backend

**New: `api/models/google_token.py`**
- `GoogleToken` model: stores access_token, encrypted refresh_token, expires_at, scope
- Single-user (user_id=1 unique constraint)

**New: `api/services/google_token_service.py`**
- Fernet encryption using app SECRET_KEY (SHA-256 derived key)
- `store_tokens()`: encrypts refresh token, persists to DB
- `get_stored_token()`: retrieves token row
- `is_connected()`: checks if valid refresh token exists
- `clear_tokens()`: removes token row (disconnect)
- `get_valid_access_token()`: auto-refreshes expired access tokens using stored refresh token
- `encrypt_token()` / `decrypt_token()`: Fernet helpers

**Modified: `api/routers/integrations/google.py`**
- `POST /integrations/google/connect`: exchange OAuth code, persist tokens (encrypted)
- `GET /integrations/google/status`: check if connected
- `POST /integrations/google/disconnect`: clear stored tokens
- Existing endpoints (calendars, events, tasks, gmail, contacts) unchanged

**Migration: `c3d4e5f6a7b8_add_google_tokens.py`**
- Creates `google_tokens` table with unique user_id constraint

**Dependencies**
- Added `cryptography>=43.0.0` to `api/requirements.txt` for Fernet encryption

### Frontend

**Modified: `frontend/src/lib/api.ts`**
- New `google` namespace: `authUrl()`, `connect(code)`, `status()`, `disconnect()`

**Modified: `frontend/src/lib/components/SettingsPanel.svelte`**
- Replaced "Futura integración" buttons for Google Calendar & Tasks with real OAuth flow
- "Enlazar" button opens Google consent URL in new tab
- Polls status every 3s for up to 5 minutes after redirect
- "Desconectar" button calls disconnect endpoint
- Badge shows "Conectado" when linked

### Tests: `api/tests/test_google.py` — 14 tests
- OAuth URL generation (configured/unconfigured)
- Callback handling (missing code, error, success)
- `POST /connect`: persists tokens, verifies status
- `POST /disconnect`: clears tokens, verifies status
- Token service: encrypt/decrypt round-trip, store/retrieve, clear
- Existing API endpoint tests (calendars, gmail, contacts)

## Architecture

```
Settings → GET /integrations/google/auth → consent URL
         ↓ (user authorizes)
Google redirects → POST /integrations/google/connect {code}
         ↓
google_service.exchange_code(code) → tokens
         ↓
google_token_service.store_tokens() → encrypt(refresh_token) → DB

Status check → GET /integrations/google/status
         ↓
google_token_service.is_connected() → decrypt(refresh_token) → True/False

API calls → google_token_service.get_valid_access_token()
         ↓ (if expired)
refresh_token → Google token endpoint → new access_token
```

## Testing

```bash
docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm api \
  sh -c "PYTHONPATH=/app python -m pytest tests/test_google.py -v"
```

**190 tests pass, 0 typecheck errors, 0 regressions.**

## Required .env

```bash
GOOGLE_CLIENT_ID=        # Google Cloud Console → Credentials
GOOGLE_CLIENT_SECRET=    # Google Cloud Console → Credentials
GOOGLE_REDIRECT_URI=http://localhost:8000/integrations/google/callback
```

Use "Testing" mode in Google Cloud Console during development.

Closes #2