### PR TITLE
fix(ci): set POSTGRES_PASSWORD for Docker Build & Smoke Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Prepare environment
         run: |
           cp .env.example .env
+          # docker-compose.yml requires a non-empty POSTGRES_PASSWORD (${VAR:?...})
+          # .env.example ships it empty, so set a CI-only value here.
+          sed -i 's/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=joidy-ci/' .env
           mkdir -p data/db data/uploads data/vault
 
       - name: Build and start Docker images


### PR DESCRIPTION
## Summary
- `docker-compose.yml` uses `${POSTGRES_PASSWORD:?...}`, which fails when the value is empty.
- `.env.example` ships `POSTGRES_PASSWORD=` empty, so the CI `Prepare environment` step (`cp .env.example .env`) produced an empty value and **every** `Docker Build & Smoke Test` run failed before building — across all open PRs and `development` itself.
- Set a CI-only non-empty password via `sed` after copying `.env.example`.

This unblocks the `Docker Build & Smoke Test` check on all 28 open PRs.

#### Test plan
- [ ] CI `Docker Build & Smoke Test` passes on this PR

Generated with [Devin](https://devin.ai)