### PR TITLE
fix(security): remove hardcoded credentials from docker-compose (#328)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,18 @@ TELEGRAM_ALLOWED_USER_ID=
 SECRET_KEY=change_this_to_a_random_secret_key
 APP_ENV=development
 
+# ── Database (PostgreSQL) ─────────────────────────
+# Required: set a strong password for the database user.
+# Generate with: openssl rand -hex 24
+POSTGRES_USER=joidy
+POSTGRES_PASSWORD=
+POSTGRES_DB=joidy
+
+# ── Monitoring (Grafana) ──────────────────────────
+# Required only if using docker-compose.monitoring.yml
+# Generate with: openssl rand -hex 24
+GRAFANA_ADMIN_PASSWORD=
+
 # Comma-separated allowed CORS origins (e.g. http://localhost:3000,https://joidy.app).
 # In development, leave empty to allow all origins with credentials disabled.
 CORS_ALLOWED_ORIGINS=

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,12 @@ setup: ## First-time setup: copy .env, create data directories
 		echo "$(GREEN)✓$(NC) .env already exists"; \
 		echo "  Run 'make doctor' to check your configuration"; \
 	fi
+	@. .env 2>/dev/null || true; \
+	if [ -z "$$POSTGRES_PASSWORD" ]; then \
+		NEW_PW=$$(openssl rand -hex 24 2>/dev/null || python3 -c "import secrets; print(secrets.token_hex(24))" 2>/dev/null || echo "dev_pw_$$(date +%s)"); \
+		sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=$$NEW_PW|" .env; \
+		echo "$(GREEN)✓$(NC) Generated POSTGRES_PASSWORD"; \
+	fi
 	@echo ""
 	@echo "Or use 'make start' for a guided setup + start!"
 	@echo "────────────────────────────────────────────────────"
@@ -305,6 +311,12 @@ start: ## 🚀 Quick start: setup + start all services
 		NEW_SECRET=$$(openssl rand -hex 32 2>/dev/null || python3 -c "import secrets; print(secrets.token_hex(32))" 2>/dev/null || echo "dev_secret_$$(date +%s)"); \
 		sed -i "s|^SECRET_KEY=.*|SECRET_KEY=$$NEW_SECRET|" .env; \
 		echo "  ✓ Generated new SECRET_KEY"; \
+	fi
+	@. .env 2>/dev/null || true; \
+	if [ -z "$$POSTGRES_PASSWORD" ]; then \
+		NEW_PW=$$(openssl rand -hex 24 2>/dev/null || python3 -c "import secrets; print(secrets.token_hex(24))" 2>/dev/null || echo "dev_pw_$$(date +%s)"); \
+		sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=$$NEW_PW|" .env; \
+		echo "  ✓ Generated new POSTGRES_PASSWORD"; \
 	fi
 	@echo ""
 	@echo "Step 2: Starting services..."

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "3001:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required — set it in .env}
     volumes:
       - grafana-data:/var/lib/grafana
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,13 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     environment:
-      POSTGRES_USER: joidy
-      POSTGRES_PASSWORD: joidy
-      POSTGRES_DB: joidy
+      POSTGRES_USER: ${POSTGRES_USER:-joidy}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required — set it in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-joidy}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U joidy -d joidy"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -24,7 +24,7 @@ services:
       - ./.env:/app/.env
       - ${OBSIDIAN_VAULT_PATH:-./data/vault}:/vault
     environment:
-      - DATABASE_URL=postgresql://joidy:joidy@postgres:5432/joidy
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-joidy}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-joidy}
       - AI_SERVICE_URL=http://ai-service:8002
       - WORKER_URL=http://worker:8001
       - APP_ENV=${APP_ENV:-production}
@@ -50,7 +50,7 @@ services:
       - ./data/db:/data/db
       - ./.env:/app/.env:ro
     environment:
-      - DATABASE_URL=postgresql://joidy:joidy@postgres:5432/joidy
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-joidy}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-joidy}
       - APP_ENV=${APP_ENV:-production}
     depends_on:
       postgres:
@@ -64,7 +64,7 @@ services:
       - ./.env:/app/.env
       - ${OBSIDIAN_VAULT_PATH:-./data/vault}:/vault
     environment:
-      - DATABASE_URL=postgresql://joidy:joidy@postgres:5432/joidy
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-joidy}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-joidy}
       - API_URL=http://api:8000
       - AI_SERVICE_URL=http://ai-service:8002
       - VAULT_PATH=/vault


### PR DESCRIPTION
## Summary

- Postgres `POSTGRES_USER`/`POSTGRES_DB` now default to `joidy` but are overridable via env vars
- `POSTGRES_PASSWORD` is **required** (no default) — compose fails fast with a clear message if missing
- `GRAFANA_ADMIN_PASSWORD` is **required** (no default) in monitoring compose
- `DATABASE_URL` in all 3 services (api, ai-service, worker) is now constructed from the same env vars instead of hardcoded `joidy:joidy`
- Postgres healthcheck uses `$$POSTGRES_USER`/`$$POSTGRES_DB` (container-side shell expansion)
- `.env.example` documents the new variables
- `make setup` and `make start` auto-generate a random `POSTGRES_PASSWORD` if not set (same pattern as `SECRET_KEY`)

Part of epic #420 (Phase 1 — Security).

#### Test plan

- [ ] `POSTGRES_PASSWORD=test docker compose -f docker-compose.yml config` — validates, `DATABASE_URL` shows `joidy:test@...`
- [ ] `docker compose -f docker-compose.yml config` without `POSTGRES_PASSWORD` — fails with clear error
- [ ] `GRAFANA_ADMIN_PASSWORD=test docker compose -f docker-compose.monitoring.yml config` — validates
- [ ] `docker compose -f docker-compose.monitoring.yml config` without `GRAFANA_ADMIN_PASSWORD` — fails with clear error
- [ ] `make setup` generates `POSTGRES_PASSWORD` in `.env`
- [ ] `make start` generates `POSTGRES_PASSWORD` if missing

Closes #328

Generated with [Devin](https://devin.ai)