### PR TITLE
fix(security): API keys & secrets exposure

### DIFF
--- a/ai-service/main.py
+++ b/ai-service/main.py
@@ -121,7 +121,7 @@ def health():
 def providers():
     return {
         "available": settings.available_providers,
-        "configured": settings.provider_config,
+        "configured": {name: True for name in settings.provider_config},
         "llm_model": settings.llm_model,
         "embedding_model": settings.embedding_model,
     }

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -5,7 +5,7 @@ Authentication endpoints.
 from config import settings
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from services.auth_service import create_access_token
+from services.auth_service import create_access_token, verify_password, hash_password
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -26,7 +26,7 @@ def login(password: str = "", username: str = "user"):
         raise HTTPException(status_code=500, detail="Server not configured for auth")
 
     expected_password = settings.auth_password or ""
-    if expected_password and password != expected_password:
+    if expected_password and not verify_password(password, expected_password):
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
     # Create token for the single user (user_id=1)

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from services.auth_service import get_current_user
+from services.auth_service import get_current_user, hash_password
 
 from config import settings
 
@@ -207,7 +207,7 @@ def perform_setup(req: SetupRequest):
             detail="Password must be at least 4 characters long",
         )
 
-    env_vars["AUTH_PASSWORD"] = req.auth_password
+    env_vars["AUTH_PASSWORD"] = hash_password(req.auth_password)
     if req.obsidian_vault_path:
         env_vars["OBSIDIAN_VAULT_PATH"] = req.obsidian_vault_path
         
@@ -219,7 +219,7 @@ def perform_setup(req: SetupRequest):
     # Reload settings in memory
     import os
     from config import settings
-    settings.auth_password = req.auth_password
+    settings.auth_password = hash_password(req.auth_password)
     settings.secret_key = env_vars["SECRET_KEY"]
     if req.obsidian_vault_path:
         os.environ["OBSIDIAN_VAULT_PATH"] = req.obsidian_vault_path

--- a/api/routers/integrations/github.py
+++ b/api/routers/integrations/github.py
@@ -857,7 +857,13 @@ async def start_web_flow():
             detail="GitHub OAuth not configured. Set GITHUB_CLIENT_ID in .env"
         )
 
-    redirect_uri = settings.github_oauth_web_url or "http://localhost:8000/integrations/github/oauth/callback"
+    if not settings.github_oauth_web_url:
+        raise HTTPException(
+            status_code=400,
+            detail="GitHub OAuth redirect URI not configured. Set GITHUB_OAUTH_WEB_URL in .env"
+        )
+
+    redirect_uri = settings.github_oauth_web_url
     authorize_url = (
         f"https://github.com/login/oauth/authorize"
         f"?client_id={settings.github_client_id}"
@@ -900,7 +906,7 @@ async def oauth_callback(
                 "client_id": settings.github_client_id,
                 "client_secret": settings.github_client_secret,
                 "code": code,
-                "redirect_uri": settings.github_oauth_web_url or "http://localhost:8000/integrations/github/oauth/callback",
+                "redirect_uri": settings.github_oauth_web_url,
             },
         )
         r.raise_for_status()

--- a/api/services/auth_service.py
+++ b/api/services/auth_service.py
@@ -9,6 +9,7 @@ import jwt
 from config import settings
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from passlib.context import CryptContext
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,22 @@ ALGORITHM = "HS256"
 TOKEN_EXPIRE_HOURS = 24 * 7  # 1 week
 
 security = HTTPBearer(auto_error=False)
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain: str, hashed_or_plain: str) -> bool:
+    """Verify a password against a stored hash or plaintext.
+
+    Supports bcrypt hashes (starting with $2b$) and plaintext for backward compat.
+    """
+    if hashed_or_plain.startswith("$2b$"):
+        return pwd_context.verify(plain, hashed_or_plain)
+    return plain == hashed_or_plain
+
+
+def hash_password(plain: str) -> str:
+    """Hash a password using bcrypt."""
+    return pwd_context.hash(plain)
 
 
 def create_access_token(user_id: int, username: str = "user") -> str:


### PR DESCRIPTION
## Security hardening batch 4

Fixes #358, #377, #380

### Changes

**#358 — /providers exposes API keys**
- `/providers` endpoint in ai-service now returns `{name: True}` instead of `{name: {api_key: "..."}}` 
- API keys are no longer exposed in any response

**#377 — AUTH_PASSWORD stored in plaintext**
- Added `passlib[bcrypt]` password hashing to `auth_service.py`:
  - `verify_password()`: supports both bcrypt hashes (`b$` prefix) and plaintext (backward compat)
  - `hash_password()`: bcrypt hashing
- Login endpoint now uses `verify_password()` instead of plaintext comparison
- Setup endpoint now stores `hash_password(req.auth_password)` in .env instead of raw password
- Existing plaintext passwords still work (backward compat) — users can re-run setup to upgrade

**#380 — GitHub OAuth redirect_uri fallback to localhost:8000**
- Removed `or "http://localhost:8000/..."` fallback in both `start_web_flow` and `oauth/callback`
- Now raises HTTP 400 if `GITHUB_OAUTH_WEB_URL` is not configured
- Prevents OAuth flow from using insecure localhost URL in production

### Testing
190 tests pass, 0 regressions.