### PR TITLE
fix(security): CORS & WebSocket auth + ai-service hardening

### DIFF
--- a/ai-service/config.py
+++ b/ai-service/config.py
@@ -9,6 +9,12 @@ class Settings(BaseSettings):
     database_url: str = "postgresql://joidy:joidy@postgres:5432/joidy"
     app_env: str = "development"
 
+    # Internal auth: shared secret for API → ai-service communication
+    internal_secret: str = ""
+
+    # CORS
+    cors_allowed_origins: str = ""
+
     # Multi-provider API keys
     gemini_api_key: str = ""
     openai_api_key: str = ""

--- a/ai-service/main.py
+++ b/ai-service/main.py
@@ -5,11 +5,13 @@ from circuit_breaker import llm_circuit_breaker, emb_circuit_breaker, CircuitBre
 from clients import get_embedding_client, get_llm_client
 from clients.prompts import CLASSIFY_PROMPT, RAG_PROMPT
 from config import settings
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
 from logging_config import get_correlation_id, set_correlation_id, setup_logging
 from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 
 @asynccontextmanager
@@ -34,6 +36,42 @@ class CorrelationMiddleware(BaseHTTPMiddleware):
 
 
 app.add_middleware(CorrelationMiddleware)
+
+
+# CORS: restrict to configured origins, or allow all in development
+_cors_origins = (
+    [o.strip() for o in settings.cors_allowed_origins.split(",") if o.strip()]
+    if settings.cors_allowed_origins
+    else (["*"] if settings.app_env != "production" else [])
+)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_cors_origins,
+    allow_credentials=settings.app_env == "production",
+    allow_methods=["GET", "POST"],
+    allow_headers=["Authorization", "Content-Type", "X-Request-ID", "X-Internal-Secret"],
+)
+
+
+class InternalAuthMiddleware(BaseHTTPMiddleware):
+    """Validate internal secret for non-health endpoints.
+
+    If INTERNAL_SECRET is configured, all endpoints except /health
+    require an X-Internal-Secret header matching the configured value.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        if settings.internal_secret and request.url.path != "/health":
+            provided = request.headers.get("X-Internal-Secret", "")
+            if provided != settings.internal_secret:
+                return JSONResponse(
+                    status_code=403,
+                    content={"detail": "Forbidden: invalid internal secret"},
+                )
+        return await call_next(request)
+
+
+app.add_middleware(InternalAuthMiddleware)
 
 
 class EmbedRequest(BaseModel):

--- a/api/config.py
+++ b/api/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     ai_service_url: str = "http://ai-service:8002"
     worker_url: str = "http://worker:8001"
     secret_key: str = ""
+    internal_secret: str = ""  # Shared secret for API → ai-service auth
     app_env: str = "development"
     cors_allowed_origins: str = ""  # Comma-separated origins for production (e.g. "https://joidy.app,https://www.joidy.app")
 

--- a/api/main.py
+++ b/api/main.py
@@ -92,8 +92,8 @@ class CorsSafetyMiddleware(BaseHTTPMiddleware):
                 request_origin = request.headers.get("origin")
                 if request_origin and request_origin in _cors_origins:
                     response.headers["Access-Control-Allow-Origin"] = request_origin
-        response.headers.setdefault("Access-Control-Allow-Methods", "*")
-        response.headers.setdefault("Access-Control-Allow-Headers", "*")
+                    response.headers.setdefault("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+                    response.headers.setdefault("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Request-Id")
         return response
 
 

--- a/api/routers/ai.py
+++ b/api/routers/ai.py
@@ -16,6 +16,8 @@ async def classify(req: ClassifyRequest):
     async with httpx.AsyncClient(timeout=30.0) as client:
         try:
             headers = {"X-Request-ID": get_correlation_id()}
+            if settings.internal_secret:
+                headers["X-Internal-Secret"] = settings.internal_secret
             r = await client.post(
                 f"{settings.ai_service_url}/classify",
                 json=req.model_dump(),
@@ -33,7 +35,10 @@ async def classify(req: ClassifyRequest):
 async def usage():
     async with httpx.AsyncClient(timeout=10.0) as client:
         try:
-            r = await client.get(f"{settings.ai_service_url}/usage", headers={"X-Request-ID": get_correlation_id()})
+            headers = {"X-Request-ID": get_correlation_id()}
+            if settings.internal_secret:
+                headers["X-Internal-Secret"] = settings.internal_secret
+            r = await client.get(f"{settings.ai_service_url}/usage", headers=headers)
             r.raise_for_status()
             return r.json()
         except httpx.HTTPError:

--- a/api/routers/websocket.py
+++ b/api/routers/websocket.py
@@ -6,7 +6,9 @@ import asyncio
 import json
 import logging
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from config import settings
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Query
+from services.auth_service import verify_token
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +48,28 @@ manager = ConnectionManager()
 
 
 @router.websocket("/ws")
-async def websocket_endpoint(websocket: WebSocket):
-    """Main WebSocket endpoint for real-time updates."""
+async def websocket_endpoint(
+    websocket: WebSocket,
+    token: str = Query(default=""),
+):
+    """Main WebSocket endpoint for real-time updates.
+
+    Validates JWT token via query parameter for authentication.
+    In development without AUTH_PASSWORD, auth is bypassed.
+    """
+    # Authenticate: verify token if auth is configured
+    if settings.auth_password:
+        if not token:
+            await websocket.close(code=4001, reason="Missing authentication token")
+            return
+        payload = verify_token(token)
+        if not payload:
+            await websocket.close(code=4001, reason="Invalid authentication token")
+            return
+    elif settings.app_env == "production":
+        await websocket.close(code=4001, reason="Authentication not configured")
+        return
+
     await manager.connect(websocket)
     try:
         while True:

--- a/api/services/embedding_service.py
+++ b/api/services/embedding_service.py
@@ -22,9 +22,13 @@ async def trigger_embedding(
     _db = _session_or_none(db)
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
+            headers = {}
+            if settings.internal_secret:
+                headers["X-Internal-Secret"] = settings.internal_secret
             response = await client.post(
                 f"{settings.ai_service_url}/embed",
                 json={"note_id": note_id, "content": content},
+                headers=headers,
             )
             response.raise_for_status()
         clear_embedding_failure(_db, note_id)

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -12,7 +12,7 @@
   import Login from '$lib/components/Login.svelte';
   import SetupWizard from '$lib/components/SetupWizard.svelte';
   import { api, type Goal, type PersonalStreak } from '$lib/api';
-  import { session, isAuthenticated } from '$lib/stores/session';
+  import { session, isAuthenticated, getToken } from '$lib/stores/session';
   import { totalXP, loadStats, pingActivity, globalLevel, nextStageXP, showNotification } from '$lib/stores/gamification';
   import { running, secondsLeft, phase } from '$lib/stores/pomodoro';
   import { initPomodoroSettings } from '$lib/stores/pomodoro';
@@ -125,7 +125,7 @@
           wsHost = `${host}:8000`;
         }
       }
-      const wsUrl = `${wsProto}//${wsHost}/ws`;
+      const wsUrl = `${wsProto}//${wsHost}/ws${getToken() ? `?token=${encodeURIComponent(getToken()!)}` : ''}`;
 
       logger.info('[layout] Connecting to WebSocket:', wsUrl);
       ws = new WebSocket(wsUrl);


### PR DESCRIPTION
## Security hardening batch 2

Fixes #326, #325, #378

### Changes

**#326 — CorsSafetyMiddleware wildcard headers**
- Removed global `setdefault("Access-Control-Allow-Methods", "*")` and `"*"` headers
- Now only adds specific methods (GET, POST, PUT, PATCH, DELETE, OPTIONS) and headers (Authorization, Content-Type, X-Request-Id) when origin matches in production
- In development, CORSMiddleware already handles these correctly

**#325 — WebSocket /ws without authentication**
- WebSocket endpoint now accepts `token` query parameter
- Validates JWT token using `verify_token()` when AUTH_PASSWORD is configured
- Rejects connections with code 4001 if token missing/invalid
- In production without AUTH_PASSWORD, rejects all connections
- Frontend (`+layout.svelte`) now sends JWT token in WebSocket URL

**#378 — ai-service without auth or CORS**
- Added `InternalAuthMiddleware` to ai-service: validates `X-Internal-Secret` header
- Added `CORSMiddleware` to ai-service with proper origin restrictions
- Added `internal_secret` and `cors_allowed_origins` to ai-service config
- API now sends `X-Internal-Secret` header in all calls to ai-service:
  - `embedding_service.py` (embed endpoint)
  - `routers/ai.py` (classify and usage endpoints)
- `/health` endpoint exempt from auth for Docker healthcheck

### Testing
190 tests pass, 0 typecheck errors, 0 regressions.