### PR TITLE
fix(security): run all containers as non-root user (#329)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,18 @@ TELEGRAM_ALLOWED_USER_ID=
 SECRET_KEY=change_this_to_a_random_secret_key
 APP_ENV=development
 
+# ── Database (PostgreSQL) ─────────────────────────
+# Required: set a strong password for the database user.
+# Generate with: openssl rand -hex 24
+POSTGRES_USER=joidy
+POSTGRES_PASSWORD=
+POSTGRES_DB=joidy
+
+# ── Monitoring (Grafana) ──────────────────────────
+# Required only if using docker-compose.monitoring.yml
+# Generate with: openssl rand -hex 24
+GRAFANA_ADMIN_PASSWORD=
+
 # Comma-separated allowed CORS origins (e.g. http://localhost:3000,https://joidy.app).
 # In development, leave empty to allow all origins with credentials disabled.
 CORS_ALLOWED_ORIGINS=

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,12 @@ setup: ## First-time setup: copy .env, create data directories
 		echo "$(GREEN)✓$(NC) .env already exists"; \
 		echo "  Run 'make doctor' to check your configuration"; \
 	fi
+	@. .env 2>/dev/null || true; \
+	if [ -z "$$POSTGRES_PASSWORD" ]; then \
+		NEW_PW=$$(openssl rand -hex 24 2>/dev/null || python3 -c "import secrets; print(secrets.token_hex(24))" 2>/dev/null || echo "dev_pw_$$(date +%s)"); \
+		sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=$$NEW_PW|" .env; \
+		echo "$(GREEN)✓$(NC) Generated POSTGRES_PASSWORD"; \
+	fi
 	@echo ""
 	@echo "Or use 'make start' for a guided setup + start!"
 	@echo "────────────────────────────────────────────────────"
@@ -305,6 +311,12 @@ start: ## 🚀 Quick start: setup + start all services
 		NEW_SECRET=$$(openssl rand -hex 32 2>/dev/null || python3 -c "import secrets; print(secrets.token_hex(32))" 2>/dev/null || echo "dev_secret_$$(date +%s)"); \
 		sed -i "s|^SECRET_KEY=.*|SECRET_KEY=$$NEW_SECRET|" .env; \
 		echo "  ✓ Generated new SECRET_KEY"; \
+	fi
+	@. .env 2>/dev/null || true; \
+	if [ -z "$$POSTGRES_PASSWORD" ]; then \
+		NEW_PW=$$(openssl rand -hex 24 2>/dev/null || python3 -c "import secrets; print(secrets.token_hex(24))" 2>/dev/null || echo "dev_pw_$$(date +%s)"); \
+		sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=$$NEW_PW|" .env; \
+		echo "  ✓ Generated new POSTGRES_PASSWORD"; \
 	fi
 	@echo ""
 	@echo "Step 2: Starting services..."

--- a/ai-service/Dockerfile
+++ b/ai-service/Dockerfile
@@ -8,6 +8,11 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+# Create non-root user (uid 1000 matches typical host user for dev volume mounts)
+RUN addgroup --system --gid 1000 app && adduser --system --uid 1000 --ingroup app app
+
+COPY --chown=app:app . .
+
+USER app
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+# Create non-root user (uid 1000 matches typical host user for dev volume mounts)
+RUN addgroup --system --gid 1000 app && adduser --system --uid 1000 --ingroup app app
+
+COPY --chown=app:app . .
+
+USER app
 
 CMD ["/bin/sh", "-c", "rm -rf alembic/versions/__pycache__ && exec uvicorn main:app --host 0.0.0.0 --port 8000 --workers ${WEB_CONCURRENCY:-2} --timeout-keep-alive ${UVICORN_TIMEOUT_KEEP_ALIVE:-5} --proxy-headers --forwarded-allow-ips='*'"]

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "3001:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required — set it in .env}
     volumes:
       - grafana-data:/var/lib/grafana
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,13 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     environment:
-      POSTGRES_USER: joidy
-      POSTGRES_PASSWORD: joidy
-      POSTGRES_DB: joidy
+      POSTGRES_USER: ${POSTGRES_USER:-joidy}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required — set it in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-joidy}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U joidy -d joidy"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -24,7 +24,7 @@ services:
       - ./.env:/app/.env
       - ${OBSIDIAN_VAULT_PATH:-./data/vault}:/vault
     environment:
-      - DATABASE_URL=postgresql://joidy:joidy@postgres:5432/joidy
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-joidy}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-joidy}
       - AI_SERVICE_URL=http://ai-service:8002
       - WORKER_URL=http://worker:8001
       - APP_ENV=${APP_ENV:-production}
@@ -50,7 +50,7 @@ services:
       - ./data/db:/data/db
       - ./.env:/app/.env:ro
     environment:
-      - DATABASE_URL=postgresql://joidy:joidy@postgres:5432/joidy
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-joidy}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-joidy}
       - APP_ENV=${APP_ENV:-production}
     depends_on:
       postgres:
@@ -64,7 +64,7 @@ services:
       - ./.env:/app/.env
       - ${OBSIDIAN_VAULT_PATH:-./data/vault}:/vault
     environment:
-      - DATABASE_URL=postgresql://joidy:joidy@postgres:5432/joidy
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-joidy}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-joidy}
       - API_URL=http://api:8000
       - AI_SERVICE_URL=http://ai-service:8002
       - VAULT_PATH=/vault

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,7 +6,8 @@ COPY package.json ./
 RUN npm install --legacy-peer-deps
 
 FROM deps AS development
-COPY . .
+COPY --chown=node:node . .
+USER node
 EXPOSE 3000
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
 
@@ -17,8 +18,9 @@ COPY . .
 RUN npm run build
 
 FROM base AS production
-COPY --from=build /app/build ./build
-COPY --from=build /app/package.json .
+COPY --from=build --chown=node:node /app/build ./build
+COPY --from=build --chown=node:node /app/package.json .
+USER node
 ENV NODE_ENV=production
 EXPOSE 3000
 CMD ["node", "build"]

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -13,6 +13,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+# Create non-root user (uid 1000 matches typical host user for dev volume mounts)
+RUN addgroup --system --gid 1000 app && adduser --system --uid 1000 --ingroup app app
+
+COPY --chown=app:app . .
+
+USER app
 
 CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary

All 4 Dockerfiles ran as root by default. Now each image runs as a non-root user:

- **api, ai-service, worker**: create system user `app` (uid 1000) with `COPY --chown=app:app` and `USER app`
- **frontend**: use existing `node` user (uid 1000) in `development` and `production` stages with `COPY --chown=node:node`

uid 1000 is chosen to match the typical host user uid, ensuring dev volume mounts (`./api:/app`, `./frontend:/app`, etc.) remain writable without permission issues.

The `build` stage in the frontend Dockerfile still runs as root (needed for `npm run build` to write to all directories), but the final `production` stage copies output with `--chown=node:node` and runs as `node`.

Part of epic #420 (Phase 1 — Security). Stacked on #421.

#### Test plan

- [ ] `docker compose -f docker-compose.yml -f docker-compose.dev.yml build` succeeds for all 4 services
- [ ] `docker compose exec api id` shows `uid=1000(app)`
- [ ] `docker compose exec ai-service id` shows `uid=1000(app)`
- [ ] `docker compose exec worker id` shows `uid=1000(app)`
- [ ] `docker compose exec frontend id` shows `uid=1000(node)`
- [ ] API healthcheck (`curl` to `/health/ready`) works as non-root
- [ ] `make dev` starts all services without permission errors
- [ ] `make migrate` (alembic) works as non-root

Closes #329

Generated with [Devin](https://devin.ai)