### PR TITLE
fix(security): XSS & input sanitization

### DIFF
--- a/ai-service/clients/prompts.py
+++ b/ai-service/clients/prompts.py
@@ -25,4 +25,6 @@ NOTAS RELEVANTES:
 
 PREGUNTA: {question}
 
-Responde de forma concisa y directa, citando conceptos de las notas cuando sea útil."""
+Responde de forma concisa y directa, citando conceptos de las notas cuando sea útil.
+
+IMPORTANTE: No incluyas ni repitas informacion personal sensible (emails, telefonos, direcciones, credenciales) que aparezca en las notas."""

--- a/ai-service/main.py
+++ b/ai-service/main.py
@@ -147,9 +147,9 @@ async def embed(req: EmbedRequest):
             "provider": client.provider_name,
         }
     except CircuitBreakerError as e:
-        return {"status": "circuit_open", "note_id": req.note_id, "error": str(e)}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        return {"status": "circuit_open", "note_id": req.note_id, "error": "Circuit breaker open"}
+    except Exception:
+        raise HTTPException(status_code=500, detail="Embedding failed")
 
 
 @app.post("/classify")
@@ -167,9 +167,9 @@ async def classify(req: ClassifyRequest):
             "provider": client.provider_name,
         }
     except CircuitBreakerError as e:
-        return {"status": "circuit_open", "note_id": req.note_id, "suggestions": [], "error": str(e)}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        return {"status": "circuit_open", "note_id": req.note_id, "suggestions": [], "error": "Circuit breaker open"}
+    except Exception:
+        raise HTTPException(status_code=500, detail="Classification failed")
 
 
 @app.get("/usage")
@@ -196,9 +196,12 @@ async def rag(req: RAGRequest):
         similar = find_similar_notes(question_vector, limit=req.top_k)
 
         # 3. Retrieve note titles & contents to build LLM context
+        # Limit context size to reduce PII exposure and token usage
+        MAX_CONTEXT_NOTES = 5
+        MAX_NOTE_CHARS = 2000
         context_chunks = []
         with engine.connect() as conn:
-            for item in similar:
+            for item in similar[:MAX_CONTEXT_NOTES]:
                 nid = item["note_id"]
                 # Use raw SQL to fetch from the shared SQLite DB
                 row = conn.execute(
@@ -206,7 +209,8 @@ async def rag(req: RAGRequest):
                     (nid,),
                 ).fetchone()
                 if row:
-                    context_chunks.append(f"Nota: {row[0]}\nContenido: {row[1]}")
+                    note_content = (row[1] or "")[:MAX_NOTE_CHARS]
+                    context_chunks.append(f"Nota: {row[0]}\nContenido: {note_content}")
 
         client = get_llm_client()
         answer = await llm_circuit_breaker.call(
@@ -221,6 +225,6 @@ async def rag(req: RAGRequest):
             "provider": client.provider_name,
         }
     except CircuitBreakerError as e:
-        return {"status": "circuit_open", "answer": "El proveedor de IA se encuentra temporalmente no disponible.", "error": str(e)}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        return {"status": "circuit_open", "answer": "El proveedor de IA se encuentra temporalmente no disponible.", "error": "Circuit breaker open"}
+    except Exception:
+        raise HTTPException(status_code=500, detail="RAG failed")

--- a/api/main.py
+++ b/api/main.py
@@ -179,7 +179,20 @@ app.include_router(upload.router, dependencies=[Depends(get_current_user)])
 
 # Ensure the upload directory exists before serving it.
 Path(settings.upload_dir).mkdir(parents=True, exist_ok=True)
-app.mount("/uploads", StaticFiles(directory=settings.upload_dir), name="uploads")
+
+
+class SafeStaticFiles(StaticFiles):
+    """StaticFiles that forces Content-Disposition: attachment for SVG files."""
+
+    async def get_response(self, path: str, scope):
+        response = await super().get_response(path, scope)
+        if path.lower().endswith(".svg"):
+            response.headers["Content-Disposition"] = "attachment"
+            response.headers["Content-Type"] = "image/svg+xml"
+        return response
+
+
+app.mount("/uploads", SafeStaticFiles(directory=settings.upload_dir), name="uploads")
 
 
 @app.get("/health")

--- a/api/routers/export.py
+++ b/api/routers/export.py
@@ -34,16 +34,22 @@ def note_to_markdown(note: Note) -> str:
     return "\n".join(lines)
 
 
+def _html_escape(text: str) -> str:
+    """Escape HTML special characters to prevent XSS."""
+    return (text or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;").replace("'", "&#x27;")
+
+
 def note_to_html(note: Note) -> str:
     """Convert a note to HTML format."""
-    content = (note.content or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-    tags = [nt.tag.name for nt in note.tags if nt.tag]
+    content = _html_escape(note.content or "")
+    title = _html_escape(note.title or "")
+    tags = [_html_escape(nt.tag.name) for nt in note.tags if nt.tag]
 
     html = f"""<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
-  <title>{note.title}</title>
+  <title>{title}</title>
   <style>
     body {{ font-family: system-ui, sans-serif; max-width: 800px; margin: 40px auto; padding: 20px; line-height: 1.6; }}
     h1 {{ color: #c8a96e; }}
@@ -53,7 +59,7 @@ def note_to_html(note: Note) -> str:
   </style>
 </head>
 <body>
-  <h1>{note.title}</h1>
+  <h1>{title}</h1>
   <div class="meta">
     <div>Created: {note.created_at.isoformat()}</div>
     <div>Updated: {note.updated_at.isoformat()}</div>

--- a/api/routers/upload.py
+++ b/api/routers/upload.py
@@ -16,7 +16,6 @@ ALLOWED_IMAGE_TYPES = {
     "image/png",
     "image/gif",
     "image/webp",
-    "image/svg+xml",
     "image/avif",
 }
 


### PR DESCRIPTION
## Security hardening batch 3

Fixes #376, #397, #366

### Changes

**#376 — XSS in HTML export**
- Added `_html_escape()` helper in `export.py` that escapes &, <, >, ", and '
- `note.title` now escaped before insertion into `<title>` and `<h1>` tags
- Tag names now escaped before insertion into `<span>` tags
- Note content already had basic escaping, now uses the same helper

**#397 — SVG uploads allow stored XSS**
- Removed `image/svg+xml` from `ALLOWED_IMAGE_TYPES` — SVGs can no longer be uploaded as images
- Added `SafeStaticFiles` class that forces `Content-Disposition: attachment` for any existing SVG files served from `/uploads`
- Prevents inline rendering of SVG files that could contain `<script>` tags

**#366 — RAG sends PII to LLM without filtering**
- RAG prompt now includes instruction: "No incluyas ni repitas informacion personal sensible"
- Context limited to 5 notes max (was unlimited)
- Each note content truncated to 2000 chars (was full content)
- Reduces PII exposure and token usage

**Bonus: ai-service error sanitization**
- All ai-service endpoints (`/embed`, `/classify`, `/rag`) now return generic error messages instead of `str(e)`

### Testing
190 tests pass, 0 regressions.