### PR TITLE
fix(frontend): raise z-index of streak action buttons above main

### DIFF
--- a/frontend/src/lib/components/StreakListItem.svelte
+++ b/frontend/src/lib/components/StreakListItem.svelte
@@ -300,6 +300,7 @@
     display: flex; flex-direction: column; gap: 3px;
     position: absolute; top: 6px; right: 6px;
     transition: opacity 0.15s;
+    z-index: 2;
   }
 
   @media (hover: hover) {


### PR DESCRIPTION
## Summary
- Fixes #502: Editar/Eliminar buttons in StreakListItem were covered by the `streak-item-main` button
- Both elements had `z-index: 1` from `.streak-item > *` selector; the main button with `flex: 1` expanded over the absolutely-positioned actions
- Add `z-index: 2` to `.item-actions` so buttons are clickable

#### Test plan
- [x] `npm run check` passes (0 errors)
- [ ] CI passes

Generated with [Devin](https://devin.ai)