### PR TITLE
Revert "chore(deps): bump marked 12→18 with renderer.code API adaptation (#510)"

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,7 @@
         "highlight.js": "^11.11.1",
         "html-to-image": "^1.11.13",
         "lucide-svelte": "^1.0.1",
-        "marked": "^18.0.7",
+        "marked": "^12.0.0",
         "turndown": "^7.2.4"
       },
       "devDependencies": {
@@ -4614,15 +4614,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "18.0.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz",
-      "integrity": "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       }
     },
     "node_modules/mdn-data": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,7 @@
     "highlight.js": "^11.11.1",
     "html-to-image": "^1.11.13",
     "lucide-svelte": "^1.0.1",
-    "marked": "^18.0.7",
+    "marked": "^12.0.0",
     "turndown": "^7.2.4"
   },
   "type": "module"

--- a/frontend/src/lib/components/GoalEditor.svelte
+++ b/frontend/src/lib/components/GoalEditor.svelte
@@ -8,15 +8,16 @@
   import { api, type Goal } from '$lib/api';
 
   const renderer = new marked.Renderer();
-  renderer.code = ({ text, lang }) => {
+  renderer.code = (code: string, infostring: string | undefined, _escaped: boolean) => {
+    const lang = infostring || '';
     const language = lang && hljs.getLanguage(lang) ? lang : '';
     let highlighted: string;
     try {
       highlighted = language
-        ? hljs.highlight(text, { language }).value
-        : hljs.highlightAuto(text).value;
+        ? hljs.highlight(code, { language }).value
+        : hljs.highlightAuto(code).value;
     } catch {
-      highlighted = text;
+      highlighted = code;
     }
     return `<pre><code class="hljs language-${language || 'auto'}">${highlighted}</code></pre>`;
   };

--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -19,7 +19,6 @@
   const AUTOSAVE_DELAY = 2000;
   const DRAFT_PREFIX = 'joidy-draft-';
 
-
   interface NoteEditorProps {
     note?: Note | null;
     momentary?: boolean;

--- a/frontend/src/lib/utils/markdown.ts
+++ b/frontend/src/lib/utils/markdown.ts
@@ -11,15 +11,16 @@ import hljs from 'highlight.js';
 
 // Configure marked with GFM and syntax highlighting via highlight.js
 const renderer = new marked.Renderer();
-renderer.code = ({ text, lang }) => {
+renderer.code = (code: string, infostring: string | undefined, _escaped: boolean) => {
+  const lang = infostring || '';
   const language = lang && hljs.getLanguage(lang) ? lang : '';
   let highlighted: string;
   try {
     highlighted = language
-      ? hljs.highlight(text, { language }).value
-      : hljs.highlightAuto(text).value;
+      ? hljs.highlight(code, { language }).value
+      : hljs.highlightAuto(code).value;
   } catch {
-    highlighted = text;
+    highlighted = code;
   }
   return `<pre><code class="hljs language-${language || 'auto'}">${highlighted}</code></pre>`;
 };


### PR DESCRIPTION
## Summary
- Reverts #510 (marked 12→18 bump + renderer.code API adaptation)
- Restores `marked@^12.0.0` and the positional-args `renderer.code` signature
- `development` already uses marked 12 with the old API; this keeps `main` consistent

#### Test plan
- [x] `npm run check` passes locally (0 errors, 114 pre-existing warnings)
- [ ] CI passes

Generated with [Devin](https://devin.ai)