### PR TITLE
docs: fix AGENTS.md migration count and TODO.md stale entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ main.py → routers/*.py → services/*.py → models/*.py
 - **routers/**: HTTP endpoints, Pydantic validation only
 - **services/**: Business logic + DB ops
 - **models/**: SQLAlchemy ORM
-- **alembic/versions/**: 12 migration files (`make migrate`)
+- **alembic/versions/**: 5 migration files (`make migrate`)
 - **tests/**: 7 test files (unittest)
 
 Internal comms:

--- a/TODO.md
+++ b/TODO.md
@@ -6,14 +6,13 @@
 ---
 
 ## 🏆 1. Logros Recientes (Completados)
-- [x] **Rate Limiting Avanzado**: Extender el middleware `RateLimitMiddleware` (PR #27 / Issue #27).
+- [x] **Migración a PostgreSQL**: PostgreSQL 16 + pgvector en producción (#4, #273).
 - [x] **Soporte de WebSocket End-to-End (Real-time)**: Conexión de Svelte a `/ws` y notificaciones reactivas (PR #27).
 - [x] **Menú de Exportación en Interfaz (Frontend)**: Controles para exportar markdown/html/zip en `NoteEditor.svelte` (PR #27).
 - [x] **Bug en Health Check de Caché (Backend)**: Corregido en `api/services/response_cache.py` (PR #27).
 - [x] **VirtualList dinámica**: Refactorizado para admitir alturas variables (Issue #7).
 - [x] **Migración Consistente a Runas Svelte 5**: Reactividad nativa en componentes (Issue #10).
 - [x] **Seguridad JWT**: Autenticación nativa por JWT (Issue #14).
-- [x] **Ruff + Black**: Pipeline de formateo automático y análisis estático (Issue #16).
 - [x] **Dashboard de Historial Anual**: Componente `StreakHeatmap` interactivo.
 - [x] **Modal de Objetivos**: Componente `GoalOverlay`.
 - [x] **Dashboard de Planificación unificado (SGOJ)**.
@@ -27,7 +26,6 @@
 ### 2.1 Integraciones & Backend
 - [ ] **Calendario Personalizado (Google API)**: Implementar Google Calendar y Tasks (#2).
 - [ ] **Sincronización Bidireccional con Obsidian via Webhook**: Triggers instantáneos externos (#3).
-- [ ] **Migración a PostgreSQL**: Adaptar los modelos para producción (#4).
 - [ ] **Integración de IA (chat/asistente)**: (#41)
 - [ ] **Integración de Gmail**: (#42)
 - [ ] **Integración de Contactos (Google)**: (#43)
@@ -36,6 +34,8 @@
 - [ ] **GitHub OAuth real**: (#46)
 - [ ] **UI de Dead Letter Queue**: Gestión de embeddings fallidos (#49).
 - [ ] **Alerting & Monitoring**: Prometheus/Grafana (#15).
+- [ ] **Ruff + Black**: Configurar e integrar linter/formatter en CI (Issue #16). *No completado — no hay config de ruff/black en el repo ni en CI.*
+- [ ] **Rate Limiting en ai-service**: El middleware existe en la API pero el ai-service no lo aplica (#367). *Parcialmente completado.*
 
 ### 2.2 Frontend & UX
 - [ ] **WYSIWYG Editor**: Editor enriquecido Markdown (#6).


### PR DESCRIPTION
## Summary

### #389 — AGENTS.md migration count
Said "12 migration files" but there are 5 (the original 4 plus the `api_usage` migration added in PR #425). Corrected to 5.

### #388 — TODO.md stale entries
Three entries contradicted the actual code state:
1. **"Migración a PostgreSQL (#4)"** was marked pending, but PostgreSQL 16 + pgvector has been in production since #273. Moved to the completed section with the correct issue reference.
2. **"Ruff + Black (#16)"** was marked completed, but there is no ruff/black config in the repo and CI doesn't run them. Moved to the backlog with a note that it's not actually done.
3. **"Rate Limiting Avanzado (#27)"** was marked completed, but #367 reports the ai-service has no rate limiting applied. Moved to the backlog with a note that it's only partially done (API middleware exists, ai-service doesn't apply it).

#### Test plan
- [x] `ls api/alembic/versions/*.py | wc -l` confirms 5 migration files
- [ ] Review TODO.md for any other stale entries (this PR fixes the 3 called out in #388)

Generated with [Devin](https://devin.ai)