### PR TITLE
chore(deps): bump pydantic-settings from 2.6.1 to 2.14.2 in /ai-service

### DIFF
--- a/ai-service/requirements.txt
+++ b/ai-service/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.115.5
 uvicorn[standard]==0.32.1
 pydantic==2.13.4
-pydantic-settings==2.6.1
+pydantic-settings==2.14.2
 google-generativeai==0.8.3
 openai==2.50.0
 anthropic==0.120.2


### PR DESCRIPTION
## Summary
- Bumps `pydantic-settings` from 2.6.1 to 2.14.2 in `ai-service/requirements.txt`
- Supersedes #493 (stale dependabot branch with merge conflicts in `requirements.txt`)
- Rebased onto current `main`, keeping `pydantic==2.13.4` (from main) and applying only the `pydantic-settings` bump

#### Test plan
- [ ] CI passes (API Lint & Typecheck, Docker Build & Smoke Test, Security Scanning)

Generated with [Devin](https://devin.ai)