### PR TITLE
fix(ai-service): PostgreSQL migration, timeouts, rate limit, cache, input validation

### DIFF
--- a/ai-service/clients/anthropic.py
+++ b/ai-service/clients/anthropic.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 import anthropic
+import httpx
 from config import settings
 
 from .base import BaseLLMClient
@@ -11,7 +12,10 @@ logger = logging.getLogger(__name__)
 
 class AnthropicClient(BaseLLMClient):
     def __init__(self, api_key: str, model: str):
-        self._client = anthropic.AsyncAnthropic(api_key=api_key)
+        self._client = anthropic.AsyncAnthropic(
+            api_key=api_key,
+            timeout=httpx.Timeout(settings.llm_timeout, connect=settings.connect_timeout),
+        )
         self._model = model
 
     @property

--- a/ai-service/clients/cohere.py
+++ b/ai-service/clients/cohere.py
@@ -11,7 +11,11 @@ logger = logging.getLogger(__name__)
 
 class CohereClient(BaseLLMClient, EmbeddingClient):
     def __init__(self, api_key: str, model: str, is_embedding: bool = False):
-        self._client = cohere.AsyncClient(api_key=api_key)
+        timeout = settings.embed_timeout if is_embedding else settings.llm_timeout
+        self._client = cohere.AsyncClient(
+            api_key=api_key,
+            timeout=timeout,
+        )
         self._model = model
         self._is_embedding = is_embedding
 

--- a/ai-service/clients/gemini.py
+++ b/ai-service/clients/gemini.py
@@ -28,7 +28,8 @@ class GeminiClient(BaseLLMClient, EmbeddingClient):
                 model=self._model,
                 content=text,
                 task_type="RETRIEVAL_DOCUMENT",
-            )
+            ),
+            timeout=settings.embed_timeout,
         )
         return result["embedding"]
 
@@ -47,7 +48,8 @@ class GeminiClient(BaseLLMClient, EmbeddingClient):
                     temperature=temperature,
                     max_output_tokens=max_tokens,
                 ),
-            )
+            ),
+            timeout=settings.llm_timeout,
         )
         return response.text
 
@@ -57,7 +59,7 @@ def _is_retryable_error(exc: Exception) -> bool:
     return "429" in msg or "resource exhausted" in msg or "rate limit" in msg
 
 
-async def _call_with_retry(func):
+async def _call_with_retry(func, timeout: float | None = None):
     attempts = max(1, settings.ai_retry_max_attempts)
     base = max(0.1, settings.ai_retry_base_delay_seconds)
     cap = max(base, settings.ai_retry_max_delay_seconds)
@@ -65,8 +67,14 @@ async def _call_with_retry(func):
     for attempt in range(1, attempts + 1):
         try:
             # Run the synchronous google.generativeai call in a thread to
-            # avoid blocking the FastAPI event loop.
-            return await asyncio.to_thread(func)
+            # avoid blocking the FastAPI event loop. google-generativeai does
+            # not expose a per-request timeout, so enforce one with wait_for.
+            coro = asyncio.to_thread(func)
+            if timeout is not None:
+                return await asyncio.wait_for(coro, timeout=timeout)
+            return await coro
+        except asyncio.TimeoutError:
+            raise TimeoutError(f"Gemini call timed out after {timeout}s")
         except Exception as exc:
             if not _is_retryable_error(exc) or attempt >= attempts:
                 raise

--- a/ai-service/clients/openai.py
+++ b/ai-service/clients/openai.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 
+import httpx
 from config import settings
 from openai import AsyncOpenAI
 
@@ -11,7 +12,11 @@ logger = logging.getLogger(__name__)
 
 class OpenAIClient(BaseLLMClient, EmbeddingClient):
     def __init__(self, api_key: str, model: str, is_embedding: bool = False):
-        self._client = AsyncOpenAI(api_key=api_key)
+        timeout = settings.embed_timeout if is_embedding else settings.llm_timeout
+        self._client = AsyncOpenAI(
+            api_key=api_key,
+            timeout=httpx.Timeout(timeout, connect=settings.connect_timeout),
+        )
         self._model = model
         self._is_embedding = is_embedding
 

--- a/ai-service/config.py
+++ b/ai-service/config.py
@@ -34,6 +34,18 @@ class Settings(BaseSettings):
     ai_retry_base_delay_seconds: float = 1.0
     ai_retry_max_delay_seconds: float = 30.0
 
+    # Timeouts (seconds) for provider calls. Prevents indefinite hangs when a
+    # provider is degraded or unreachable. Embeddings are usually fast; LLM
+    # generation can take longer.
+    embed_timeout: float = 30.0
+    llm_timeout: float = 60.0
+    # Connect timeout shared by all providers (time to establish the TCP link).
+    connect_timeout: float = 5.0
+
+    # Response cache: avoids re-calling providers for identical inputs.
+    cache_ttl_seconds: float = 3600.0
+    cache_max_size: int = 2048
+
     @property
     def provider_config(self) -> dict:
         """Returns dict of provider -> {api_key, base_url} for available providers."""

--- a/ai-service/cost_tracker.py
+++ b/ai-service/cost_tracker.py
@@ -1,68 +1,86 @@
 """
-Tracks approximate Gemini API usage for transparency.
-Gemini 2.0 Flash: $0.075/1M input tokens, $0.30/1M output tokens.
-text-embedding-004: Free tier.
+Tracks approximate AI provider usage for transparency.
+
+Costs are rough estimates based on Gemini 2.0 Flash pricing:
+$0.075/1M input tokens, $0.30/1M output tokens.
+text-embedding-004: free tier (no input cost).
+
+Records are stored in the shared PostgreSQL database (table ``api_usage``)
+created by Alembic migration. Previously this used a stale SQLite file at
+``/data/db/joidy.db`` which never worked after the PostgreSQL migration (#273).
 """
 
-import sqlite3
-from datetime import date
-from pathlib import Path
+import logging
+from datetime import datetime, timezone
 
-DB_PATH = Path("/data/db/joidy.db")
+from sqlalchemy import text
+
+from database import engine
+
+logger = logging.getLogger(__name__)
 
 COST_PER_1M_INPUT = 0.075
 COST_PER_1M_OUTPUT = 0.300
 
 
-def _get_conn():
-    conn = sqlite3.connect(str(DB_PATH))
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS api_usage (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            operation TEXT NOT NULL,
-            input_tokens INTEGER DEFAULT 0,
-            output_tokens INTEGER DEFAULT 0,
-            created_at TEXT DEFAULT (datetime('now'))
-        )
-    """)
-    conn.commit()
-    return conn
-
-
 def record_usage(operation: str, input_tokens: int = 0, output_tokens: int = 0):
+    """Persist a single API call's token usage.
+
+    Non-blocking: logs a warning on failure instead of raising, so a tracking
+    issue never breaks the actual AI request. Unlike the previous SQLite
+    implementation, errors are surfaced in the logs rather than silently
+    swallowed.
+    """
     try:
-        conn = _get_conn()
-        conn.execute(
-            "INSERT INTO api_usage (operation, input_tokens, output_tokens) VALUES (?, ?, ?)",
-            (operation, input_tokens, output_tokens),
-        )
-        conn.commit()
-        conn.close()
-    except Exception:
-        pass  # Non-blocking
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO api_usage (operation, input_tokens, output_tokens) "
+                    "VALUES (:op, :in, :out)"
+                ),
+                {"op": operation, "in": input_tokens, "out": output_tokens},
+            )
+            conn.commit()
+    except Exception as exc:
+        logger.warning("[cost_tracker] record_usage failed: %s", exc)
 
 
 def get_monthly_stats() -> dict:
+    """Aggregate token usage and estimated cost for the current month."""
     try:
-        conn = _get_conn()
-        month_start = date.today().replace(day=1).isoformat()
-        row = conn.execute(
-            "SELECT SUM(input_tokens), SUM(output_tokens), COUNT(*) FROM api_usage WHERE created_at >= ?",
-            (month_start,),
-        ).fetchone()
-        conn.close()
+        now = datetime.now(timezone.utc)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT COALESCE(SUM(input_tokens), 0), "
+                    "COALESCE(SUM(output_tokens), 0), COUNT(*) "
+                    "FROM api_usage WHERE created_at >= :month_start"
+                ),
+                {"month_start": month_start},
+            ).fetchone()
 
-        total_input = row[0] or 0
-        total_output = row[1] or 0
-        total_calls = row[2] or 0
-        estimated_cost = (total_input / 1_000_000 * COST_PER_1M_INPUT) + (total_output / 1_000_000 * COST_PER_1M_OUTPUT)
+        total_input = int(row[0] or 0)
+        total_output = int(row[1] or 0)
+        total_calls = int(row[2] or 0)
+        estimated_cost = (
+            total_input / 1_000_000 * COST_PER_1M_INPUT
+            + total_output / 1_000_000 * COST_PER_1M_OUTPUT
+        )
 
         return {
-            "month": date.today().strftime("%Y-%m"),
+            "month": now.strftime("%Y-%m"),
             "total_input_tokens": total_input,
             "total_output_tokens": total_output,
             "total_api_calls": total_calls,
             "estimated_cost_usd": round(estimated_cost, 4),
         }
-    except Exception:
-        return {}
+    except Exception as exc:
+        logger.warning("[cost_tracker] get_monthly_stats failed: %s", exc)
+        return {
+            "month": datetime.now(timezone.utc).strftime("%Y-%m"),
+            "total_input_tokens": 0,
+            "total_output_tokens": 0,
+            "total_api_calls": 0,
+            "estimated_cost_usd": 0,
+        }

--- a/ai-service/database.py
+++ b/ai-service/database.py
@@ -1,3 +1,4 @@
+import json
 import struct
 from config import settings
 from sqlalchemy import create_engine, text
@@ -15,6 +16,15 @@ def get_db():
     finally:
         db.close()
 
+def _vector_literal(embedding: list[float]) -> str:
+    """Serialize a Python list into the pgvector text format ``[a,b,c]``.
+
+    ``str(list)`` produces Python repr (``[0.1, 0.2, ...]``) which is fragile
+    for pgvector. ``json.dumps`` with tight separators yields the canonical
+    pgvector format with no spaces after commas.
+    """
+    return json.dumps(embedding, separators=(",", ":"))
+
 def store_embedding(note_id: int, embedding: list[float]):
     """Store or update embedding for a note."""
     with engine.connect() as conn:
@@ -24,7 +34,7 @@ def store_embedding(note_id: int, embedding: list[float]):
             VALUES (:note_id, :embedding)
             ON CONFLICT (note_id) DO UPDATE SET embedding = EXCLUDED.embedding
             """),
-            {"note_id": note_id, "embedding": str(embedding)}
+            {"note_id": note_id, "embedding": _vector_literal(embedding)}
         )
         conn.execute(
             text("UPDATE notes SET is_embedded = true WHERE id = :note_id"),
@@ -42,6 +52,6 @@ def find_similar_notes(embedding: list[float], limit: int = 5) -> list[dict]:
             ORDER BY embedding <=> :embedding ASC
             LIMIT :limit
             """),
-            {"embedding": str(embedding), "limit": limit}
+            {"embedding": _vector_literal(embedding), "limit": limit}
         ).fetchall()
         return [{"note_id": row[0], "distance": row[1]} for row in rows]

--- a/ai-service/main.py
+++ b/ai-service/main.py
@@ -5,12 +5,15 @@ from circuit_breaker import llm_circuit_breaker, emb_circuit_breaker, CircuitBre
 from clients import get_embedding_client, get_llm_client
 from clients.prompts import CHAT_SYSTEM_PROMPT, CLASSIFY_PROMPT, RAG_PROMPT
 from config import settings
+from cost_tracker import get_monthly_stats, record_usage
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from logging_config import get_correlation_id, set_correlation_id, setup_logging
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from rate_limiter import get_limiter
+from response_cache import cache_key, get_cache
+from sqlalchemy import text
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -89,18 +92,23 @@ app.add_middleware(InternalAuthMiddleware)
 
 class EmbedRequest(BaseModel):
     note_id: int
-    content: str
+    content: str = Field(max_length=100_000)
 
 
 class ClassifyRequest(BaseModel):
     note_id: int
-    content: str
+    content: str = Field(max_length=10_000)
     existing_tags: list[str] = []
 
 
 class RAGRequest(BaseModel):
-    question: str
-    top_k: int = 5
+    question: str = Field(max_length=1000)
+    top_k: int = Field(default=5, ge=1, le=20)
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token estimate (~4 chars/token) for cost tracking."""
+    return max(1, len(text) // 4)
 
 
 class ChatMessage(BaseModel):
@@ -203,19 +211,34 @@ async def embed(req: EmbedRequest):
     if not settings.is_ai_enabled:
         return {"status": "disabled", "note_id": req.note_id, "error": "No AI provider configured"}
 
-    try:
-        client = get_embedding_client()
-        vector = await emb_circuit_breaker.call(client.embed, req.content)
+    await get_limiter(settings.max_requests_per_minute).acquire()
 
-        # Save vector embedding to shared SQLite database
+    # Cache: identical content + model always yields the same vector, so skip
+    # the provider call entirely when we have a hit.
+    key = cache_key("embed", settings.embedding_model, req.content)
+    cached = get_cache().get(key)
+
+    try:
+        if cached is not None:
+            vector = cached
+            provider_name = settings.embedding_model.split(":", 1)[0]
+        else:
+            client = get_embedding_client()
+            vector = await emb_circuit_breaker.call(client.embed, req.content)
+            provider_name = client.provider_name
+            get_cache().set(key, vector)
+
+        # Save vector embedding to shared PostgreSQL database
         from database import store_embedding
         store_embedding(req.note_id, vector)
+
+        record_usage("embed", input_tokens=_estimate_tokens(req.content))
 
         return {
             "status": "success",
             "note_id": req.note_id,
             "embedding": vector,
-            "provider": client.provider_name,
+            "provider": provider_name,
         }
     except CircuitBreakerError as e:
         return {"status": "circuit_open", "note_id": req.note_id, "error": "Circuit breaker open"}
@@ -228,14 +251,33 @@ async def classify(req: ClassifyRequest):
     if not settings.is_ai_enabled:
         return {"status": "disabled", "note_id": req.note_id, "suggestions": [], "error": "No AI provider configured"}
 
+    await get_limiter(settings.max_requests_per_minute).acquire()
+
+    # Cache keyed on content + existing tags + model. Classify is often fired
+    # repeatedly while editing, so this avoids burning provider quota.
+    tags_key = ",".join(sorted(req.existing_tags))
+    key = cache_key("classify", settings.llm_model, req.content, tags_key)
+    cached = get_cache().get(key)
+
     try:
-        client = get_llm_client()
-        suggestions = await llm_circuit_breaker.call(client.classify, req.content, req.existing_tags, CLASSIFY_PROMPT)
+        if cached is not None:
+            suggestions = cached
+            provider_name = settings.llm_model.split(":", 1)[0]
+        else:
+            client = get_llm_client()
+            suggestions = await llm_circuit_breaker.call(
+                client.classify, req.content, req.existing_tags, CLASSIFY_PROMPT
+            )
+            provider_name = client.provider_name
+            get_cache().set(key, suggestions)
+
+        record_usage("classify", input_tokens=_estimate_tokens(req.content))
+
         return {
             "status": "success",
             "note_id": req.note_id,
             "suggestions": suggestions,
-            "provider": client.provider_name,
+            "provider": provider_name,
         }
     except CircuitBreakerError as e:
         return {"status": "circuit_open", "note_id": req.note_id, "suggestions": [], "error": "Circuit breaker open"}
@@ -245,10 +287,11 @@ async def classify(req: ClassifyRequest):
 
 @app.get("/usage")
 def usage():
+    stats = get_monthly_stats()
     return {
         "ai_enabled": settings.is_ai_enabled,
         "available_providers": settings.available_providers,
-        "estimated_cost_usd": 0,
+        **stats,
     }
 
 
@@ -257,27 +300,30 @@ async def rag(req: RAGRequest):
     if not settings.is_ai_enabled:
         return {"status": "disabled", "answer": "No AI provider configured"}
 
+    await get_limiter(settings.max_requests_per_minute).acquire()
+
     try:
         # 1. Get embedding for the question
         emb_client = get_embedding_client()
         question_vector = await emb_circuit_breaker.call(emb_client.embed, req.question)
 
-        # 2. Find similar note IDs from SQLite vector database
+        # 2. Find similar note IDs via pgvector cosine similarity
         from database import engine, find_similar_notes
         similar = find_similar_notes(question_vector, limit=req.top_k)
 
-        # 3. Retrieve note titles & contents to build LLM context
-        # Limit context size to reduce PII exposure and token usage
+        # 3. Retrieve note titles & contents to build LLM context.
+        # Use SQLAlchemy text() with named parameters — PostgreSQL does not
+        # accept the SQLite "?" placeholder style (previously broken, #398).
+        # Limit context size to reduce PII exposure and token usage.
         MAX_CONTEXT_NOTES = 5
         MAX_NOTE_CHARS = 2000
         context_chunks = []
         with engine.connect() as conn:
             for item in similar[:MAX_CONTEXT_NOTES]:
                 nid = item["note_id"]
-                # Use raw SQL to fetch from the shared SQLite DB
                 row = conn.execute(
-                    "SELECT title, content FROM notes WHERE id = ?",  # type: ignore
-                    (nid,),
+                    text("SELECT title, content FROM notes WHERE id = :nid"),
+                    {"nid": nid},
                 ).fetchone()
                 if row:
                     note_content = (row[1] or "")[:MAX_NOTE_CHARS]
@@ -289,6 +335,10 @@ async def rag(req: RAGRequest):
             prompt=RAG_PROMPT.format(question=req.question, context="\n\n---\n\n".join(context_chunks)),
             temperature=0.2,
             max_tokens=512,
+        )
+        record_usage(
+            "rag",
+            input_tokens=_estimate_tokens(req.question) + sum(_estimate_tokens(c) for c in context_chunks),
         )
         return {
             "status": "success",

--- a/ai-service/response_cache.py
+++ b/ai-service/response_cache.py
@@ -1,0 +1,66 @@
+"""In-process TTL + size-bounded response cache for AI provider calls.
+
+Avoids re-calling providers for identical inputs (same text + model). The
+model is part of the cache key so changing the configured model invalidates
+stale entries automatically.
+
+This is a simple in-memory cache suitable for a single ai-service instance.
+For multi-instance deployments a shared store (e.g. Redis) would be needed,
+but that is out of scope here and the project does not currently run multiple
+ai-service replicas.
+"""
+
+import hashlib
+import time
+from collections import OrderedDict
+from threading import Lock
+from typing import Any
+
+from config import settings
+
+
+class TTLCache:
+    def __init__(self, max_size: int, ttl_seconds: float):
+        self._max_size = max(max_size, 1)
+        self._ttl = max(0.0, ttl_seconds)
+        self._data: "OrderedDict[str, tuple[float, Any]]" = OrderedDict()
+        self._lock = Lock()
+
+    def _is_expired(self, ts: float) -> bool:
+        return self._ttl <= 0 or (time.monotonic() - ts) >= self._ttl
+
+    def get(self, key: str) -> Any:
+        with self._lock:
+            entry = self._data.get(key)
+            if entry is None:
+                return None
+            ts, value = entry
+            if self._is_expired(ts):
+                self._data.pop(key, None)
+                return None
+            self._data.move_to_end(key)
+            return value
+
+    def set(self, key: str, value: Any) -> None:
+        with self._lock:
+            self._data[key] = (time.monotonic(), value)
+            self._data.move_to_end(key)
+            while len(self._data) > self._max_size:
+                self._data.popitem(last=False)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+
+
+_cache = TTLCache(max_size=settings.cache_max_size, ttl_seconds=settings.cache_ttl_seconds)
+
+
+def cache_key(*parts: str) -> str:
+    """Build a stable SHA-256 cache key from the given string parts."""
+    raw = "\x1f".join(parts)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def get_cache() -> TTLCache:
+    return _cache

--- a/api/alembic/versions/d4e5f6a7b8c9_add_api_usage.py
+++ b/api/alembic/versions/d4e5f6a7b8c9_add_api_usage.py
@@ -1,0 +1,52 @@
+"""add api_usage table for ai-service cost tracking
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-07-31 19:00:00.000000
+
+The ai-service cost_tracker previously wrote to a stale SQLite file
+(/data/db/joidy.db) that never worked after the PostgreSQL migration (#273).
+This migration creates the api_usage table in the shared PostgreSQL database
+so cost/usage tracking actually persists.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4e5f6a7b8c9'
+down_revision: Union[str, None] = 'c3d4e5f6a7b8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'api_usage',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('operation', sa.String(length=50), nullable=False),
+        sa.Column('input_tokens', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('output_tokens', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        'ix_api_usage_created_at',
+        'api_usage',
+        ['created_at'],
+        unique=False,
+    )
+    op.create_index(
+        'ix_api_usage_operation',
+        'api_usage',
+        ['operation'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_api_usage_operation', table_name='api_usage')
+    op.drop_index('ix_api_usage_created_at', table_name='api_usage')
+    op.drop_table('api_usage')


### PR DESCRIPTION
## Summary
Batch of ai-service fixes for the assigned high-priority bugs. All changes are confined to `ai-service/` plus one Alembic migration in `api/`.

- **#398** — `/rag` used SQLite `?` placeholder syntax with a raw SQL string, which throws on PostgreSQL. Switched to `sqlalchemy.text()` with named params (`:nid`); removed stale "shared SQLite DB" comment.
- **#399** — `cost_tracker.py` opened a legacy `/data/db/joidy.db` SQLite file that no longer exists (PostgreSQL-only since #273). `record_usage()` failed silently (`except: pass`) so cost tracking never worked and `/usage` always returned `0`. Rewrote to use the shared PostgreSQL engine, added Alembic migration for `api_usage`, wired `/usage` to real stats, and surface failures via logs.
- **#400** — `store_embedding`/`find_similar_notes` passed `str(list)` (Python repr with spaces) to pgvector. Switched to `json.dumps` with tight separators for the canonical pgvector `[a,b,c]` format.
- **#365** — OpenAI, Anthropic, Cohere, Gemini clients had no request timeouts, so a degraded provider could hang the service indefinitely. Added configurable `embed_timeout`/`llm_timeout`/`connect_timeout` (`httpx.Timeout` for SDK clients, `asyncio.wait_for` for `google-generativeai`).
- **#367** — Request models had no `max_length`, allowing multi-megabyte inputs. Added `Field(max_length=...)` bounds. The existing `rate_limiter` was never invoked; wired `get_limiter().acquire()` into `/embed`, `/classify`, `/rag`.
- **#372** — No response cache; identical embed/classify calls re-hit the provider (costly during reindexing and while typing). Added a TTL + size-bounded in-process cache keyed by content + model (model in the key invalidates entries when the configured model changes).

## Notes
- New migration `d4e5f6a7b8c9_add_api_usage` (down_revision `c3d4e5f6a7b8`). Run `make migrate`.
- Cache is in-process (single ai-service instance). Multi-instance would need Redis — out of scope.
- Token counts for `record_usage` are rough estimates (~4 chars/token) since provider response objects aren't uniformly shaped across all 6 providers.

#### Test plan
- [ ] `python -m compileall ai-service` passes
- [ ] `make migrate` applies the new migration cleanly
- [ ] `POST /embed` → row appears in `api_usage`; `GET /usage` returns non-zero after calls
- [ ] `POST /rag` no longer 500s on PostgreSQL (was the original #398 crash)
- [ ] Repeated identical `/embed` and `/classify` calls hit cache (no duplicate provider calls)
- [ ] Oversized `content`/`question` rejected with 422
- [ ] Provider call against an unreachable host times out instead of hanging

Generated with [Devin](https://devin.ai)