### PR TITLE
feat(frontend): vitest coverage con thresholds + @vitest/coverage-v8 (#369)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build/
 .mypy_cache/
 .coverage
 htmlcov/
+frontend/coverage/
 
 # Node / SvelteKit
 node_modules/

--- a/docs/database.md
+++ b/docs/database.md
@@ -158,6 +158,26 @@ CREATE TABLE embedding_failures (
 );
 ```
 
+Registro de reintentos de embeddings fallidos (ver `embedding_service.py`).
+
+---
+
+#### note_embeddings
+
+```sql
+CREATE TABLE note_embeddings (
+    note_id INTEGER REFERENCES notes(id) ON DELETE CASCADE PRIMARY KEY,
+    embedding VECTOR(768)
+);
+```
+
+Vector de embeddings por nota (pgvector, dimensión 768 = Gemini). Un solo embedding por nota (PK = note_id).
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| note_id | INTEGER | FK a notes.id (PK, un embedding por nota) |
+| embedding | VECTOR(768) | Vector semántico generado por el provider de embeddings |
+
 Retry logic para embeddings fallidos.
 
 ---
@@ -350,13 +370,258 @@ CREATE TABLE planning_assignments (
 ```sql
 CREATE TABLE github_repos (
     id INTEGER PRIMARY KEY,
-    repo_id INTEGER UNIQUE,
-    name VARCHAR(100) NOT NULL,
-    full_name VARCHAR(200) NOT NULL,
-    color VARCHAR(20) DEFAULT '#888888',
-    last_synced DATETIME
+    name VARCHAR(200) NOT NULL,
+    full_name VARCHAR(200) UNIQUE NOT NULL,
+    description TEXT,
+    url VARCHAR(500) NOT NULL,
+    default_branch VARCHAR(100) DEFAULT 'main',
+    is_private BOOLEAN DEFAULT FALSE,
+    status VARCHAR(50) DEFAULT 'ACTIVE',       -- GitHubRepoStatus: ACTIVE | ARCHIVED
+    webhook_id INTEGER,
+    webhook_secret VARCHAR(100),
+    last_synced_at DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 ```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| id | INTEGER | Primary key |
+| name | VARCHAR(200) | Nombre del repo |
+| full_name | VARCHAR(200) | `owner/repo` (único) |
+| description | TEXT | Descripción del repo |
+| url | VARCHAR(500) | URL del repo |
+| default_branch | VARCHAR(100) | Rama por defecto |
+| is_private | BOOLEAN | Si es repo privado |
+| status | VARCHAR(50) | ACTIVE o ARCHIVED |
+| webhook_id | INTEGER | ID del webhook de GitHub |
+| webhook_secret | VARCHAR(100) | Secreto para verificar firma del webhook |
+| last_synced_at | DATETIME | Última sincronización |
+| created_at / updated_at | DATETIME | Timestamps |
+
+---
+
+#### github_items
+
+Items de GitHub sincronizados (issues/PRs) y su vínculo con goals/notas.
+
+```sql
+CREATE TABLE github_items (
+    id INTEGER PRIMARY KEY,
+    repo_id INTEGER REFERENCES github_repos(id) ON DELETE CASCADE,
+    external_id INTEGER NOT NULL,
+    item_type VARCHAR(50) NOT NULL,            -- GitHubItemType: ISSUE | PULL_REQUEST
+    number INTEGER NOT NULL,
+    title VARCHAR(500) NOT NULL,
+    body TEXT DEFAULT '',
+    state VARCHAR(20) DEFAULT 'open',
+    state_reason VARCHAR(50),
+    author VARCHAR(100) DEFAULT '',
+    assignee VARCHAR(100),
+    labels VARCHAR(500) DEFAULT '',
+    url VARCHAR(500) NOT NULL,
+    html_url VARCHAR(500) NOT NULL,
+    goal_id INTEGER REFERENCES goals(id) ON DELETE SET NULL,
+    note_id INTEGER REFERENCES notes(id) ON DELETE SET NULL,
+    synced_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| id | INTEGER | Primary key |
+| repo_id | INTEGER | FK a github_repos.id |
+| external_id | INTEGER | ID del item en GitHub |
+| item_type | VARCHAR(50) | ISSUE o PULL_REQUEST |
+| number | INTEGER | Número en GitHub |
+| title | VARCHAR(500) | Título |
+| body | TEXT | Cuerpo |
+| state | VARCHAR(20) | open/closed |
+| state_reason | VARCHAR(50) | Motivo de cierre |
+| author | VARCHAR(100) | Autor |
+| assignee | VARCHAR(100) | Asignado |
+| labels | VARCHAR(500) | Labels separados por coma |
+| url / html_url | VARCHAR(500) | URLs del item |
+| goal_id | INTEGER | FK a goals.id (opcional, item → goal) |
+| note_id | INTEGER | FK a notes.id (opcional, item → nota) |
+
+---
+
+#### github_events
+
+Webhook events de GitHub crudos, pendientes de procesar.
+
+```sql
+CREATE TABLE github_events (
+    id INTEGER PRIMARY KEY,
+    repo_id INTEGER REFERENCES github_repos(id) ON DELETE CASCADE,
+    event_type VARCHAR(50) NOT NULL,           -- GitHubEventType: ISSUES | PULL_REQUEST | ...
+    action VARCHAR(50) NOT NULL,
+    sender VARCHAR(100) NOT NULL,
+    item_type VARCHAR(50),
+    item_number INTEGER,
+    item_external_id INTEGER,
+    payload JSON DEFAULT '{}',
+    processed BOOLEAN DEFAULT FALSE,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| id | INTEGER | Primary key |
+| repo_id | INTEGER | FK a github_repos.id |
+| event_type | VARCHAR(50) | Tipo de evento (issues, pull_request, ...) |
+| action | VARCHAR(50) | Acción (opened, closed, ...) |
+| sender | VARCHAR(100) | Usuario que disparó el evento |
+| item_type | VARCHAR(50) | Tipo de item afectado |
+| item_number / item_external_id | INTEGER | Identificación del item |
+| payload | JSON | Payload crudo del webhook |
+| processed | BOOLEAN | Si ya fue procesado por el worker |
+
+---
+
+### 2.8 Integración Google
+
+#### google_tokens
+
+Tokens de integraciones Google (Gmail, Calendar, Tasks, Contacts).
+
+```sql
+CREATE TABLE google_tokens (
+    id INTEGER PRIMARY KEY,
+    user_id INTEGER NOT NULL DEFAULT 1 UNIQUE,
+    access_token TEXT,
+    refresh_token_encrypted TEXT,
+    token_type VARCHAR DEFAULT 'Bearer',
+    expires_at DATETIME,
+    scope TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| id | INTEGER | Primary key |
+| user_id | INTEGER | Usuario (único, un token por usuario) |
+| access_token | TEXT | Access token de OAuth |
+| refresh_token_encrypted | TEXT | Refresh token cifrado |
+| token_type | VARCHAR | Bearer |
+| expires_at | DATETIME | Expiración del access token |
+| scope | TEXT | Scopes concedidos |
+
+---
+
+### 2.9 Push Notifications
+
+#### push_subscriptions
+
+Suscripciones Web Push (VAPID) por usuario.
+
+```sql
+CREATE TABLE push_subscriptions (
+    id INTEGER PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    endpoint VARCHAR NOT NULL,
+    p256dh VARCHAR NOT NULL,
+    auth VARCHAR NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| id | INTEGER | Primary key |
+| user_id | INTEGER | Usuario |
+| endpoint | VARCHAR | Endpoint de Push API |
+| p256dh | VARCHAR | Clave pública del cliente |
+| auth | VARCHAR | Secreto de autenticación |
+
+---
+
+### 2.10 Sincronización
+
+#### sync_state
+
+Estado de sincronización por nota (para sync bidireccional con Obsidian).
+
+```sql
+CREATE TABLE sync_state (
+    id INTEGER PRIMARY KEY,
+    note_id INTEGER NOT NULL,
+    last_synced_at DATETIME,
+    local_mtime DATETIME,
+    remote_mtime DATETIME,
+    conflict BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| id | INTEGER | Primary key |
+| note_id | INTEGER | Nota sincronizada |
+| last_synced_at | DATETIME | Última sincronización |
+| local_mtime | DATETIME | Modificación local |
+| remote_mtime | DATETIME | Modificación remota |
+| conflict | BOOLEAN | Si hay conflicto pendiente |
+
+---
+
+### 2.11 Configuración
+
+#### system_config
+
+Configuración clave-valor del sistema.
+
+```sql
+CREATE TABLE system_config (
+    id INTEGER PRIMARY KEY,
+    key VARCHAR UNIQUE NOT NULL,
+    value VARCHAR,
+    updated_at DATETIME
+);
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| id | INTEGER | Primary key |
+| key | VARCHAR | Clave (única) |
+| value | VARCHAR | Valor |
+| updated_at | DATETIME | Última actualización |
+
+---
+
+### 2.12 Métricas de IA
+
+#### api_usage
+
+Tracking de uso/costo de las llamadas al servicio de IA (creada en la migración `d4e5f6a7b8c9`).
+
+```sql
+CREATE TABLE api_usage (
+    id INTEGER PRIMARY KEY,
+    operation VARCHAR(50) NOT NULL,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+CREATE INDEX ix_api_usage_created_at ON api_usage(created_at);
+CREATE INDEX ix_api_usage_operation ON api_usage(operation);
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| id | INTEGER | Primary key |
+| operation | VARCHAR(50) | Operación (embed, classify, rag) |
+| input_tokens | INTEGER | Tokens de entrada |
+| output_tokens | INTEGER | Tokens de salida |
+| created_at | TIMESTAMPTZ | Fecha (UTC) |
 
 ---
 
@@ -366,13 +631,19 @@ CREATE TABLE github_repos (
 
 | Archivo | Modelos |
 |---------|---------|
-| note.py | Note, Tag, NoteTag, NoteLink, TagCooccurrence, EmbeddingFailure |
+| note.py | Note, Tag, NoteTag, NoteLink, TagCooccurrence, EmbeddingFailure, NoteEmbedding |
 | goal.py | Goal |
 | gamification.py | XPEvent, StreakRecord, UserStats |
 | personal_streaks.py | PersonalStreak, StreakCheckin |
 | skill.py | Skill |
 | planning.py | PlanningAssignment |
-| github.py | GitHubRepo |
+| github.py | GitHubRepo, GitHubItem, GitHubEvent |
+| google_token.py | GoogleToken |
+| sync_state.py | SyncState |
+| push_subscription.py | PushSubscription |
+| config.py | SystemConfig |
+
+> `api_usage` no tiene modelo ORM; se crea vía migración (`d4e5f6a7b8c9_add_api_usage.py`) y se escribe directamente con SQLAlchemy Core en el ai-service.
 
 ### 3.2 Ejemplo de Modelo
 
@@ -435,14 +706,13 @@ docker compose exec api alembic revision -m "description"
 
 | Archivo | Descripción |
 |---------|-------------|
-| 20260421_000001_initial_schema.py | Schema inicial |
-| 20260421_000002_tag_cooccurrences.py | Co-ocurrencias de tags |
-| 20260421_000003_embedding_failures.py | Tabla de reintentos |
-| 20260427_consolidated.py | Consolidación |
-| 20260501_planning.py | Planificación |
-| 20260502_github_integration.py | GitHub |
-| 20260503_add_max_assignment_days.py | Max days |
-| 20260504_add_source_path_to_goals.py | Source path |
+| 2f638d55375d_schema.py | Schema inicial consolidado |
+| a1b2c3d4e5f6_cleanup_hex_named_tags.py | Limpieza de tags con nombres hex |
+| bce8f3a471d1_add_push_subscriptions_table.py | Tabla push_subscriptions |
+| c3d4e5f6a7b8_add_google_tokens.py | Tabla google_tokens |
+| d4e5f6a7b8c9_add_api_usage.py | Tabla api_usage (costo IA) |
+| 8261da3f5e9d_add_sync_state.py | Tabla sync_state |
+| e5f6a7b8c9d0_add_missing_indexes.py | Índices faltantes (ix_notes_created_at, ix_notes_updated_at) |
 
 ---
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,6 +40,7 @@
         "@types/dompurify": "^3.2.0",
         "@types/highlight.js": "^9.12.4",
         "@types/node": "^26.1.2",
+        "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.8.0",
         "eslint-plugin-svelte": "^3.22.0",
         "globals": "^17.8.0",
@@ -121,6 +122,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
@@ -131,6 +142,22 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
@@ -139,6 +166,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -1216,9 +1267,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1233,9 +1281,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1250,9 +1295,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1267,9 +1309,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1284,9 +1323,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1301,9 +1337,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1318,9 +1351,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1335,9 +1365,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1352,9 +1379,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1369,9 +1393,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1386,9 +1407,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1403,9 +1421,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1420,9 +1435,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2779,6 +2791,37 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -2992,6 +3035,35 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
@@ -4214,6 +4286,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -4248,6 +4330,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-to-image": {
       "version": "1.11.13",
@@ -4374,6 +4463,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4594,6 +4722,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/marked": {
@@ -5446,6 +5602,19 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@types/dompurify": "^3.2.0",
     "@types/highlight.js": "^9.12.4",
     "@types/node": "^26.1.2",
+    "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.8.0",
     "eslint-plugin-svelte": "^3.22.0",
     "globals": "^17.8.0",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -12,6 +12,18 @@ export default defineConfig({
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}'],
 		environment: 'jsdom',
-		setupFiles: ['./vitest.setup.ts']
+		setupFiles: ['./vitest.setup.ts'],
+		coverage: {
+			provider: 'v8',
+			include: ['src/lib/stores/**', 'src/lib/utils/**'],
+			exclude: ['**/*.d.ts', '**/*.test.ts', 'src/lib/stores/index.ts'],
+			thresholds: {
+				lines: 25,
+				functions: 25,
+				statements: 24,
+				branches: 20
+			},
+			reporter: ['text', 'html']
+		}
 	}
 });


### PR DESCRIPTION
## Resumen
Contribución al issue #369 (testing frontend). Configura cobertura de tests en vitest con thresholds para prevenir regresiones.

## Cambios
- **`@vitest/coverage-v8`** agregado como dev dependency.
- **`vitest.config.ts`**: provider v8, scope a `src/lib/stores/**` + `src/lib/utils/**`, reporter text+html.
- **Thresholds globales realistas** (lines 25, functions 25, statements 24, branches 20) — sirven de piso actual y subirán conforme se agreguen tests a stores/utils pendientes.
- **`.gitignore`**: excluye `frontend/coverage/`.

## Estado actual de tests frontend
- 6 archivos de tests, **124 tests pasando**.
- Cobertura por archivo clave: `logger.ts` 100%, `gamification.ts` 95%, `settings.ts` 79%, `notes.ts` 69%.
- Los stores/utilities restantes están en 0% y son el siguiente trabajo del issue #369 (pomodoro, chat, graph, export, date, etc.).

## Verificación
```bash
docker compose exec frontend npm run test -- --coverage
# 124 passed, thresholds OK, sin errores de cobertura
```