### PR TITLE
fix: high-priority bugs batch (#359, #360, #361, #368)

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -12,6 +12,8 @@ logger = logging.getLogger(__name__)
 
 engine = create_engine(
     settings.database_url,
+    pool_pre_ping=True,
+    pool_recycle=3600,
 )
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -25,6 +27,9 @@ def get_db():
     db = SessionLocal()
     try:
         yield db
+    except Exception:
+        db.rollback()
+        raise
     finally:
         db.close()
 

--- a/api/models/github.py
+++ b/api/models/github.py
@@ -65,7 +65,7 @@ class GitHubItem(Base):
     __tablename__ = "github_items"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    repo_id: Mapped[int] = mapped_column(Integer, ForeignKey("github_repos.id"), nullable=False)
+    repo_id: Mapped[int] = mapped_column(Integer, ForeignKey("github_repos.id", ondelete="CASCADE"), nullable=False)
     external_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
 
     item_type: Mapped[GitHubItemType] = mapped_column(Enum(GitHubItemType), nullable=False)
@@ -82,8 +82,8 @@ class GitHubItem(Base):
     url: Mapped[str] = mapped_column(String(500), nullable=False)
     html_url: Mapped[str] = mapped_column(String(500), nullable=False)
 
-    goal_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("goals.id"), nullable=True)
-    note_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("notes.id"), nullable=True)
+    goal_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("goals.id", ondelete="SET NULL"), nullable=True)
+    note_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("notes.id", ondelete="SET NULL"), nullable=True)
 
     synced_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
@@ -97,7 +97,7 @@ class GitHubEvent(Base):
     __tablename__ = "github_events"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    repo_id: Mapped[int] = mapped_column(Integer, ForeignKey("github_repos.id"), nullable=False)
+    repo_id: Mapped[int] = mapped_column(Integer, ForeignKey("github_repos.id", ondelete="CASCADE"), nullable=False)
 
     event_type: Mapped[GitHubEventType] = mapped_column(Enum(GitHubEventType), nullable=False)
     action: Mapped[str] = mapped_column(String(50), nullable=False)

--- a/api/models/goal.py
+++ b/api/models/goal.py
@@ -63,10 +63,10 @@ class Goal(Base):
     color: Mapped[str] = mapped_column(String(20), default="#c8a96e")
     theme: Mapped[str] = mapped_column(String(20), default="solid")
 
-    note_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("notes.id"), nullable=True)
-    tag_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("tags.id"), nullable=True)
+    note_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("notes.id", ondelete="SET NULL"), nullable=True)
+    tag_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("tags.id", ondelete="SET NULL"), nullable=True)
 
-    parent_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("goals.id"), nullable=True)
+    parent_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("goals.id", ondelete="SET NULL"), nullable=True)
 
     pending_removal: Mapped[bool] = mapped_column(Boolean, default=False)
 

--- a/api/models/note.py
+++ b/api/models/note.py
@@ -31,7 +31,7 @@ class Tag(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
-    parent_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("tags.id"), nullable=True)
+    parent_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("tags.id", ondelete="SET NULL"), nullable=True)
     color: Mapped[str] = mapped_column(String(20), default="#888888")
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 

--- a/api/models/planning.py
+++ b/api/models/planning.py
@@ -10,7 +10,7 @@ class PlanningAssignment(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
-    goal_id: Mapped[int] = mapped_column(Integer, ForeignKey("goals.id"), nullable=False)
+    goal_id: Mapped[int] = mapped_column(Integer, ForeignKey("goals.id", ondelete="CASCADE"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=None)
 
     goal = relationship("Goal")

--- a/api/models/skill.py
+++ b/api/models/skill.py
@@ -16,7 +16,7 @@ class Skill(Base):
     __tablename__ = "skills"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
-    tag_id: Mapped[int] = mapped_column(Integer, ForeignKey("tags.id"), unique=True)
+    tag_id: Mapped[int] = mapped_column(Integer, ForeignKey("tags.id", ondelete="CASCADE"), unique=True)
     note_count: Mapped[int] = mapped_column(Integer, default=0)
     level: Mapped[str] = mapped_column(String(20), default="locked")  # locked|apprentice|journeyman|expert|master
     xp: Mapped[int] = mapped_column(Integer, default=0)

--- a/api/repositories.py
+++ b/api/repositories.py
@@ -299,9 +299,10 @@ class StreakRecordRepository(BaseRepository[StreakRecord]):
         super().__init__(db, StreakRecord)
 
     def get_today(self) -> StreakRecord | None:
+        today = datetime.now(timezone.utc).date()
         return (
             self._db.query(StreakRecord)
-            .filter(StreakRecord.activity_date == date.today())
+            .filter(StreakRecord.activity_date == today)
             .first()
         )
 

--- a/api/routers/gamification.py
+++ b/api/routers/gamification.py
@@ -24,8 +24,8 @@ def _cached_stats(db: Session):
     next_stage_xp = PLANT_STAGES[stats.plant_stage + 1][0] if stats.plant_stage + 1 < len(PLANT_STAGES) else None
 
     # Heal: active today but streak still at 0 (written by old buggy engine)
-    from datetime import date as _date
-    if stats.current_streak == 0 and stats.last_activity_date == _date.today():
+    from datetime import datetime, timezone
+    if stats.current_streak == 0 and stats.last_activity_date == datetime.now(timezone.utc).date():
         stats.current_streak = 1
         if stats.longest_streak < 1:
             stats.longest_streak = 1

--- a/api/routers/personal_streaks.py
+++ b/api/routers/personal_streaks.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from database import get_db
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -24,7 +24,7 @@ def _backfill_streak_history(db: Session, streak: PersonalStreak):
     if not streak.start_date:
         return
 
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
     end_date = streak.created_at.date() if streak.created_at else today
     current = streak.start_date
 
@@ -67,7 +67,7 @@ def _compute_streak(checkin_dates: list[date], frequency: str = "daily", frequen
         return 0, 0
 
     dates_set = set(checkin_dates)
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
 
     if frequency == "every_n" and frequency_days > 1:
         # For every-N-days: streak counts how many consecutive "on-time" check-ins
@@ -127,7 +127,7 @@ def _compute_streak(checkin_dates: list[date], frequency: str = "daily", frequen
 
 
 def _streak_to_dict(streak: PersonalStreak, days_history: int = 365) -> dict:
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
     checkin_dates = [c.check_date for c in streak.checkins]
     checkin_map = {c.check_date: c for c in streak.checkins}
     current, longest = compute_streak(checkin_dates, streak.frequency or "daily", streak.frequency_days or 1)
@@ -265,7 +265,7 @@ def global_stats(db: Session = Depends(get_db)):
         total_checkins += len(checkin_dates)
 
     # Check-in rate for active streaks in last 30 days
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
     thirty_ago = today - timedelta(days=30)
     possible_checkins = 0
     actual_checkins = 0
@@ -326,7 +326,7 @@ def create_streak(data: StreakCreate, db: Session = Depends(get_db)):
         color=data.color,
         theme=data.theme,
         category=data.category,
-        start_date=data.start_date or date.today(),
+        start_date=data.start_date or datetime.now(timezone.utc).date(),
         target_date=data.target_date,
         offset=data.offset,
         frequency=data.frequency,
@@ -338,7 +338,7 @@ def create_streak(data: StreakCreate, db: Session = Depends(get_db)):
     db.refresh(streak)
 
     # Automatically backfill if start_date is in the past
-    if streak.start_date and streak.start_date < date.today():
+    if streak.start_date and streak.start_date < datetime.now(timezone.utc).date():
         backfill_streak_history(db, streak)
 
     return _streak_to_dict(streak)
@@ -368,7 +368,7 @@ def update_streak(streak_id: int, data: StreakUpdate, db: Session = Depends(get_
     db.refresh(streak)
 
     # If start_date was moved back, backfill again
-    if streak.start_date and streak.start_date < date.today():
+    if streak.start_date and streak.start_date < datetime.now(timezone.utc).date():
         backfill_streak_history(db, streak)
 
     return _streak_to_dict(streak)
@@ -392,7 +392,7 @@ def checkin(streak_id: int, data: CheckInData = None, db: Session = Depends(get_
     if not streak:
         raise HTTPException(status_code=404, detail="Streak not found")
 
-    today = data.check_date or date.today()
+    today = data.check_date or datetime.now(timezone.utc).date()
     existing = db.query(StreakCheckIn).filter(
         StreakCheckIn.streak_id == streak_id,
         StreakCheckIn.check_date == today,
@@ -435,7 +435,7 @@ def undo_checkin(streak_id: int, db: Session = Depends(get_db)):
     if not streak:
         raise HTTPException(status_code=404, detail="Streak not found")
 
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
     ci = db.query(StreakCheckIn).filter(
         StreakCheckIn.streak_id == streak_id,
         StreakCheckIn.check_date == today,
@@ -462,7 +462,7 @@ def use_freeze(streak_id: int, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="No freezes available")
 
     # Check if already checked in today
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
     already = db.query(StreakCheckIn).filter(
         StreakCheckIn.streak_id == streak_id,
         StreakCheckIn.check_date == today,
@@ -497,7 +497,7 @@ def get_history(
     if not streak:
         raise HTTPException(status_code=404, detail="Streak not found")
 
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
     since = today - timedelta(days=days)
     checkins = (
         db.query(StreakCheckIn)

--- a/api/routers/vault.py
+++ b/api/routers/vault.py
@@ -1,6 +1,6 @@
 """Endpoints for triggering _joidy/ vault file writes."""
 
-from datetime import date
+from datetime import datetime, timezone
 
 from database import get_db
 from fastapi import APIRouter, Depends
@@ -13,7 +13,7 @@ router = APIRouter(prefix="/vault", tags=["vault"])
 @router.post("/write-daily")
 def trigger_write_daily(db: Session = Depends(get_db)):
     ok = write_daily(db)
-    return {"status": "ok" if ok else "no_vault", "file": f"_joidy/daily/{date.today().isoformat()}.md"}
+    return {"status": "ok" if ok else "no_vault", "file": f"_joidy/daily/{datetime.now(timezone.utc).date().isoformat()}.md"}
 
 
 @router.post("/write-objectives")

--- a/api/services/gamification_engine.py
+++ b/api/services/gamification_engine.py
@@ -11,7 +11,7 @@ Every mutation in the system calls process_event(), which:
 import json
 import logging
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, timezone
 
 from config import settings
 from models.config import SystemConfig
@@ -148,6 +148,11 @@ STREAK_MILESTONES = {7, 30, 100, 365}
 GRACE_PERIOD_DAYS = 1  # One missed day forgiven per week
 
 
+def _today_utc() -> date:
+    """Return today's date in UTC to avoid timezone-related streak bugs."""
+    return datetime.now(timezone.utc).date()
+
+
 @dataclass
 class GamificationResult:
     xp_awarded: int = 0
@@ -177,7 +182,7 @@ def _compute_plant_stage(total_xp: int, db: Session | None = None) -> tuple[int,
 
 
 def _compute_streak(db: Session, stats: UserStats) -> tuple[int, bool]:
-    today = date.today()
+    today = _today_utc()
     last = stats.last_activity_date
 
     if last is None:
@@ -210,7 +215,7 @@ def process_event(
         metadata = {}
 
     stats = _get_or_create_stats(db)
-    today = date.today()
+    today = _today_utc()
 
     # Check if already at max XP
     stages = get_plant_stages(db)

--- a/api/services/joidy_vault_writer.py
+++ b/api/services/joidy_vault_writer.py
@@ -128,7 +128,7 @@ def write_daily(db: Session, target_date: date | None = None) -> bool:
     if not vault:
         return False
 
-    today = target_date or date.today()
+    today = target_date or datetime.now(timezone.utc).date()
     daily_dir = vault / JOIDY_DIR / "daily"
     daily_dir.mkdir(parents=True, exist_ok=True)
     filepath = daily_dir / f"{today.isoformat()}.md"

--- a/api/services/note_service.py
+++ b/api/services/note_service.py
@@ -3,7 +3,7 @@ import re
 
 from config import settings
 from models.note import Note, NoteLink, NoteTag, Tag
-from services.gamification_engine import process_event
+from services.gamification_engine import process_event, xp_for, get_xp_table
 from services.goal_service import sync_goals_from_note
 from services.response_cache import clear_api_caches
 from services.sanitizer import sanitize_content, sanitize_tag, sanitize_title
@@ -230,6 +230,15 @@ def delete_note(db: Session, note_id: int) -> bool:
         return False
 
     touched_tag_ids = {nt.tag_id for nt in note.tags}
+
+    # Revert XP awarded for note creation to prevent XP farming
+    from models.gamification import UserStats, XPEvent
+    stats = db.query(UserStats).filter(UserStats.id == 1).first()
+    if stats:
+        xp_to_revert = xp_for("note_created", db, 10)
+        stats.total_xp = max(0, stats.total_xp - xp_to_revert)
+        db.add(XPEvent(event_type="note_deleted", xp=-xp_to_revert, metadata_json=f'{{"note_id": {note_id}}}'))
+
     db.delete(note)
     sync_tag_cooccurrences_for_tags(db, touched_tag_ids)
     db.commit()

--- a/api/services/personal_streak_service.py
+++ b/api/services/personal_streak_service.py
@@ -1,5 +1,5 @@
 """Personal Streaks Service — extracted from routers for better separation of concerns."""
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from models.personal_streaks import PersonalStreak, StreakCheckIn
 from repositories import PersonalStreakRepository, StreakCheckInRepository
@@ -11,7 +11,7 @@ def backfill_streak_history(db: Session, streak: PersonalStreak) -> None:
     if not streak.start_date:
         return
 
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
     end_date = streak.created_at.date() if streak.created_at else today
     current = streak.start_date
 
@@ -51,7 +51,7 @@ def compute_streak(checkin_dates: list[date], frequency: str = "daily", frequenc
         return 0, 0
 
     dates_set = set(checkin_dates)
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
 
     if frequency == "every_n" and frequency_days > 1:
         sorted_dates = sorted(dates_set, reverse=True)


### PR DESCRIPTION
## High-priority bug fixes

Fixes #359, #360, #361, #368

### Changes

**#359 — XP farmable by creating and deleting notes**
- `delete_note()` now reverts the XP awarded for `note_created` (default 10 XP)
- Records a `note_deleted` XPEvent with negative XP for audit trail
- `total_xp` is clamped to 0 to prevent negative XP

**#360 — No db.rollback() on exceptions**
- `get_db()` now calls `db.rollback()` in the `except` block before `close()`
- Prevents partial/failed transactions from corrupting session state
- Added `pool_pre_ping=True` and `pool_recycle=3600` to SQLAlchemy engine to prevent stale connections

**#361 — date.today() without timezone**
- Replaced all `date.today()` with `datetime.now(timezone.utc).date()` in:
  - `gamification_engine.py` (`_compute_streak`, `process_event`)
  - `personal_streak_service.py` (`backfill_streak_history`, `compute_streak`)
  - `joidy_vault_writer.py` (`write_daily`)
  - `repositories.py` (`StreakRecordRepository.get_today`)
  - `routers/personal_streaks.py` (all occurrences)
  - `routers/vault.py` (`trigger_write_daily`)
  - `routers/gamification.py` (heal check)
- Prevents streak breakage when server timezone differs from user timezone

**#368 — Foreign keys without ondelete**
- Added `ondelete="CASCADE"` to:
  - `skills.tag_id → tags.id`
  - `planning_assignments.goal_id → goals.id`
  - `github_items.repo_id → github_repos.id`
  - `github_events.repo_id → github_repos.id`
- Added `ondelete="SET NULL"` to:
  - `tags.parent_id → tags.id` (self-referencing)
  - `goals.note_id → notes.id`
  - `goals.tag_id → tags.id`
  - `goals.parent_id → goals.id` (self-referencing)
  - `github_items.goal_id → goals.id`
  - `github_items.note_id → notes.id`

### Testing
190 tests pass, 0 regressions.

### Note
The `ondelete` changes to models require a migration to apply at the database level. The existing relationships already have `cascade="all, delete-orphan"` in SQLAlchemy ORM, so the ORM-level cascade works without a migration. The database-level `ondelete` will take effect on the next migration.