### PR TITLE
fix(backend): goal cycles, rate-limit leak, SQLite legacy, indexes, pagination

### DIFF
--- a/api/alembic/versions/e5f6a7b8c9d0_add_missing_indexes.py
+++ b/api/alembic/versions/e5f6a7b8c9d0_add_missing_indexes.py
@@ -1,0 +1,46 @@
+"""add missing indexes on FKs and frequently filtered/ordered columns
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-31 19:30:00.000000
+
+PostgreSQL does not auto-create indexes on foreign keys (unlike MySQL/InnoDB),
+and several columns used in WHERE/JOIN/ORDER BY clauses were unindexed,
+causing full table scans as the dataset grows (#403).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e5f6a7b8c9d0'
+down_revision: Union[str, None] = 'd4e5f6a7b8c9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index('ix_goals_parent_id', 'goals', ['parent_id'], unique=False)
+    op.create_index('ix_goals_note_id', 'goals', ['note_id'], unique=False)
+    op.create_index('ix_goals_tag_id', 'goals', ['tag_id'], unique=False)
+    op.create_index('ix_goals_state', 'goals', ['state'], unique=False)
+    op.create_index('ix_notes_created_at', 'notes', ['created_at'], unique=False)
+    op.create_index('ix_notes_updated_at', 'notes', ['updated_at'], unique=False)
+    op.create_index('ix_note_links_target_note_id', 'note_links', ['target_note_id'], unique=False)
+    op.create_index('ix_embedding_failures_next_retry_at', 'embedding_failures', ['next_retry_at'], unique=False)
+    op.create_index('ix_personal_streaks_is_archived', 'personal_streaks', ['is_archived'], unique=False)
+    op.create_index('ix_personal_streaks_category', 'personal_streaks', ['category'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_personal_streaks_category', table_name='personal_streaks')
+    op.drop_index('ix_personal_streaks_is_archived', table_name='personal_streaks')
+    op.drop_index('ix_embedding_failures_next_retry_at', table_name='embedding_failures')
+    op.drop_index('ix_note_links_target_note_id', table_name='note_links')
+    op.drop_index('ix_notes_updated_at', table_name='notes')
+    op.drop_index('ix_notes_created_at', table_name='notes')
+    op.drop_index('ix_goals_state', table_name='goals')
+    op.drop_index('ix_goals_tag_id', table_name='goals')
+    op.drop_index('ix_goals_note_id', table_name='goals')
+    op.drop_index('ix_goals_parent_id', table_name='goals')

--- a/api/database.py
+++ b/api/database.py
@@ -35,18 +35,9 @@ def get_db():
 
 
 def init_db():
-    db_url = settings.database_url
-
-    if db_url.startswith("sqlite"):
-        # SQLite path: ensure the parent directory exists and create tables.
-        # We skip PostgreSQL-specific vector extension and alembic migrations
-        # because the existing migrations are pgvector-oriented and SQLite
-        # does not support the PG vector extension.
-        db_path = Path(db_url.replace("sqlite:///", "").split("?")[0]).parent
-        db_path.mkdir(parents=True, exist_ok=True)
-        Base.metadata.create_all(engine)
-        return
-
+    # The project is PostgreSQL-only (16 + pgvector) since #273. The previous
+    # SQLite branch created a stale joidy.db and silently skipped migrations
+    # and the vector extension, causing schema drift and broken AI features.
     Path("/data/db").mkdir(parents=True, exist_ok=True)
     with engine.connect() as conn:
         conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))

--- a/api/middleware/rate_limit.py
+++ b/api/middleware/rate_limit.py
@@ -3,7 +3,6 @@ Per-user rate limiting middleware using sliding window.
 """
 
 import time
-from collections import defaultdict
 from dataclasses import dataclass
 
 from fastapi import HTTPException, Request
@@ -22,9 +21,10 @@ class UserRateLimiter:
         self.requests_per_minute = requests_per_minute
         self.auth_requests_per_minute = auth_requests_per_minute
         self.window_size = 60.0
-        self._user_windows: dict[str, UserLimit] = defaultdict(
-            lambda: UserLimit(requests=[], window_size=60.0)
-        )
+        # Plain dict (not defaultdict): entries are created on demand and
+        # removed once their window empties out, so inactive IPs/tokens/keys
+        # don't accumulate forever (previously a monotonic memory leak).
+        self._user_windows: dict[str, UserLimit] = {}
 
     def _get_limit_for_request(self, request: Request) -> tuple[str, int]:
         """Extract identifier and limit for rate limiting."""
@@ -51,15 +51,29 @@ class UserRateLimiter:
         cutoff = now - user_limit.window_size
         user_limit.requests = [ts for ts in user_limit.requests if ts > cutoff]
 
+    def _get_or_create_window(self, identifier: str) -> UserLimit:
+        user_limit = self._user_windows.get(identifier)
+        if user_limit is None:
+            user_limit = UserLimit(requests=[], window_size=self.window_size)
+            self._user_windows[identifier] = user_limit
+        return user_limit
+
+    def _maybe_evict(self, identifier: str, user_limit: UserLimit) -> None:
+        """Drop the window entry if it has no active requests, keeping the
+        dict bounded over time."""
+        if not user_limit.requests:
+            self._user_windows.pop(identifier, None)
+
     def check_rate_limit(self, request: Request) -> tuple[bool, int]:
         """Returns (allowed, limit)."""
         identifier, limit = self._get_limit_for_request(request)
         now = time.time()
 
-        user_limit = self._user_windows[identifier]
+        user_limit = self._get_or_create_window(identifier)
         self._clean_old_requests(user_limit, now)
 
         if len(user_limit.requests) >= limit:
+            # Window is non-empty (at capacity), so keep the entry.
             return False, limit
 
         user_limit.requests.append(now)
@@ -69,9 +83,13 @@ class UserRateLimiter:
         """Get remaining requests for identifier in current window."""
         identifier, _ = self._get_limit_for_request(request)
         now = time.time()
-        user_limit = self._user_windows[identifier]
+        user_limit = self._user_windows.get(identifier)
+        if user_limit is None:
+            return limit
         self._clean_old_requests(user_limit, now)
-        return max(0, limit - len(user_limit.requests))
+        remaining = max(0, limit - len(user_limit.requests))
+        self._maybe_evict(identifier, user_limit)
+        return remaining
 
 
 # Default: 60 requests per minute per IP, 5000 per authenticated key/token

--- a/api/models/goal.py
+++ b/api/models/goal.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     Enum,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
@@ -80,4 +81,13 @@ class Goal(Base):
 
     tag: Mapped["Tag | None"] = relationship("Tag")  # type: ignore
     note: Mapped["Note | None"] = relationship("Note")  # type: ignore
+
+    __table_args__ = (
+        # PostgreSQL does not auto-create indexes on FKs. These cover the
+        # common hierarchy/join/filter paths (#403).
+        Index("ix_goals_parent_id", "parent_id"),
+        Index("ix_goals_note_id", "note_id"),
+        Index("ix_goals_tag_id", "tag_id"),
+        Index("ix_goals_state", "state"),
+    )
 

--- a/api/models/note.py
+++ b/api/models/note.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from database import Base
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 class NoteEmbedding(Base):
@@ -24,6 +24,12 @@ class Note(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
 
     tags: Mapped[list["NoteTag"]] = relationship("NoteTag", back_populates="note", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        # Notes are frequently listed/ordered by these timestamps (#403).
+        Index("ix_notes_created_at", "created_at"),
+        Index("ix_notes_updated_at", "updated_at"),
+    )
 
 
 class Tag(Base):
@@ -65,6 +71,12 @@ class NoteLink(Base):
     source_note: Mapped["Note"] = relationship("Note", foreign_keys=[source_note_id], backref="out_links")
     target_note: Mapped["Note"] = relationship("Note", foreign_keys=[target_note_id], backref="in_links")
 
+    __table_args__ = (
+        # The composite PK (source_note_id, target_note_id) covers lookups by
+        # source, but backlink queries filter on target_note_id alone (#403).
+        Index("ix_note_links_target_note_id", "target_note_id"),
+    )
+
 
 class TagCooccurrence(Base):
     __tablename__ = "tag_cooccurrences"
@@ -83,3 +95,8 @@ class EmbeddingFailure(Base):
     last_error: Mapped[str] = mapped_column(Text, default="")
     next_retry_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        # The retry scheduler filters/orders by next_retry_at (#403).
+        Index("ix_embedding_failures_next_retry_at", "next_retry_at"),
+    )

--- a/api/models/personal_streaks.py
+++ b/api/models/personal_streaks.py
@@ -5,6 +5,7 @@ from sqlalchemy import (
     Date,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     String,
     UniqueConstraint,
@@ -41,6 +42,12 @@ class PersonalStreak(Base):
         back_populates="streak",
         cascade="all, delete-orphan",
         order_by="StreakCheckIn.check_date",
+    )
+
+    __table_args__ = (
+        # list_streaks filters on is_archived and category on every request (#403).
+        Index("ix_personal_streaks_is_archived", "is_archived"),
+        Index("ix_personal_streaks_category", "category"),
     )
 
 

--- a/api/routers/goals.py
+++ b/api/routers/goals.py
@@ -20,6 +20,7 @@ from services.goal_service import (
     get_goal_streak,
     resolve_pending_removal,
     sync_goals_from_note,
+    validate_goal_parent,
 )
 from services.joidy_vault_writer import (
     _write_goal_file,
@@ -223,6 +224,9 @@ def goal_streak(db: Session = Depends(get_db)):
 
 @router.post("/", status_code=201)
 def create_goal(data: GoalCreate, db: Session = Depends(get_db)):
+    # New goal has no id yet, so only parent existence can be violated, but
+    # validate anyway for consistency and to reject non-existent parents.
+    validate_goal_parent(db, goal_id=None, parent_id=data.parent_id)
     goal = Goal(**data.model_dump())
     db.add(goal)
     db.commit()
@@ -243,6 +247,9 @@ def update_goal(goal_id: int, data: GoalUpdate, db: Session = Depends(get_db)):
 
     update_data = data.model_dump(exclude_none=True)
     content = update_data.pop("content", None)
+
+    if "parent_id" in update_data:
+        validate_goal_parent(db, goal_id=goal.id, parent_id=update_data["parent_id"])
 
     for field, value in update_data.items():
         setattr(goal, field, value)
@@ -326,6 +333,7 @@ def save_goal_content(goal_id: int, data: GoalContent, db: Session = Depends(get
     goal.theme = data.theme
     goal.note_id = data.note_id
     goal.tag_id = data.tag_id
+    validate_goal_parent(db, goal_id=goal.id, parent_id=data.parent_id)
     goal.parent_id = data.parent_id
     goal.max_assignment_days = data.max_assignment_days
 

--- a/api/routers/integrations/github.py
+++ b/api/routers/integrations/github.py
@@ -168,8 +168,18 @@ async def add_repo_to_db(
 
 
 @router.get("/repos/db")
-async def list_repos_in_db(db: Session = Depends(get_db)):
-    repos = db.execute(select(GitHubRepo)).scalars().all()
+async def list_repos_in_db(
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+):
+    repos = (
+        db.execute(
+            select(GitHubRepo).offset(offset).limit(limit)
+        )
+        .scalars()
+        .all()
+    )
     return {
         "repos": [
             {
@@ -555,6 +565,8 @@ async def get_items_in_db(
     db: Session = Depends(get_db),
     repo_id: int | None = Query(None),
     goal_id: int | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
 ):
     query = select(GitHubItem)
     if repo_id:
@@ -562,7 +574,7 @@ async def get_items_in_db(
     if goal_id:
         query = query.where(GitHubItem.goal_id == goal_id)
 
-    items = db.execute(query).scalars().all()
+    items = db.execute(query.offset(offset).limit(limit)).scalars().all()
     return {
         "items": [
             {

--- a/api/routers/personal_streaks.py
+++ b/api/routers/personal_streaks.py
@@ -302,6 +302,8 @@ def list_streaks(
     category: str | None = Query(None),
     include_history: bool = Query(True),
     days_history: int = Query(365, ge=1, le=730),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
 ):
     q = db.query(PersonalStreak).options(selectinload(PersonalStreak.checkins))
@@ -309,7 +311,7 @@ def list_streaks(
         q = q.filter(PersonalStreak.is_archived == False)
     if category and category != "all":
         q = q.filter(PersonalStreak.category == category)
-    streaks = q.order_by(PersonalStreak.created_at).all()
+    streaks = q.order_by(PersonalStreak.created_at).offset(offset).limit(limit).all()
     return [
         _streak_to_dict(s, days_history=days_history if include_history else 0)
         for s in streaks

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -47,6 +47,12 @@ def create_tag(data: TagCreate, db: Session = Depends(get_db)):
     existing = db.query(Tag).filter(Tag.name == data.name.lower().strip()).first()
     if existing:
         raise HTTPException(status_code=409, detail="Tag already exists")
+    # A brand-new tag can't form a cycle (it has no id yet), but the parent
+    # must still exist. set_parent already enforces cycles for updates.
+    if data.parent_id is not None:
+        parent = db.query(Tag).filter(Tag.id == data.parent_id).first()
+        if not parent:
+            raise HTTPException(status_code=400, detail="Parent tag no existe")
     tag = Tag(name=data.name.lower().strip(), parent_id=data.parent_id)
     db.add(tag)
     db.commit()

--- a/api/services/goal_service.py
+++ b/api/services/goal_service.py
@@ -1,6 +1,7 @@
 import re
 from datetime import datetime, timedelta, timezone
 
+from fastapi import HTTPException
 from models.goal import (
     Goal,
     GoalFailConfig,
@@ -11,6 +12,33 @@ from models.goal import (
 from models.note import Note, NoteTag
 from repositories import GoalRepository
 from sqlalchemy.orm import Session
+
+
+def validate_goal_parent(db: Session, goal_id: int | None, parent_id: int | None) -> None:
+    """Ensure setting ``parent_id`` on a goal does not create a cycle.
+
+    A goal cannot be its own parent, and the parent chain starting from
+    ``parent_id`` must not lead back to ``goal_id``. Also verifies the parent
+    exists. Without this, recursive hierarchy queries can loop indefinitely
+    (#412).
+    """
+    if parent_id is None:
+        return
+    if goal_id is not None and parent_id == goal_id:
+        raise HTTPException(status_code=400, detail="Un goal no puede ser su propio padre")
+
+    visited: set[int] = set()
+    if goal_id is not None:
+        visited.add(goal_id)
+    current = parent_id
+    while current is not None:
+        if current in visited:
+            raise HTTPException(status_code=400, detail="Ciclo detectado en jerarquía de goals")
+        visited.add(current)
+        parent = db.query(Goal).filter(Goal.id == current).first()
+        if not parent:
+            raise HTTPException(status_code=400, detail="Parent goal no existe")
+        current = parent.parent_id
 
 
 def _parse_temporality(text: str) -> GoalTemporality:


### PR DESCRIPTION
## Summary
Batch of backend bug fixes for the assigned high-priority issues. All changes are in `api/` plus one Alembic migration.

- **#412** — `Goal.parent_id` had no cycle validation. `create_goal`, `update_goal` and `save_goal_content` could build `A→B→A` cycles (or self-references), looping recursive hierarchy queries. Added `validate_goal_parent()` (walks the parent chain, rejects self-reference, non-existent parent, and cycles) and call it in all three endpoints. `create_tag` now rejects non-existent parents (`set_parent` already handled cycles).
- **#401** — `UserRateLimiter._user_windows` was a `defaultdict` that grew forever: every unique IP/token/API key created a permanent entry even after going inactive (classic unbounded rate-limiter memory leak). Switched to a plain dict that evicts entries once their window empties.
- **#387** — `init_db()` kept a full SQLite branch (legacy from before the PostgreSQL migration #273) that created a stale `joidy.db` and silently skipped the vector extension + alembic migrations, causing schema drift. Removed the branch; the project is PostgreSQL-only. (`config.py` already defaulted to the PostgreSQL URL.)
- **#403** — PostgreSQL does not auto-create indexes on FKs (unlike MySQL/InnoDB). Added indexes on `goals(parent_id, note_id, tag_id, state)`, `notes(created_at, updated_at)`, `note_links(target_note_id)` (for backlink queries), `embedding_failures(next_retry_at)` (retry scheduler), `personal_streaks(is_archived, category)`. Migration `e5f6a7b8c9d0`.
- **#390** — `list_streaks`, `list_repos_in_db` and `get_items_in_db` returned all rows with no limit. Added `limit`/`offset` query params (default 50, max 200/100). The other `.all()` calls flagged in the issue (`gamification` streak-history/recent-events, `stats` daily aggregates, `goals` list) were already bounded by `limit`/`days` caps.

## Migration ordering
`e5f6a7b8c9d0` chains after `d4e5f6a7b8c9` (from ai-service PR #425). **Merge #425 first** to keep a single alembic head. CI does not run alembic (sqlite + `compileall` + pytest only), so this only affects `make migrate` at deploy time.

#### Test plan
- [ ] `python -m compileall api` passes
- [ ] `make test-api` passes (existing e2e suite uses sqlite + `create_all`)
- [ ] `make migrate` applies `e5f6a7b8c9d0` cleanly (after #425)
- [ ] Creating a goal with `parent_id` = its own id → 400
- [ ] Building A→B then A.parent=B, B.parent=A → 400 on the second update
- [ ] `GET /personal-streaks/?limit=10&offset=0` returns ≤10 rows
- [ ] Rate limiter: after a burst then 60s idle, `_user_windows` shrinks

Generated with [Devin](https://devin.ai)