### PR TITLE
fix(api): add goal restoration from vault joidy_managed files

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -62,6 +62,21 @@ async def lifespan(app: FastAPI):
     setup_logging()
     init_db()
     logger.info("Database initialization complete")
+
+    # Auto-restore goals from vault if DB has none (#504)
+    try:
+        from database import SessionLocal
+        from models.goal import Goal
+        from services.joidy_vault_writer import restore_goals_from_vault
+
+        with SessionLocal() as db:
+            if db.query(Goal).count() == 0:
+                result = restore_goals_from_vault(db)
+                if result["restored"] > 0:
+                    logger.info("Restored %d goals from vault", result["restored"])
+    except Exception:
+        logger.exception("Failed to auto-restore goals from vault")
+
     yield
 
 

--- a/api/routers/vault.py
+++ b/api/routers/vault.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from database import get_db
 from fastapi import APIRouter, Depends
-from services.joidy_vault_writer import write_daily, write_objectives, write_skills
+from services.joidy_vault_writer import restore_goals_from_vault, write_daily, write_objectives, write_skills
 from sqlalchemy.orm import Session
 
 router = APIRouter(prefix="/vault", tags=["vault"])
@@ -26,3 +26,9 @@ def trigger_write_objectives(db: Session = Depends(get_db)):
 def trigger_write_skills(db: Session = Depends(get_db)):
     ok = write_skills(db)
     return {"status": "ok" if ok else "no_vault"}
+
+
+@router.post("/restore-goals")
+def trigger_restore_goals(db: Session = Depends(get_db)):
+    """Restore goals from joidy_managed files in Objetivos/ (#504)."""
+    return restore_goals_from_vault(db)

--- a/api/services/joidy_vault_writer.py
+++ b/api/services/joidy_vault_writer.py
@@ -123,6 +123,68 @@ def delete_goal_file(goal_id: int) -> bool:
     return False
 
 
+def restore_goals_from_vault(db: Session) -> dict:
+    """Scan Objetivos/ for joidy_managed files and restore missing goals to DB (#504).
+
+    Only restores goals whose goal_id is not already in the database, preserving
+    original IDs and all frontmatter fields. Returns a summary dict.
+    """
+    obj_dir = get_objectives_dir()
+    if not obj_dir:
+        return {"status": "no_vault", "restored": 0, "skipped": 0}
+
+    restored = 0
+    skipped = 0
+
+    for f in sorted(obj_dir.glob("*.md")):
+        content = f.read_text(encoding="utf-8")
+        parsed = _parse_goal_content(content)
+
+        if not parsed.get("joidy_managed"):
+            continue
+
+        goal_id_str = parsed.get("goal_id")
+        if not goal_id_str:
+            continue
+
+        try:
+            goal_id = int(goal_id_str)
+        except (ValueError, TypeError):
+            continue
+
+        existing = db.query(Goal).filter(Goal.id == goal_id).first()
+        if existing:
+            skipped += 1
+            continue
+
+        goal = Goal(
+            id=goal_id,
+            title=parsed.get("title", "Untitled"),
+            description=parsed.get("content", ""),
+            temporality=parsed.get("temporality", "DAILY"),
+            measurement_type=parsed.get("measurement_type", "COUNT"),
+            target_value=float(parsed.get("target_value", 1.0) or 1.0),
+            current_value=float(parsed.get("current_value", 0.0) or 0.0),
+            state=parsed.get("state", "ACTIVE"),
+            fail_config=parsed.get("fail_config", "STATIC"),
+            fail_emoji=parsed.get("fail_emoji", "🔴"),
+            color=parsed.get("color", "#c8a96e"),
+            theme=parsed.get("theme", "solid"),
+            max_assignment_days=int(parsed["max_assignment_days"]) if parsed.get("max_assignment_days") and parsed["max_assignment_days"] != "None" else None,
+            note_id=int(parsed["note_id"]) if parsed.get("note_id") and parsed["note_id"] != "None" else None,
+            tag_id=int(parsed["tag_id"]) if parsed.get("tag_id") and parsed["tag_id"] != "None" else None,
+            parent_id=int(parsed["parent_id"]) if parsed.get("parent_id") and parsed["parent_id"] != "None" else None,
+            is_completed=str(parsed.get("is_completed", "")).lower() == "true",
+            completed_at=datetime.fromisoformat(parsed["completed_at"]) if parsed.get("completed_at") and parsed["completed_at"] != "None" else None,
+            source_path=str(f.relative_to(f.parents[1])),
+        )
+        db.add(goal)
+        restored += 1
+
+    db.commit()
+    return {"status": "ok", "restored": restored, "skipped": skipped}
+
+
 def write_daily(db: Session, target_date: date | None = None) -> bool:
     vault = get_vault_path()
     if not vault:


### PR DESCRIPTION
## Summary
- Fixes #504: goals were written to `Objetivos/` with `joidy_managed` markers but there was no restoration path if the database was lost
- Adds `restore_goals_from_vault()` in `joidy_vault_writer.py` — scans `Objetivos/` for joidy_managed files and restores missing goals to DB, preserving original IDs and all frontmatter fields
- Adds `POST /vault/restore-goals` endpoint for manual triggering
- Adds auto-restore on API startup if DB has zero goals (with error handling)

#### Test plan
- [x] `python -m py_compile` passes on all modified files
- [ ] CI passes

Generated with [Devin](https://devin.ai)