### PR TITLE
refactor(frontend): add shared EmptyState and ProgressBar components

### DIFF
--- a/frontend/src/lib/components/EmptyState.svelte
+++ b/frontend/src/lib/components/EmptyState.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  /**
+   * Shared empty-state component (#255).
+   * Replaces duplicated empty-state markup across GoalList, StreakListPanel,
+   * ChatInterface, GithubWidget, notes, goals, etc.
+   */
+  export let icon: Snippet | null = null;
+  export let children: Snippet | null = null;
+  export let title = '';
+  export let message = '';
+  export let actionLabel = '';
+  export let onAction: (() => void) | null = null;
+</script>
+
+<div class="empty-state">
+  {#if icon}
+    <div class="empty-state-icon">
+      {@render icon()}
+    </div>
+  {/if}
+  {#if title}
+    <h4 class="empty-state-title">{title}</h4>
+  {/if}
+  {#if message}
+    <p class="empty-state-msg">{message}</p>
+  {/if}
+  {#if actionLabel && onAction}
+    <button class="empty-state-action" onclick={onAction}>{actionLabel}</button>
+  {/if}
+  {#if children}
+    {@render children()}
+  {/if}
+</div>
+
+<style>
+  .empty-state {
+    padding: 32px;
+    text-align: center;
+    color: var(--text-muted);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .empty-state-icon {
+    opacity: 0.25;
+    margin-bottom: 4px;
+  }
+
+  .empty-state-title {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-secondary);
+  }
+
+  .empty-state-msg {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.4;
+  }
+
+  .empty-state-action {
+    margin-top: 4px;
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-size: 12px;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: var(--r-sm);
+    transition: background var(--t-fast);
+  }
+
+  .empty-state-action:hover {
+    background: var(--hover);
+  }
+</style>

--- a/frontend/src/lib/components/GoalCard.svelte
+++ b/frontend/src/lib/components/GoalCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Pin, PinOff, Target, Clock, Tag, FileText, Settings } from 'lucide-svelte';
   import StreakIcon from './StreakIcon.svelte';
+  import ProgressBar from './ProgressBar.svelte';
   import { getGoalContext } from '$lib/stores/goalContext';
 
   export let goal: any;
@@ -91,9 +92,7 @@
         </span>
         <span class="progress-pct">{(goal.state === 'COMPLETED' || goal.is_completed) ? 100 : goal.progress_pct}%</span>
       </div>
-      <div class="progress-bar">
-        <div class="progress-fill" style="width: {(goal.state === 'COMPLETED' || goal.is_completed) ? 100 : goal.progress_pct}%"></div>
-      </div>
+      <ProgressBar value={(goal.state === 'COMPLETED' || goal.is_completed) ? 100 : goal.progress_pct} color="var(--goal-color)" height={6} />
     </div>
     <div class="card-footer">
       <span class="goal-id">#{goal.id}</span>
@@ -319,20 +318,6 @@
     font-weight: 600;
     color: var(--goal-color);
     font-family: var(--font-mono);
-  }
-
-  .progress-bar {
-    height: 6px;
-    background: var(--border);
-    border-radius: 3px;
-    overflow: hidden;
-  }
-
-  .card-progress .progress-fill {
-    height: 100%;
-    background: var(--goal-color);
-    border-radius: 3px;
-    transition: width 0.3s ease;
   }
 
   .card-footer {

--- a/frontend/src/lib/components/GoalList.svelte
+++ b/frontend/src/lib/components/GoalList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import GoalCard from './GoalCard.svelte';
+  import EmptyState from './EmptyState.svelte';
   import type { Goal, Note } from '$lib/api';
   import type { Tag as TagType } from '$lib/api';
   import { setGoalContext } from '$lib/stores/goalContext';
@@ -77,7 +78,7 @@
 
 <div class="editor-grid-container">
   {#if visibleGoals.length === 0}
-    <div class="empty-state">No hay objetivos que coincidan con los filtros.</div>
+    <EmptyState message="No hay objetivos que coincidan con los filtros." />
   {:else}
     <div class="editor-grid">
       {#each visibleGoals as goal (goal.id)}
@@ -102,12 +103,6 @@
     grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
     gap: 20px;
     width: 100%;
-  }
-
-  .empty-state {
-    padding: 32px;
-    text-align: center;
-    color: var(--text-muted);
   }
 
   @media (max-width: 768px) {

--- a/frontend/src/lib/components/ProgressBar.svelte
+++ b/frontend/src/lib/components/ProgressBar.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  /**
+   * Shared progress bar component (#255).
+   * Replaces duplicated progress-track/progress-fill markup across XPBar,
+   * GoalCard, goals/+page, OnboardingTour, etc.
+   */
+  export let value = 0;
+  export let max = 100;
+  export let color = '';
+  export let height = 6;
+  export let variant: 'default' | 'success' = 'default';
+
+  $: pct = max > 0 ? Math.min(100, Math.max(0, (value / max) * 100)) : 0;
+</script>
+
+<div class="progress-track" style="height: {height}px; border-radius: {Math.max(1, height / 2)}px;">
+  <div
+    class="progress-fill"
+    class:success={variant === 'success'}
+    style="width: {pct}%; {color ? `background: ${color};` : ''}"
+  ></div>
+</div>
+
+<style>
+  .progress-track {
+    background: var(--border);
+    overflow: hidden;
+    position: relative;
+  }
+
+  .progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--xp) 0%, var(--xp-2) 52%, var(--xp-3) 100%);
+    transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .progress-fill.success {
+    background: var(--success);
+  }
+</style>

--- a/frontend/src/lib/components/StreakListPanel.svelte
+++ b/frontend/src/lib/components/StreakListPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Plus, Archive, Search, Flame } from 'lucide-svelte';
   import StreakListItem from './StreakListItem.svelte';
+  import EmptyState from './EmptyState.svelte';
   import type { PersonalStreak } from '$lib/api';
 
   interface Props {
@@ -88,11 +89,9 @@
     {:else if loading}
       <div class="empty-state mono">Cargando...</div>
     {:else if filteredStreaks.length === 0}
-      <div class="empty-state">
-        <Flame size={24} style="opacity:.25; margin-bottom:8px;" />
-        <p>No hay rachas. ¡Crea una para comenzar!</p>
-        <button class="link-btn" onclick={onCreate}>Crear una nueva</button>
-      </div>
+      <EmptyState message="No hay rachas. ¡Crea una para comenzar!" actionLabel="Crear una nueva" onAction={onCreate}>
+        {#snippet icon()}<Flame size={24} />{/snippet}
+      </EmptyState>
     {:else}
       {#each filteredStreaks as streak (streak.id)}
         <StreakListItem


### PR DESCRIPTION
## Summary
- Fixes #255 (partial): several components duplicated empty-state and progress-bar markup instead of reusing shared components
- Add `EmptyState.svelte` — shared empty state with optional icon (snippet), title, message, action button, and children snippet
- Add `ProgressBar.svelte` — shared progress bar with value/max/color/height/variant props
- Refactor `GoalList` to use `EmptyState` (removes duplicated `.empty-state` CSS)
- Refactor `StreakListPanel` to use `EmptyState` with icon snippet and action button
- Refactor `GoalCard` to use `ProgressBar` (removes duplicated `.progress-bar`/`.progress-fill` CSS)

#### Test plan
- [x] `npm run check` passes (0 errors, 115 warnings — all pre-existing)
- [ ] CI passes

Generated with [Devin](https://devin.ai)