### PR TITLE
fix(ci): best-effort file logging so Docker smoke test starts under non-root bind-mount

### DIFF
--- a/ai-service/logging_config.py
+++ b/ai-service/logging_config.py
@@ -87,8 +87,6 @@ class CorrelationLogFilter(logging.Filter):
 def setup_logging() -> None:
     """Configure AI service logging for console + rotating file."""
     log_dir = Path("/data/logs")
-    log_dir.mkdir(parents=True, exist_ok=True)
-
     is_production = settings.app_env == "production"
 
     root = logging.getLogger()
@@ -106,15 +104,25 @@ def setup_logging() -> None:
     stream.addFilter(CorrelationLogFilter())
     root.addHandler(stream)
 
-    # File handler — always JSON
-    file_handler = RotatingFileHandler(
-        log_dir / "ai-service.log",
-        maxBytes=5_000_000,
-        backupCount=5,
-        encoding="utf-8",
-    )
-    file_handler.setFormatter(JSONFormatter())
-    file_handler.addFilter(CorrelationLogFilter())
-    root.addHandler(file_handler)
+    # File handler — always JSON. Best-effort: an unwritable log dir must
+    # never prevent startup (e.g. read-only mount in CI smoke tests).
+    file_handler = None
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        file_handler = RotatingFileHandler(
+            log_dir / "ai-service.log",
+            maxBytes=5_000_000,
+            backupCount=5,
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        stream.stream.write(
+            f"WARNING: file logging disabled — could not init "
+            f"'{log_dir}': {exc}\n"
+        )
+    if file_handler is not None:
+        file_handler.setFormatter(JSONFormatter())
+        file_handler.addFilter(CorrelationLogFilter())
+        root.addHandler(file_handler)
 
     logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -69,8 +69,6 @@ def setup_logging() -> None:
     Uses JSON format in production, colored human-readable in development.
     """
     log_dir = Path(settings.log_dir)
-    log_dir.mkdir(parents=True, exist_ok=True)
-
     is_production = settings.app_env == "production"
 
     root = logging.getLogger()
@@ -89,16 +87,27 @@ def setup_logging() -> None:
     stream.addFilter(CorrelationLogFilter())
     root.addHandler(stream)
 
-    # File handler — always JSON for machine parsing
-    file_handler = RotatingFileHandler(
-        log_dir / "api.log",
-        maxBytes=5_000_000,
-        backupCount=5,
-        encoding="utf-8",
-    )
-    file_handler.setFormatter(JSONFormatter())
-    file_handler.addFilter(CorrelationLogFilter())
-    root.addHandler(file_handler)
+    # File handler — always JSON for machine parsing.
+    # File logging is best-effort: a missing/unwritable log dir (e.g. a
+    # read-only bind-mount in CI smoke tests) must never prevent startup.
+    file_handler = None
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        file_handler = RotatingFileHandler(
+            log_dir / "api.log",
+            maxBytes=5_000_000,
+            backupCount=5,
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        stream.stream.write(
+            f"WARNING: file logging disabled — could not init "
+            f"'{log_dir}': {exc}\n"
+        )
+    if file_handler is not None:
+        file_handler.setFormatter(JSONFormatter())
+        file_handler.addFilter(CorrelationLogFilter())
+        root.addHandler(file_handler)
 
     # Reduce noise from third-party libraries
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)

--- a/worker/logging_config.py
+++ b/worker/logging_config.py
@@ -84,8 +84,6 @@ class DevFormatter(logging.Formatter):
 def setup_logging() -> None:
     """Configure worker logging for console + rotating file."""
     log_dir = Path("/data/logs")
-    log_dir.mkdir(parents=True, exist_ok=True)
-
     is_production = settings.app_env == "production"
 
     root = logging.getLogger()
@@ -103,15 +101,25 @@ def setup_logging() -> None:
         stream.setFormatter(DevFormatter())
     root.addHandler(stream)
 
-    file_handler = RotatingFileHandler(
-        log_dir / "worker.log",
-        maxBytes=5_000_000,
-        backupCount=5,
-        encoding="utf-8",
-    )
-    file_handler.addFilter(CorrelationLogFilter())
-    file_handler.setFormatter(JSONFormatter())
-    root.addHandler(file_handler)
+    # File handler is best-effort: an unwritable log dir must never prevent startup.
+    file_handler = None
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        file_handler = RotatingFileHandler(
+            log_dir / "worker.log",
+            maxBytes=5_000_000,
+            backupCount=5,
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        stream.stream.write(
+            f"WARNING: file logging disabled — could not init "
+            f"'{log_dir}': {exc}\n"
+        )
+    if file_handler is not None:
+        file_handler.addFilter(CorrelationLogFilter())
+        file_handler.setFormatter(JSONFormatter())
+        root.addHandler(file_handler)
 
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("watchfiles").setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary
- Docker smoke test uses `docker-compose.dev.yml` (bind-mounts `./api:/app`, runs as non-root `app` user). `setup_logging()` called `log_dir.mkdir()` unconditionally, so a non-writable `data/logs` raised `PermissionError` inside FastAPI's lifespan and `/health` never came up → "API did not become healthy within 60 seconds".
- Wrap `mkdir` + `RotatingFileHandler` construction in `try/except OSError` in `api`, `worker`, and `ai-service` `logging_config.py`. On failure, emit a WARNING to stdout and keep console logging only.
- File logging is best-effort: it must never prevent service startup.

## Root cause (from PR #470 failing run)
```
api/main.py:62 → logging_config.py:72 → log_dir.mkdir(parents=True, exist_ok=True)
PermissionError: [Errno 13] Permission denied: 'data'
ERROR: Application startup failed. Exiting.
```

#### Test plan
- [x] `python -m compileall` passes on all 3 `logging_config.py`
- [ ] CI passes on all jobs (Docker Build & Smoke Test should now go green)

Generated with [Devin](https://devin.ai)