### PR TITLE
feat(frontend): command palette (Cmd+K) for navigation and actions (#394)

### DIFF
--- a/frontend/src/lib/components/CommandPalette.svelte
+++ b/frontend/src/lib/components/CommandPalette.svelte
@@ -5,7 +5,7 @@
   import { Search, CornerDownLeft } from 'lucide-svelte';
   import DynamicIcon from './DynamicIcon.svelte';
   import { notes } from '$lib/stores/notes';
-  import { darkMode } from '$lib/stores/settings';
+  import { darkMode, devMode } from '$lib/stores/settings';
   import { isOpen, close } from '$lib/stores/commandPalette';
   import { get } from 'svelte/store';
 
@@ -26,6 +26,7 @@
     { type: 'Navegación', title: 'Ir a Rachas', icon: 'Flame', action: () => goto('/streaks') },
     { type: 'Navegación', title: 'Ir a IA', icon: 'Brain', action: () => goto('/ai') },
     { type: 'Navegación', title: 'Ir a Offline', icon: 'CloudOff', action: () => goto('/offline') },
+    { type: 'Navegación', title: 'Ajustes', icon: 'Settings', action: () => window.dispatchEvent(new CustomEvent('joidy:open-settings')) },
   ];
 
   const actionCommands: Command[] = [
@@ -69,6 +70,14 @@
       icon: 'SunMoon',
       action: () => {
         darkMode.toggle();
+      },
+    },
+    {
+      type: 'Acciones',
+      title: 'Toggle dev mode',
+      icon: 'Terminal',
+      action: () => {
+        devMode.toggle();
       },
     },
     {


### PR DESCRIPTION
## Summary

Implements a command palette triggered by **Cmd+K** (Mac) / **Ctrl+K** (Windows/Linux) for quick navigation and actions, per issue #394.

## Changes

### `frontend/src/lib/stores/commandPalette.ts`
- `isOpen` writable store
- `open()`, `close()`, and `toggle()` helper functions

### `frontend/src/lib/components/CommandPalette.svelte`
- Modal overlay with search input and filterable command list
- Commands grouped by category: **Navegación**, **Acciones**, **Etiquetas**, **Notas**
- Fuzzy matching + scoring for search/filter
- Keyboard navigation: Arrow Up/Down to move, Enter to select, Escape to close
- Backdrop click to close
- **Navigation commands**: Dashboard, Notas, Goals, Grafo, Skills, Rachas, IA, Offline, Ajustes
- **Action commands**: Crear nota, Crear goal, Crear racha, Iniciar Pomodoro, Toggle tema, Toggle dev mode, Exportar notas
- Also searches notes (by title/content) and `#tags`

### `frontend/src/routes/+layout.svelte`
- Global `Cmd`/`Ctrl+K` keydown listener to toggle the palette
- Listener cleaned up in the `onMount` return (follows existing cleanup patterns)
- `<CommandPalette />` rendered in the authenticated layout

## Conventions
- Uses existing design tokens (`--elevated`, `--border`, `--r-lg`, `--hover`, `--text-*`, `--z-modal`)
- Uses existing stores (`darkMode`, `devMode`, `notes`) for actions
- SSR-safe
- Static UI icons imported directly from `lucide-svelte`; dynamic icons via `<DynamicIcon />`

## Typecheck
```
svelte-check found 0 errors and 116 warnings in 22 files
```
(All warnings are pre-existing; none introduced by this change.)

Closes #394

Generated with [Devin](https://devin.ai)