### PR TITLE
ci(release): auto-release on merge to main with alpha pre-release mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,19 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g. v0.1.0-alpha.5, v1.0.0). Leave empty to auto-bump.'
+        required: false
+        default: ''
+      prerelease:
+        description: 'Mark as pre-release (alpha/non-production ready)'
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   contents: write
@@ -14,13 +25,58 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Create Release
+      - name: Determine version
+        id: version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" \
-            --title "Joidy ${GITHUB_REF_NAME}" \
-            --generate-notes \
-            --verify-tag
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # Auto-bump: find latest alpha tag and increment.
+            # While in alpha, every merge to main produces v1.0.0-alpha.<N>.
+            # The initial release was v1.0.0-alpha (no number); subsequent
+            # releases get a numeric suffix to keep them sortable.
+            LATEST=$(git tag -l 'v1.0.0-alpha*' | sort -V | tail -1)
+            if [ -z "$LATEST" ]; then
+              VERSION="v1.0.0-alpha.1"
+            elif [ "$LATEST" = "v1.0.0-alpha" ]; then
+              VERSION="v1.0.0-alpha.1"
+            else
+              N=$(echo "$LATEST" | sed 's/.*alpha\.\([0-9]*\)/\1/')
+              N=$((N + 1))
+              VERSION="v1.0.0-alpha.${N}"
+            fi
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # Auto-detect prerelease: anything with a hyphen suffix (alpha/beta/rc)
+          # is a pre-release. Manual dispatch can override via input.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PRERELEASE="${{ inputs.prerelease }}"
+          else
+            case "$VERSION" in
+              *-*) PRERELEASE=true ;;
+              *) PRERELEASE=false ;;
+            esac
+          fi
+          echo "prerelease=${PRERELEASE}" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag and release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PRERELEASE="${{ steps.version.outputs.prerelease }}"
+          # Tag the commit that triggered the workflow.
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          ARGS=(--title "Joidy ${VERSION}" --generate-notes --verify-tag)
+          if [ "$PRERELEASE" = "true" ]; then
+            PREPEND=$(printf '## ⚠️ Alpha — Non-Production Ready\n\nThis is an **alpha** pre-release. Expect breaking changes, bugs, and incomplete features. Do **not** use in production.\n\n')
+            ARGS+=(--prerelease --notes-prepend "$PREPEND")
+          fi
+          gh release create "$VERSION" "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- `release.yml` now triggers on push to `main` (auto-release) + `workflow_dispatch` (manual)
- Auto-bumps version as `v1.0.0-alpha.<N>` while in alpha phase (continues from existing `v1.0.0-alpha`)
- All alpha/beta/rc versions auto-marked as pre-release (non-production ready)
- Adds warning banner to pre-release notes
- Removes tag-push trigger to avoid duplicate releases (release.yml creates the tag, publish.yml fires on `release: published`)

#### Test plan
- [ ] Merge this PR to development
- [ ] Fast-forward main to development
- [ ] Verify release.yml triggers and creates `v1.0.0-alpha.1` as pre-release
- [ ] Verify publish.yml triggers on the release

Generated with [Devin](https://devin.ai)