### PR TITLE
fix: remove leftover conflict markers from #465 merge

### DIFF
--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -1,13 +1,10 @@
 import { writable, derived } from 'svelte/store';
 import { browser } from '$app/environment';
-<<<<<<< HEAD
-=======
 import {
   startAutoTheme,
   stopAutoTheme,
   clearDynamicTheme,
 } from '$lib/utils/dynamicTheme';
->>>>>>> origin/development
 
 const COLORS_KEY     = 'joidy-accent-colors';
 const DEFAULT_COLORS = ['#c8a96e'];

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -771,10 +771,6 @@
       font-size: 9px;
     }
   }
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-=======
 
 .focus-mode-btn {
   display: flex;
@@ -795,6 +791,4 @@
   background: var(--elevated);
   border-color: var(--accent);
 }
->>>>>>> origin/development
->>>>>>> origin/development
 </style>


### PR DESCRIPTION
Repair: #465 squash-merge committed literal conflict markers in settings.ts and +page.svelte. Removes markers, keeps dynamicTheme import and .focus-mode-btn styles.