### PR TITLE
docs: fix stale documentation (#389 #339 #340 #341)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,8 @@ main.py → routers/*.py → services/*.py → models/*.py
 - **routers/**: HTTP endpoints, Pydantic validation only
 - **services/**: Business logic + DB ops
 - **models/**: SQLAlchemy ORM
-- **alembic/versions/**: 5 migration files (`make migrate`)
-- **tests/**: 7 test files (unittest)
+- **alembic/versions/**: 7 migration files (`make migrate`)
+- **tests/**: 31 test files (unittest)
 
 Internal comms:
 - API → AI: `http://ai-service:8002`
@@ -96,7 +96,7 @@ Two concurrent asyncio tasks: `watch_vault()` (watches `/vault/*.md`, 2s debounc
 
 ### Frontend (`frontend/src/`)
 - `routes/`: SvelteKit pages (notes, goals, graph, skills, streaks, ai, etc.)
-- `lib/stores/`: 20 Svelte stores (notes, gamification, pomodoro, graph, settings, etc.)
+- `lib/stores/`: 24 Svelte stores (notes, gamification, pomodoro, graph, settings, etc.)
 - `lib/actions/`: Svelte actions (focusTrap, liquidGlass)
 - `lib/api.ts`: API client wrapper
 - `lib/components/`: Reusable Svelte components (Modal, DynamicIcon, GoalCard, StreakListItem, etc.)

--- a/DATA_MODEL.md
+++ b/DATA_MODEL.md
@@ -90,7 +90,7 @@ columns.
 | `id` | Integer | PK, indexed |
 | `title` | String(500) | not null |
 | `content` | Text | default `""` |
-| `source` | String(50) | default `"joidy"` (`joidy` \| `obsidian`) |
+| `source` | String(50) | default `"joidy"` (`joidy` \| `obsidian` \| `api` \| `import`) |
 | `source_path` | String(1000) | nullable, indexed |
 | `is_embedded` | Boolean | default `False` |
 | `created_at` | DateTime | server default `now()` |
@@ -385,6 +385,21 @@ token is encrypted with Fernet using the app's `SECRET_KEY`.
 | `created_at` | DateTime | server default `now()` |
 | `updated_at` | DateTime | server default `now()`, onupdate `now()` |
 
+### `api_usage` — `APIUsage` (no ORM model; created by Alembic migration)
+Tracks AI provider token usage for cost estimation. Written by
+`ai-service/cost_tracker.py` via raw SQL (no SQLAlchemy model in `api/models/`).
+Created by migration `d4e5f6a7b8c9_add_api_usage.py`.
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | Integer | PK |
+| `operation` | String(50) | not null (e.g. `embed`, `classify`, `chat`) |
+| `input_tokens` | Integer | default `0` |
+| `output_tokens` | Integer | default `0` |
+| `created_at` | DateTime (timezone) | server default `now()`, indexed |
+
+**Indexes:** `ix_api_usage_created_at`, `ix_api_usage_operation`.
+
 ---
 
 ## Entity-Relationship Diagram
@@ -635,6 +650,13 @@ erDiagram
         datetime created_at
         datetime updated_at
     }
+    api_usage {
+        integer id PK
+        string operation
+        integer input_tokens
+        integer output_tokens
+        datetime created_at
+    }
 ```
 
 ---
@@ -653,4 +675,10 @@ erDiagram
 - **Indexes:** Primary keys and explicitly `index=True` columns are indexed
   automatically by SQLAlchemy. Unique constraints (e.g. `tags.name`,
   `github_repos.full_name`, `streak_checkins(streak_id, check_date)`) also
-  create indexes.
+  create indexes. Migration `e5f6a7b8c9d0_add_missing_indexes.py` added
+  explicit indexes on frequently filtered/ordered columns: `notes.created_at`,
+  `notes.updated_at`, `note_links.target_note_id`,
+  `embedding_failures.next_retry_at`, `goals.parent_id`, `goals.note_id`,
+  `goals.tag_id`, `goals.state`, `personal_streaks.is_archived`,
+  `personal_streaks.category`. The `api_usage` table has indexes on
+  `created_at` and `operation`.

--- a/api/README.md
+++ b/api/README.md
@@ -73,7 +73,7 @@ api/
 ├── services/          Business logic + DB operations
 ├── models/            SQLAlchemy ORM models
 ├── middleware/        Correlation ID, request ID, rate limit, metrics
-├── alembic/           Migrations (versions/ has 12 files)
+├── alembic/           Migrations (versions/ has 7 files)
 ├── repositories.py    Shared query helpers
 └── tests/             pytest/unittest test suite
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -57,6 +57,7 @@ interactive OpenAPI docs at `/docs` for full schemas.
 | Method | Path | Auth | Description | Request Body | Response |
 |--------|------|------|-------------|--------------|----------|
 | GET | `/notes/` | Yes | List notes (filters: `tag`, `source_path`, `skip`, `limit`) | — | `List[Note]` |
+| POST | `/notes/search/semantic` | Yes | Semantic search over embeddings (pgvector cosine similarity) | `{query, limit?, threshold?}` | `{results: [{note, score}]}` |
 | GET | `/notes/{note_id}` | Yes | Get a single note | — | `Note` |
 | POST | `/notes/` | Yes | Create a note (201) | `{title, content, tags, source, source_path}` | `Note` + `gamification` |
 | PUT | `/notes/{note_id}` | Yes | Update a note | `{title?, content?, tags?, source_path?, source?}` | `Note` + `gamification` |
@@ -67,6 +68,7 @@ interactive OpenAPI docs at `/docs` for full schemas.
 | POST | `/notes/bulk-untag` | Yes | Remove tags from multiple notes | `{ids: [int], tags: [str]}` | `{removed, notes, tags}` |
 | POST | `/notes/{note_id}/accept-tag` | Yes | Accept an AI-suggested tag (`tag_name` query) | — | `{tag, gamification}` |
 | GET | `/notes/{note_id}/backlinks` | Yes | Notes linking to this note | — | `List[Note]` |
+| GET | `/notes/{note_id}/similar` | Yes | Semantically similar notes (pgvector cosine similarity, `limit` query) | — | `List[{note, score}]` |
 | POST | `/notes/embeddings/retry-failed` | Yes | Retry failed embeddings (`limit` query) | — | `{queued, remaining_failures}` |
 | GET | `/notes/embeddings/dead-letters` | Yes | List dead-lettered embedding failures (`limit` query) | — | list of failure entries |
 | POST | `/notes/embeddings/dead-letters/{note_id}/reset` | Yes | Reset a dead letter for retry | — | `{status, note_id}` |
@@ -199,6 +201,9 @@ interactive OpenAPI docs at `/docs` for full schemas.
 |--------|------|------|-------------|--------------|----------|
 | POST | `/ai/classify` | Yes | Classify a note and suggest tags (proxied to AI service) | `{note_id, content, existing_tags}` | `{note_id, status, suggestions}` |
 | GET | `/ai/usage` | Yes | AI usage and estimated cost | — | `{ai_enabled, estimated_cost_usd}` |
+| POST | `/ai/cluster` | Yes | Cluster notes by semantic similarity (`eps`, `min_samples`, `max_notes` queries) | — | `{clusters, total_notes}` |
+| POST | `/ai/daily-recap` | Yes | Generate an AI daily recap (`target_date` query, YYYY-MM-DD) | — | recap object |
+| POST | `/ai/chat` | Yes | Conversational AI assistant (forwards context + messages to AI service) | `{messages: [{role, content}]}` | chat response object |
 
 ### 2.19 Sync (`sync.py`)
 
@@ -331,8 +336,10 @@ class Goal(Base):
     tag_id: int | None
     parent_id: int | None
     max_assignment_days: int | None
+    pending_removal: bool
     is_completed: bool
     completed_at: datetime | None
+    source_path: str | None
     created_at: datetime
     updated_at: datetime
 ```


### PR DESCRIPTION
## Summary

Fixes stale documentation across multiple files to reflect the current state of the codebase.

### Changes

**AGENTS.md (#389)**
- Updated migration file count: 5 → 7 (actual files in `api/alembic/versions/`)
- Updated test file count: 7 → 31 (actual `test_*.py` files in `api/tests/`)
- Updated Svelte stores count: 20 → 24 (actual `.ts` files in `frontend/src/lib/stores/`, excluding `.test.ts`)

**DATA_MODEL.md (#339)**
- Added `api_usage` table documentation (created by migration `d4e5f6a7b8c9`, used by `ai-service/cost_tracker.py` via raw SQL — no ORM model)
- Updated `notes.source` column to reflect all allowed values: `joidy | obsidian | api | import` (was only `joidy | obsidian`)
- Added `api_usage` entity to the Mermaid ER diagram
- Documented all explicit indexes added by migration `e5f6a7b8c9d0_add_missing_indexes.py`

**docs/api.md (#340)**
- Added `POST /notes/search/semantic` — semantic search over embeddings (pgvector cosine similarity)
- Added `GET /notes/{note_id}/similar` — semantically similar notes
- Added `POST /ai/cluster` — cluster notes by semantic similarity
- Added `POST /ai/daily-recap` — AI daily recap generation
- Added `POST /ai/chat` — conversational AI assistant
- Added missing `pending_removal` and `source_path` fields to the Goal data model
- No "auth no requerida" text found — JWT enforcement is already correctly documented

**api/README.md (#341)**
- Fixed stale migration count: 12 → 7

### Verification
- `python -m compileall -q api/ ai-service/ worker/` — no syntax errors
- All counts verified against actual directory contents

Closes #389, Closes #339, Closes #340, Closes #341