### PR TITLE
chore(deps): bump marked 12→18 with renderer.code API adaptation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,7 @@
         "highlight.js": "^11.11.1",
         "html-to-image": "^1.11.13",
         "lucide-svelte": "^1.0.1",
-        "marked": "^12.0.0",
+        "marked": "^18.0.7",
         "turndown": "^7.2.4"
       },
       "devDependencies": {
@@ -4597,15 +4597,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
-      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "version": "18.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz",
+      "integrity": "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/mdn-data": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,7 +58,7 @@
     "highlight.js": "^11.11.1",
     "html-to-image": "^1.11.13",
     "lucide-svelte": "^1.0.1",
-    "marked": "^12.0.0",
+    "marked": "^18.0.7",
     "turndown": "^7.2.4"
   },
   "type": "module"

--- a/frontend/src/lib/components/GoalEditor.svelte
+++ b/frontend/src/lib/components/GoalEditor.svelte
@@ -8,16 +8,15 @@
   import { api, type Goal } from '$lib/api';
 
   const renderer = new marked.Renderer();
-  renderer.code = (code: string, infostring: string | undefined, _escaped: boolean) => {
-    const lang = infostring || '';
+  renderer.code = ({ text, lang }) => {
     const language = lang && hljs.getLanguage(lang) ? lang : '';
     let highlighted: string;
     try {
       highlighted = language
-        ? hljs.highlight(code, { language }).value
-        : hljs.highlightAuto(code).value;
+        ? hljs.highlight(text, { language }).value
+        : hljs.highlightAuto(text).value;
     } catch {
-      highlighted = code;
+      highlighted = text;
     }
     return `<pre><code class="hljs language-${language || 'auto'}">${highlighted}</code></pre>`;
   };

--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -23,16 +23,15 @@
 
   // Configure marked with GFM and syntax highlighting via highlight.js
   const renderer = new marked.Renderer();
-  renderer.code = (code: string, infostring: string | undefined, _escaped: boolean) => {
-    const lang = infostring || '';
+  renderer.code = ({ text, lang }) => {
     const language = lang && hljs.getLanguage(lang) ? lang : '';
     let highlighted: string;
     try {
       highlighted = language
-        ? hljs.highlight(code, { language }).value
-        : hljs.highlightAuto(code).value;
+        ? hljs.highlight(text, { language }).value
+        : hljs.highlightAuto(text).value;
     } catch {
-      highlighted = code;
+      highlighted = text;
     }
     return `<pre><code class="hljs language-${language || 'auto'}">${highlighted}</code></pre>`;
   };


### PR DESCRIPTION
## Summary
- Bumps `marked` from 12.0.2 to 18.0.7 in `frontend` (major version upgrade)
- Adapts the custom `renderer.code` callback to marked 18.x's new object-based signature: `(code, infostring, escaped)` → `({ text, lang, escaped })` in `NoteEditor.svelte` and `GoalEditor.svelte`
- Supersedes #495 (the dependabot bump alone failed Frontend Typecheck due to the breaking API change)

Marked 18 includes several ReDoS-mitigation fixes (O(n²) backtracking in HTML block close, tilde interrupt, inline link href regexes) and markdown spec compliance fixes.

#### Test plan
- [x] `npm run check` passes locally with 0 errors (114 pre-existing warnings unchanged)
- [ ] CI passes (Frontend Typecheck, Docker Build & Smoke Test)

Generated with [Devin](https://devin.ai)