### PR TITLE
fix(quality): remove @ts-nocheck from 4 components, fix all type errors (#345)

### DIFF
--- a/frontend/src/lib/components/KnowledgeGraph.svelte
+++ b/frontend/src/lib/components/KnowledgeGraph.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  // @ts-nocheck
   import { onMount, onDestroy } from 'svelte';
   import * as d3 from 'd3';
   import { graphData, selectedTag } from '$lib/stores/graph';
@@ -7,7 +6,7 @@
 
   export let width = 800;
   export let height = 600;
-  export let focusId: number | null = null;
+  export let focusId: number | string | null = null;
 
   let svgEl: SVGSVGElement;
   let canvasEl: HTMLCanvasElement;
@@ -17,16 +16,16 @@
   let filterType: 'all' | 'notes' | 'tags' = 'all';
   let showOrphans = true;
   let searchQuery = '';
-  let hoveredId: number | null = null;
-  let lastFocusId: number | null = null;
+  let hoveredId: number | string | null = null;
+  let lastFocusId: number | string | null = null;
 
   let ctx: CanvasRenderingContext2D | null = null;
   let animationFrame: number;
   let sim: d3.Simulation<SimNode, undefined> | undefined;
   let zoom: d3.ZoomBehavior<SVGSVGElement, unknown>;
   let currentTransform = d3.zoomIdentity;
-  let neighborMap = new Map<number, Set<number>>();
-  let labelIndex = new Map<number, string>();
+  let neighborMap = new Map<number | string, Set<number | string>>();
+  let labelIndex = new Map<number | string, string>();
 
   const COLORS = {
     tag: '#7d6b91',
@@ -43,13 +42,7 @@
     return COLORS[type as keyof typeof COLORS] || COLORS.default;
   }
 
-  interface SimNode extends GraphNode {
-    x?: number;
-    y?: number;
-    fx?: number | null;
-    fy?: number | null;
-    vx?: number;
-    vy?: number;
+  interface SimNode extends GraphNode, d3.SimulationNodeDatum {
   }
 
   interface SimLink extends d3.SimulationLinkDatum<SimNode> {
@@ -96,21 +89,21 @@
     let filteredNodes = filterNodes(nodes);
     if (filteredNodes.length === 0) return;
 
-    let nodeIds = new Set(filteredNodes.map(n => n.id));
+    let nodeIds = new Set<number | string>(filteredNodes.map(n => n.id));
     let filteredEdges = edges.filter(e =>
-      nodeIds.has(e.source as number) && nodeIds.has(e.target as number)
+      nodeIds.has(e.source) && nodeIds.has(e.target)
     );
 
     if (!showOrphans) {
-      const degreeMap = new Map<number, number>();
+      const degreeMap = new Map<number | string, number>();
       filteredEdges.forEach((e) => {
-        degreeMap.set(e.source as number, (degreeMap.get(e.source as number) ?? 0) + 1);
-        degreeMap.set(e.target as number, (degreeMap.get(e.target as number) ?? 0) + 1);
+        degreeMap.set(e.source, (degreeMap.get(e.source) ?? 0) + 1);
+        degreeMap.set(e.target, (degreeMap.get(e.target) ?? 0) + 1);
       });
       filteredNodes = filteredNodes.filter(n => (degreeMap.get(n.id) ?? 0) > 0);
       nodeIds = new Set(filteredNodes.map(n => n.id));
       filteredEdges = filteredEdges.filter(e =>
-        nodeIds.has(e.source as number) && nodeIds.has(e.target as number)
+        nodeIds.has(e.source) && nodeIds.has(e.target)
       );
     }
 
@@ -133,13 +126,13 @@
       x: width/2 + (Math.random() - 0.5) * width * 0.8,
       y: height/2 + (Math.random() - 0.5) * height * 0.8,
     }));
-    const nodeMap = new Map(simNodes.map(n => [n.id, n]));
+    const nodeMap = new Map<number | string, SimNode>(simNodes.map(n => [n.id, n]));
     neighborMap = new Map();
     labelIndex = new Map(simNodes.map(n => [n.id, getNodeLabel(n).toLowerCase()]));
 
     const simLinks: SimLink[] = filteredEdges.map((e: GraphEdge) => ({
-      source: nodeMap.get(e.source as number) as SimNode,
-      target: nodeMap.get(e.target as number) as SimNode,
+      source: nodeMap.get(e.source) as SimNode,
+      target: nodeMap.get(e.target) as SimNode,
       type: e.type,
       weight: e.weight ?? 1,
       particles: e.type === 'linked' || e.type === 'tagged' ? [
@@ -167,7 +160,7 @@
         .strength(0.3))
       .force('charge', d3.forceManyBody().strength(-150).theta(0.8))
       .force('center', d3.forceCenter(width / 2, height / 2).strength(0.05))
-      .force('collision', d3.forceCollide().radius((d: SimNode) => nodeRadiusBase(d) + 6))
+      .force('collision', d3.forceCollide<SimNode>().radius((d: SimNode) => nodeRadiusBase(d) + 6))
       .alphaDecay(0.03)
       .velocityDecay(0.3)
       .alphaMin(0.001);
@@ -281,20 +274,20 @@
       };
 
       simLinks.forEach((link: SimLink) => {
-        if (!link.source.x || !link.source.y || !link.target.x || !link.target.y) return;
+        const source = link.source as SimNode;
+        const target = link.target as SimNode;
+        if (!source.x || !source.y || !target.x || !target.y) return;
 
-        const sx = link.source.x, sy = link.source.y;
-        const tx = link.target.x, ty = link.target.y;
+        const sx = source.x, sy = source.y;
+        const tx = target.x, ty = target.y;
 
         let linkAlpha = link.type === 'cooccurrence' ? 0.3 : 0.5;
         if (focus !== null) {
-          const sourceId = (link.source as SimNode).id;
-          const targetId = (link.target as SimNode).id;
+          const sourceId = source.id;
+          const targetId = target.id;
           linkAlpha = (sourceId === focus || targetId === focus) ? 0.9 : 0.08;
         } else if (hasQuery) {
-          const sourceNode = link.source as SimNode;
-          const targetNode = link.target as SimNode;
-          linkAlpha = (matchesQuery(sourceNode) || matchesQuery(targetNode)) ? 0.55 : 0.05;
+          linkAlpha = (matchesQuery(source) || matchesQuery(target)) ? 0.55 : 0.05;
         }
 
         ctx!.beginPath();
@@ -431,7 +424,7 @@
     zoomToFit();
   }
 
-  function focusOnNode(id: number) {
+  function focusOnNode(id: number | string) {
     if (!svgEl || !sim) return;
     const node = sim.nodes().find(n => n.id === id);
     if (!node || node.x === undefined || node.y === undefined) return;

--- a/frontend/src/lib/components/KnowledgeGraphForce.svelte
+++ b/frontend/src/lib/components/KnowledgeGraphForce.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
-  // @ts-nocheck
   import { onDestroy, onMount } from 'svelte';
   import { browser } from '$app/environment';
   import { graphData, selectedTag } from '$lib/stores/graph';
   import type { GraphNode, GraphEdge } from '$lib/api';
   import { forceCollide } from 'd3';
+  import type { NodeObject } from 'force-graph';
 
-  let ForceGraph: typeof import('force-graph') | null = null;
+  // ForceGraph constructor is dynamically imported; typed loosely since
+  // force-graph uses a Kapsule factory pattern with complex generics not
+  // fully captured by its .d.ts (callbacks expect NodeObject, we use GraphNode).
+  let ForceGraph: any = null;
+
+  // GraphNode extended with force-graph runtime properties (x, y added by the simulation)
+  type ForceGraphNode = GraphNode & NodeObject;
 
   export let width = 800;
   export let height = 600;
@@ -16,7 +22,7 @@
   export let data: { nodes: GraphNode[]; edges: GraphEdge[] } | null = null;
 
   let containerEl: HTMLDivElement;
-  let graph: ReturnType<typeof import('force-graph')['default']> | null = null;
+  let graph: any = null;
   let lastFocusId: number | string | null = null;
   let searchQuery = '';
   
@@ -205,7 +211,7 @@
       if (n.type === 'note' && !showNotes) return false;
       if (n.type === 'tag' && !showTags) return false;
       if (n.type === 'unresolved' && !showUnresolved) return false;
-      if (n.type === 'attachment' && !showAttachments) return false;
+      if ((n.type as string) === 'attachment' && !showAttachments) return false;
       return true;
     });
 
@@ -245,8 +251,10 @@
 
     graph
       .nodeRelSize(3.2)
-      .nodeCanvasObject((node: GraphNode, ctx: CanvasRenderingContext2D, scale: number) => {
-        if (!Number.isFinite(node.x) || !Number.isFinite(node.y)) return;
+      .nodeCanvasObject((node: ForceGraphNode, ctx: CanvasRenderingContext2D, scale: number) => {
+        const x = node.x;
+        const y = node.y;
+        if (x === undefined || y === undefined || !Number.isFinite(x) || !Number.isFinite(y)) return;
         const label = getNodeLabel(node);
         const isNote = node.type === 'note';
         const isTag = node.type === 'tag';
@@ -270,7 +278,7 @@
         ctx.globalAlpha = alpha;
 
         // Custom Color Queries Evaluation
-        let nodeColor = isTag ? COLORS.tag : (isUnresolved ? COLORS.unresolved : COLORS.note);
+        let nodeColor: string = isTag ? COLORS.tag : (isUnresolved ? COLORS.unresolved : COLORS.note);
         for (const group of colorGroups) {
           if (matchesQuery(node, group.query)) {
             nodeColor = group.color;
@@ -285,7 +293,7 @@
           ctx.strokeStyle = nodeColor;
           ctx.lineWidth = 1.2 / scale;
           ctx.setLineDash([2, 2]);
-          ctx.arc(node.x, node.y, r, 0, Math.PI * 2);
+          ctx.arc(x, y, r, 0, Math.PI * 2);
           ctx.stroke();
           ctx.setLineDash([]); // reset dash
 
@@ -294,17 +302,17 @@
         } else {
           // Normal nodes draw with gradient fill
           const gradient = ctx.createRadialGradient(
-            node.x - r * 0.3,
-            node.y - r * 0.3,
+            x - r * 0.3,
+            y - r * 0.3,
             0,
-            node.x,
-            node.y,
+            x,
+            y,
             r
           );
           gradient.addColorStop(0, lightenColor(nodeColor, 0.25));
           gradient.addColorStop(1, nodeColor);
           ctx.fillStyle = gradient;
-          ctx.arc(node.x, node.y, r, 0, Math.PI * 2);
+          ctx.arc(x, y, r, 0, Math.PI * 2);
           ctx.fill();
         }
 
@@ -314,7 +322,7 @@
           ctx.strokeStyle = '#ffffff';
           ctx.lineWidth = 1.5 / scale;
           ctx.globalAlpha = 0.95 * alpha;
-          ctx.arc(node.x, node.y, r + 2 / scale, 0, Math.PI * 2);
+          ctx.arc(x, y, r + 2 / scale, 0, Math.PI * 2);
           ctx.stroke();
         }
 
@@ -324,7 +332,7 @@
           ctx.strokeStyle = COLORS.selected;
           ctx.lineWidth = 2.0 / scale;
           ctx.globalAlpha = 0.95 * alpha;
-          ctx.arc(node.x, node.y, r + 3 / scale, 0, Math.PI * 2);
+          ctx.arc(x, y, r + 3 / scale, 0, Math.PI * 2);
           ctx.stroke();
         }
 
@@ -339,7 +347,7 @@
           ctx.globalAlpha = alpha;
 
           const labelText = label.length > 28 ? label.slice(0, 26) + '...' : label;
-          ctx.fillText(labelText, node.x, node.y + r + 6 / scale);
+          ctx.fillText(labelText, x, y + r + 6 / scale);
         }
       })
       .linkWidth((l: GraphEdge) => {
@@ -384,9 +392,9 @@
 
   function focusOnNode(id: number | string) {
     if (!graph) return;
-    const node = graph.graphData().nodes.find((n: GraphNode) => n.id === id) as GraphNode | undefined;
+    const node = graph.graphData().nodes.find((n: ForceGraphNode) => n.id === id) as ForceGraphNode | undefined;
     if (!node) return;
-    graph.centerAt(node.x, node.y, 400);
+    graph.centerAt(node.x ?? 0, node.y ?? 0, 400);
     graph.zoom(1.2, 400);
   }
 
@@ -459,7 +467,9 @@
 
     const module = await import('force-graph');
     if (!containerEl) return; // Prevent crash if unmounted during import
-    
+
+    // force-graph uses a Kapsule factory pattern: ForceGraph() returns a
+    // constructor, then calling it with the element creates a chainable instance.
     ForceGraph = module.default;
     graph = ForceGraph()(containerEl)
       .width(width)
@@ -467,8 +477,8 @@
       .backgroundColor('transparent')
       .enableNodeDrag(true)
       .onNodeClick(handleNodeClick)
-      .onNodeHover((node: GraphNode | null) => {
-        hoveredNode = node;
+      .onNodeHover((node: ForceGraphNode | null) => {
+        hoveredNode = node as GraphNode | null;
       });
 
     // NOTE: a `.minimap('#graph-minimap', ...)` chain used to be appended here,

--- a/frontend/src/lib/components/NoteCard.svelte
+++ b/frontend/src/lib/components/NoteCard.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  // @ts-nocheck
   import { createEventDispatcher } from 'svelte';
   import { goto } from '$app/navigation';
   import TagChip from './TagChip.svelte';
@@ -47,10 +46,10 @@
 
   function onCustomize(e: Event) {
     e.stopPropagation();
-    dispatch('customize', { 
-      path: getMetaKey(), 
-      icon: getFileMeta().icon, 
-      color: getFileMeta().color,
+    dispatch('customize', {
+      path: getMetaKey(),
+      icon: getFileMeta().icon,
+      color: getFileMeta().color ?? null,
       note: note
     });
   }
@@ -91,8 +90,8 @@
   {#if showTags && note.tags.length > 0}
     <div class="note-tags">
       {#each note.tags.slice(0, 4) as tag}
-        <TagChip {tag} onclick={(e) => {
-          const linkedNote = findNoteByTitle(e.detail);
+        <TagChip {tag} onclick={(tag) => {
+          const linkedNote = findNoteByTitle(tag);
           if (linkedNote) {
             goto(`/notes?id=${linkedNote.id}`);
           }

--- a/frontend/src/lib/components/VirtualList.svelte
+++ b/frontend/src/lib/components/VirtualList.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  // @ts-nocheck
   import { onMount, tick } from 'svelte';
 
   export let items: any[] = [];
@@ -69,9 +68,10 @@
 
   let ro: ResizeObserver;
 
-  onMount(async () => {
-    await tick();
-    if (containerEl) {
+  onMount(() => {
+    let destroyed = false;
+    tick().then(() => {
+      if (destroyed || !containerEl) return;
       containerHeight = containerEl.clientHeight;
       ro = new ResizeObserver((entries) => {
         let changed = false;
@@ -95,8 +95,9 @@
         }
       });
       ro.observe(containerEl);
-    }
+    });
     return () => {
+      destroyed = true;
       if (ro) ro.disconnect();
     };
   });


### PR DESCRIPTION
## Summary

Removed `// @ts-nocheck` from 4 components and fixed all 50 resulting TypeScript errors. `svelte-check` now reports **0 errors** (was 50).

### KnowledgeGraph.svelte
- `SimNode` now extends `d3.SimulationNodeDatum` (fixes `forceCollide` callback type)
- Map/Set types changed from `number` to `number | string` (matching `GraphNode.id`)
- `hoveredId`/`lastFocusId`/`focusId` changed to `number | string | null`
- `link.source`/`link.target` cast to `SimNode` before accessing `.x`/`.y`
- Removed unnecessary `as number` casts throughout

### KnowledgeGraphForce.svelte
- Created `ForceGraphNode` type (`GraphNode & NodeObject`) for force-graph compatibility
- Extracted `x`/`y` to local consts after undefined check (fixes canvas API calls)
- `nodeColor` explicitly typed as `string` (fixes `COLORS` const literal union)
- `n.type === 'attachment'` cast to `string` (type doesn't include 'attachment')
- `ForceGraph` and `graph` typed as `any` (Kapsule factory pattern with complex generics not captured by .d.ts)
- `focusOnNode` uses `?? 0` for optional `x`/`y`

### NoteCard.svelte
- `TagChip` `onclick` callback receives `tag: string`, not event with `.detail`
- `dispatch` color uses `?? null` (`getFileMeta` returns `undefined` for `DynamicIcon` compatibility)

### VirtualList.svelte
- `onMount` callback no longer `async` (returns cleanup function, not `Promise`)

Part of epic #420 (Phase 1 — Quality). Stacked on #422.

#### Test plan

- [x] `npx svelte-check --tsconfig ./tsconfig.json --threshold error` reports 0 errors
- [x] No `@ts-nocheck` remaining in `frontend/src/`
- [ ] `npm run build` succeeds
- [ ] KnowledgeGraph renders correctly (d3 force simulation)
- [ ] KnowledgeGraphForce renders correctly (force-graph)
- [ ] NoteCard tag click navigates to linked note
- [ ] VirtualList scroll/resize works

Closes #345

Generated with [Devin](https://devin.ai)