### PR TITLE
test(backend): critical test coverage for 4 untested components (#402)

### DIFF
--- a/api/tests/test_personal_streak_service.py
+++ b/api/tests/test_personal_streak_service.py
@@ -1,0 +1,202 @@
+"""Unit tests for personal_streak_service — streak creation, check-in increment,
+streak breaking (missed days), and grace period / every_n frequency logic.
+
+Uses in-memory SQLite and the real repository layer to exercise
+compute_streak and calculate_streak_stats.
+"""
+
+import sys
+import types
+import unittest
+from datetime import UTC, date, datetime, timedelta
+
+# Stub sqlite_vec before importing app modules (matches conftest pattern).
+if "sqlite_vec" not in sys.modules:
+    _stub = types.ModuleType("sqlite_vec")
+    _stub.load = lambda _conn: None  # type: ignore
+    sys.modules["sqlite_vec"] = _stub
+
+from database import Base
+from models.personal_streaks import PersonalStreak, StreakCheckIn
+from repositories import PersonalStreakRepository, StreakCheckInRepository
+from services.personal_streak_service import (
+    backfill_streak_history,
+    calculate_streak_stats,
+    compute_streak,
+)
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+
+class PersonalStreakTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        with self.engine.begin() as conn:
+            try:
+                conn.execute(
+                    text(
+                        "CREATE TABLE IF NOT EXISTS tag_cooccurrences "
+                        "(tag_a_id INTEGER, tag_b_id INTEGER, weight INTEGER, "
+                        "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP)"
+                    )
+                )
+            except Exception:
+                pass
+        self.Session = sessionmaker(bind=self.engine)
+
+    def tearDown(self) -> None:
+        self.engine.dispose()
+
+    def _today(self) -> date:
+        return datetime.now(UTC).date()
+
+    def _create_streak(self, db, **kwargs) -> PersonalStreak:
+        defaults = {
+            "name": "Test Streak",
+            "frequency": "daily",
+            "frequency_days": 1,
+        }
+        defaults.update(kwargs)
+        streak = PersonalStreakRepository(db).add(PersonalStreak(**defaults))
+        db.commit()
+        return streak
+
+    def _add_checkin(self, db, streak, check_date) -> StreakCheckIn:
+        ci = StreakCheckIn(streak_id=streak.id, check_date=check_date)
+        StreakCheckInRepository(db).add(ci)
+        db.commit()
+        return ci
+
+
+class ComputeStreakDailyTest(PersonalStreakTestBase):
+    def test_empty_checkins_returns_zero(self):
+        current, longest = compute_streak([])
+        self.assertEqual(current, 0)
+        self.assertEqual(longest, 0)
+
+    def test_single_checkin_today(self):
+        today = self._today()
+        current, longest = compute_streak([today])
+        self.assertEqual(current, 1)
+        self.assertEqual(longest, 1)
+
+    def test_consecutive_days_increment_streak(self):
+        today = self._today()
+        dates = [today - timedelta(days=i) for i in range(5)]
+        current, longest = compute_streak(dates)
+        self.assertEqual(current, 5)
+        self.assertEqual(longest, 5)
+
+    def test_missed_today_counts_yesterday(self):
+        # If today is not checked in but yesterday is, streak counts from yesterday.
+        yesterday = self._today() - timedelta(days=1)
+        current, longest = compute_streak([yesterday])
+        self.assertEqual(current, 1)
+
+    def test_gap_breaks_streak(self):
+        today = self._today()
+        # 3 consecutive then a 3-day gap then 2 consecutive.
+        dates = [today - timedelta(days=i) for i in range(2)]  # today, yesterday
+        dates.append(today - timedelta(days=5))
+        dates.append(today - timedelta(days=6))
+        dates.append(today - timedelta(days=7))
+        current, longest = compute_streak(dates)
+        self.assertEqual(current, 2)  # the recent run of 2
+        self.assertEqual(longest, 3)  # the older run of 3
+
+    def test_longest_run_is_max(self):
+        today = self._today()
+        # Run of 2, gap, run of 4.
+        dates = [today - timedelta(days=i) for i in range(4)]
+        dates.append(today - timedelta(days=6))
+        dates.append(today - timedelta(days=7))
+        current, longest = compute_streak(dates)
+        self.assertEqual(current, 4)
+        self.assertEqual(longest, 4)
+
+
+class ComputeStreakEveryNTest(PersonalStreakTestBase):
+    def test_every_n_allows_gap_within_n(self):
+        today = self._today()
+        # Every 3 days: today, 3 days ago, 6 days ago.
+        dates = [today, today - timedelta(days=3), today - timedelta(days=6)]
+        current, longest = compute_streak(dates, frequency="every_n", frequency_days=3)
+        self.assertEqual(current, 3)
+        self.assertEqual(longest, 3)
+
+    def test_every_n_gap_beyond_n_breaks(self):
+        today = self._today()
+        # Gap of 5 days exceeds frequency_days=3.
+        dates = [today, today - timedelta(days=5)]
+        current, longest = compute_streak(dates, frequency="every_n", frequency_days=3)
+        self.assertEqual(current, 1)
+
+
+class CalculateStreakStatsTest(PersonalStreakTestBase):
+    def test_stats_reflect_checkins(self):
+        db = self.Session()
+        streak = self._create_streak(db)
+        today = self._today()
+        for i in range(3):
+            self._add_checkin(db, streak, today - timedelta(days=i))
+
+        db.refresh(streak)
+        stats = calculate_streak_stats(streak)
+        self.assertEqual(stats["current_streak"], 3)
+        self.assertEqual(stats["longest_streak"], 3)
+        db.close()
+
+    def test_stats_with_no_checkins(self):
+        db = self.Session()
+        streak = self._create_streak(db)
+        stats = calculate_streak_stats(streak)
+        self.assertEqual(stats["current_streak"], 0)
+        self.assertEqual(stats["longest_streak"], 0)
+        db.close()
+
+
+class BackfillStreakHistoryTest(PersonalStreakTestBase):
+    def test_backfill_generates_missing_checkins(self):
+        db = self.Session()
+        start = self._today() - timedelta(days=5)
+        streak = self._create_streak(db, start_date=start)
+        # Set created_at to today so backfill covers start..yesterday.
+        streak.created_at = datetime.now(UTC)
+        db.commit()
+        db.refresh(streak)
+
+        backfill_streak_history(db, streak)
+        db.refresh(streak)
+        # Should have check-ins for start_date through yesterday (5 days).
+        self.assertEqual(len(streak.checkins), 5)
+        self.assertEqual(streak.total_checkins, 5)
+        db.close()
+
+    def test_backfill_no_start_date_does_nothing(self):
+        db = self.Session()
+        streak = self._create_streak(db)  # no start_date
+        backfill_streak_history(db, streak)
+        db.refresh(streak)
+        self.assertEqual(len(streak.checkins), 0)
+        db.close()
+
+    def test_backfill_every_n_frequency(self):
+        db = self.Session()
+        start = self._today() - timedelta(days=6)
+        streak = self._create_streak(db, start_date=start, frequency="every_n", frequency_days=2)
+        streak.created_at = datetime.now(UTC)
+        db.commit()
+        db.refresh(streak)
+
+        backfill_streak_history(db, streak)
+        db.refresh(streak)
+        # Every 2 days from start over 6 days: day 0, 2, 4 = 3 check-ins (excluding today).
+        checkin_dates = {c.check_date for c in streak.checkins}
+        expected = {start + timedelta(days=i) for i in range(0, 6, 2) if start + timedelta(days=i) < self._today()}
+        self.assertEqual(checkin_dates, expected)
+        db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/tests/test_push_service.py
+++ b/api/tests/test_push_service.py
@@ -1,0 +1,150 @@
+"""Unit tests for push_service — WebPush wrapper.
+
+Mocks the pywebpush.webpush HTTP call so no real network/FCM traffic occurs.
+Covers successful send and failure (WebPushException) handling.
+"""
+
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Stub sqlite_vec before importing app modules (matches conftest pattern).
+if "sqlite_vec" not in sys.modules:
+    _stub = types.ModuleType("sqlite_vec")
+    _stub.load = lambda _conn: None  # type: ignore
+    sys.modules["sqlite_vec"] = _stub
+
+from config import settings
+from database import Base
+from models.push_subscription import PushSubscription
+from pywebpush import WebPushException
+from services.push_service import send_push_to_user
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+class PushServiceTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+        self._orig_key = settings.vapid_private_key
+        self._orig_email = settings.vapid_claim_email
+        settings.vapid_private_key = "test-vapid-key"
+        settings.vapid_claim_email = "test@example.com"
+
+    def tearDown(self) -> None:
+        settings.vapid_private_key = self._orig_key
+        settings.vapid_claim_email = self._orig_email
+        self.engine.dispose()
+
+    def _add_subscription(self, db, user_id=1):
+        sub = PushSubscription(
+            user_id=user_id,
+            endpoint="https://fcm.googleapis.com/fcm/send/abc123",
+            p256dh="p256dh-key",
+            auth="auth-key",
+        )
+        db.add(sub)
+        db.commit()
+        return sub
+
+
+class SendPushSuccessTest(PushServiceTestBase):
+    @patch("services.push_service.webpush")
+    def test_successful_push_to_single_subscription(self, mock_webpush):
+        db = self.Session()
+        self._add_subscription(db)
+
+        send_push_to_user(db, user_id=1, title="Hello", body="World")
+
+        mock_webpush.assert_called_once()
+        call_kwargs = mock_webpush.call_args
+        self.assertEqual(
+            call_kwargs.kwargs["subscription_info"]["endpoint"],
+            "https://fcm.googleapis.com/fcm/send/abc123",
+        )
+        import json
+
+        self.assertEqual(json.loads(call_kwargs.kwargs["data"]), {"title": "Hello", "body": "World"})
+        self.assertEqual(call_kwargs.kwargs["vapid_private_key"], "test-vapid-key")
+        db.close()
+
+    @patch("services.push_service.webpush")
+    def test_successful_push_to_multiple_subscriptions(self, mock_webpush):
+        db = self.Session()
+        self._add_subscription(db, user_id=1)
+        self._add_subscription(db, user_id=1)
+
+        send_push_to_user(db, user_id=1, title="Hi", body="There")
+
+        self.assertEqual(mock_webpush.call_count, 2)
+        db.close()
+
+    @patch("services.push_service.webpush")
+    def test_no_subscriptions_does_not_call_webpush(self, mock_webpush):
+        db = self.Session()
+        send_push_to_user(db, user_id=999, title="Nope", body="Nobody")
+        mock_webpush.assert_not_called()
+        db.close()
+
+
+class SendPushFailureTest(PushServiceTestBase):
+    @patch("services.push_service.webpush")
+    def test_webpush_exception_does_not_raise(self, mock_webpush):
+        mock_webpush.side_effect = WebPushException("Boom", response=MagicMock())
+        db = self.Session()
+        self._add_subscription(db)
+
+        # Should not raise — failure is logged, not propagated.
+        send_push_to_user(db, user_id=1, title="Hi", body="Fail")
+        mock_webpush.assert_called_once()
+        db.close()
+
+    @patch("services.push_service.webpush")
+    def test_failure_on_one_sub_continues_to_next(self, mock_webpush):
+        mock_webpush.side_effect = [
+            WebPushException("first fails", response=MagicMock()),
+            None,  # second succeeds
+        ]
+        db = self.Session()
+        self._add_subscription(db, user_id=1)
+        self._add_subscription(db, user_id=1)
+
+        send_push_to_user(db, user_id=1, title="Hi", body="Mixed")
+        self.assertEqual(mock_webpush.call_count, 2)
+        db.close()
+
+
+class SendPushNoVapidKeyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+        self._orig_key = settings.vapid_private_key
+        settings.vapid_private_key = ""
+
+    def tearDown(self) -> None:
+        settings.vapid_private_key = self._orig_key
+        self.engine.dispose()
+
+    @patch("services.push_service.webpush")
+    def test_no_vapid_key_skips_push(self, mock_webpush):
+        db = self.Session()
+        sub = PushSubscription(
+            user_id=1,
+            endpoint="https://example.com/endpoint",
+            p256dh="key",
+            auth="auth",
+        )
+        db.add(sub)
+        db.commit()
+
+        send_push_to_user(db, user_id=1, title="Skip", body="Me")
+        mock_webpush.assert_not_called()
+        db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/tests/test_response_cache.py
+++ b/api/tests/test_response_cache.py
@@ -1,0 +1,241 @@
+"""Unit tests for response_cache — TTL cache hit/miss, clear, stats, and expiry.
+
+The cache module is pure (no DB), so these tests exercise the _TTLCache and the
+module-level helpers (clear_api_caches, get_cache_stats) directly.
+"""
+
+import sys
+import types
+import unittest
+
+# Stub sqlite_vec before importing app modules (matches conftest pattern).
+if "sqlite_vec" not in sys.modules:
+    _stub = types.ModuleType("sqlite_vec")
+    _stub.load = lambda _conn: None  # type: ignore
+    sys.modules["sqlite_vec"] = _stub
+
+import services.response_cache as response_cache_module
+from services.response_cache import (
+    _TTLCache,
+    clear_api_caches,
+    get_cache_stats,
+    register_cache_clearer,
+    ttl_cache,
+)
+
+
+class TTLCacheHitMissTest(unittest.TestCase):
+    def test_cache_hit_on_repeat_call(self):
+        cache = _TTLCache(ttl_seconds=60.0)
+        calls = []
+
+        @cache.decorator()
+        def func(x):
+            calls.append(x)
+            return x * 2
+
+        self.assertEqual(func(5), 10)
+        self.assertEqual(func(5), 10)  # cached
+        self.assertEqual(len(calls), 1)  # not re-executed
+
+    def test_cache_miss_on_different_args(self):
+        cache = _TTLCache(ttl_seconds=60.0)
+        calls = []
+
+        @cache.decorator()
+        def func(x):
+            calls.append(x)
+            return x * 2
+
+        self.assertEqual(func(1), 2)
+        self.assertEqual(func(2), 4)
+        self.assertEqual(len(calls), 2)
+
+    def test_cache_miss_on_different_kwargs(self):
+        cache = _TTLCache(ttl_seconds=60.0)
+        calls = []
+
+        @cache.decorator()
+        def func(a, b=0):
+            calls.append((a, b))
+            return a + b
+
+        self.assertEqual(func(1, b=2), 3)
+        self.assertEqual(func(1, b=3), 4)  # different b → miss
+        self.assertEqual(len(calls), 2)
+
+
+class TTLCacheClearTest(unittest.TestCase):
+    def test_cache_clear_resets_cache(self):
+        cache = _TTLCache(ttl_seconds=60.0)
+        calls = []
+
+        @cache.decorator()
+        def func(x):
+            calls.append(x)
+            return x
+
+        func(1)
+        func(1)  # hit
+        self.assertEqual(len(calls), 1)
+
+        func.cache_clear()
+        func(1)  # miss after clear
+        self.assertEqual(len(calls), 2)
+
+    def test_clear_api_caches_invokes_registered_clearers(self):
+        cache = _TTLCache(ttl_seconds=60.0)
+        calls = []
+
+        @cache.decorator()
+        def func(x):
+            calls.append(x)
+            return x
+
+        register_cache_clearer(func.cache_clear)
+        func(1)
+        func(1)
+        self.assertEqual(len(calls), 1)
+
+        clear_api_caches()
+        func(1)
+        self.assertEqual(len(calls), 2)
+
+
+class TTLCacheStatsTest(unittest.TestCase):
+    def setUp(self):
+        # Swap the module-level _cache for a fresh instance so stats are
+        # isolated per test and get_cache_stats() reflects only our calls.
+        self._orig_cache = response_cache_module._cache
+        self._orig_clearers = list(response_cache_module._REGISTERED_CLEARERS)
+        response_cache_module._cache = _TTLCache(ttl_seconds=60.0)
+        response_cache_module._REGISTERED_CLEARERS.clear()
+
+    def tearDown(self):
+        response_cache_module._cache = self._orig_cache
+        response_cache_module._REGISTERED_CLEARERS.clear()
+        response_cache_module._REGISTERED_CLEARERS.extend(self._orig_clearers)
+
+    def test_get_cache_stats_returns_hits_misses(self):
+        @ttl_cache()
+        def func(x):
+            return x
+
+        func(1)  # miss
+        func(1)  # hit
+        func(2)  # miss
+
+        stats = get_cache_stats()
+        self.assertTrue(stats["initialized"])
+        self.assertEqual(stats["hits"], 1)
+        self.assertEqual(stats["misses"], 2)
+        self.assertEqual(stats["total"], 3)
+        self.assertEqual(stats["hit_rate_pct"], 33)
+
+    def test_get_cache_stats_includes_config(self):
+        stats = get_cache_stats()
+        self.assertEqual(stats["ttl_seconds"], 60.0)
+        self.assertEqual(stats["max_entries"], 256)
+        self.assertIn("registered_clearers", stats)
+
+
+class TTLCacheExpiryTest(unittest.TestCase):
+    def test_ttl_expiry_returns_stale_and_re_executes(self):
+        cache = _TTLCache(ttl_seconds=0.05)
+        calls = []
+
+        @cache.decorator()
+        def func(x):
+            calls.append(x)
+            return x
+
+        func(1)
+        self.assertEqual(len(calls), 1)
+        # Wait for TTL to expire.
+        import time
+
+        time.sleep(0.1)
+        func(1)  # expired → re-execute
+        self.assertEqual(len(calls), 2)
+
+    def test_ttl_not_expired_within_window(self):
+        cache = _TTLCache(ttl_seconds=60.0)
+        calls = []
+
+        @cache.decorator()
+        def func(x):
+            calls.append(x)
+            return x
+
+        func(1)
+        func(1)
+        self.assertEqual(len(calls), 1)  # still cached
+
+
+class TTLCacheIgnoreParamsTest(unittest.TestCase):
+    def test_ignore_params_excludes_from_key(self):
+        cache = _TTLCache(ttl_seconds=60.0)
+        calls = []
+
+        @cache.decorator(ignore_params={"token"})
+        def func(x, token=""):
+            calls.append(x)
+            return x
+
+        self.assertEqual(func(1, token="a"), 1)
+        self.assertEqual(func(1, token="b"), 1)  # token ignored → hit
+        self.assertEqual(len(calls), 1)
+
+    def test_db_param_always_ignored(self):
+        cache = _TTLCache(ttl_seconds=60.0)
+        calls = []
+
+        @cache.decorator()
+        def func(x, db=None):
+            calls.append(x)
+            return x
+
+        self.assertEqual(func(1, db="session1"), 1)
+        self.assertEqual(func(1, db="session2"), 1)  # db ignored → hit
+        self.assertEqual(len(calls), 1)
+
+
+class TTLCacheEvictionTest(unittest.TestCase):
+    def test_max_entries_evicts_oldest(self):
+        cache = _TTLCache(ttl_seconds=60.0, max_entries=2)
+        calls = []
+
+        @cache.decorator()
+        def func(x):
+            calls.append(x)
+            return x
+
+        func(1)
+        func(2)
+        func(3)  # exceeds capacity → evict oldest (1)
+        self.assertEqual(len(calls), 3)
+
+        stats = cache.stats.snapshot()
+        self.assertGreaterEqual(stats["evictions"], 1)
+
+    def test_eviction_removes_stale_first(self):
+        cache = _TTLCache(ttl_seconds=0.05, max_entries=2)
+        calls = []
+
+        @cache.decorator()
+        def func(x):
+            calls.append(x)
+            return x
+
+        func(1)
+        import time
+
+        time.sleep(0.1)  # entry 1 now stale
+        func(2)
+        func(3)  # at capacity, but 1 is stale → evict stale
+        stats = cache.stats.snapshot()
+        self.assertGreaterEqual(stats["evictions"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/tests/test_routers_auth.py
+++ b/api/tests/test_routers_auth.py
@@ -1,0 +1,129 @@
+"""Tests for the auth router (/auth/login, /auth/status).
+
+Uses the FastAPI TestClient via the `client` fixture from conftest.py.
+The auth router is excluded from JWT enforcement, so these endpoints are
+reachable without a bearer token.
+"""
+
+import sys
+import types
+
+# Stub sqlite_vec before importing app modules (matches conftest pattern).
+if "sqlite_vec" not in sys.modules:
+    _stub = types.ModuleType("sqlite_vec")
+    _stub.load = lambda _conn: None  # type: ignore
+    sys.modules["sqlite_vec"] = _stub
+
+from config import settings
+from fastapi.testclient import TestClient
+from services.auth_service import hash_password
+
+
+def test_login_with_valid_credentials(client: TestClient):
+    orig_password = settings.auth_password
+    orig_key = settings.secret_key
+    try:
+        settings.secret_key = "test-secret-key-for-auth-router"
+        settings.auth_password = hash_password("s3cret")
+        response = client.post("/auth/login", params={"password": "s3cret"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["token_type"] == "bearer"
+        assert "access_token" in data
+        assert len(data["access_token"]) > 0
+    finally:
+        settings.auth_password = orig_password
+        settings.secret_key = orig_key
+
+
+def test_login_with_invalid_credentials(client: TestClient):
+    orig_password = settings.auth_password
+    orig_key = settings.secret_key
+    try:
+        settings.secret_key = "test-secret-key-for-auth-router"
+        settings.auth_password = hash_password("s3cret")
+        response = client.post("/auth/login", params={"password": "wrong"})
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid credentials"
+    finally:
+        settings.auth_password = orig_password
+        settings.secret_key = orig_key
+
+
+def test_login_without_password_configured_succeeds(client: TestClient):
+    orig_password = settings.auth_password
+    orig_key = settings.secret_key
+    try:
+        settings.secret_key = "test-secret-key-for-auth-router"
+        settings.auth_password = ""
+        # No password configured → any password is accepted.
+        response = client.post("/auth/login", params={"password": "anything"})
+        assert response.status_code == 200
+        assert "access_token" in response.json()
+    finally:
+        settings.auth_password = orig_password
+        settings.secret_key = orig_key
+
+
+def test_login_without_secret_key_returns_500(client: TestClient):
+    orig_password = settings.auth_password
+    orig_key = settings.secret_key
+    try:
+        settings.secret_key = ""
+        settings.auth_password = hash_password("s3cret")
+        response = client.post("/auth/login", params={"password": "s3cret"})
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Server not configured for auth"
+    finally:
+        settings.auth_password = orig_password
+        settings.secret_key = orig_key
+
+
+def test_auth_status_when_configured(client: TestClient):
+    orig_password = settings.auth_password
+    orig_key = settings.secret_key
+    try:
+        settings.secret_key = "test-secret-key-for-auth-router"
+        settings.auth_password = hash_password("s3cret")
+        response = client.get("/auth/status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is True
+        assert data["has_password"] is True
+    finally:
+        settings.auth_password = orig_password
+        settings.secret_key = orig_key
+
+
+def test_auth_status_when_not_configured(client: TestClient):
+    orig_password = settings.auth_password
+    orig_key = settings.secret_key
+    try:
+        settings.secret_key = ""
+        settings.auth_password = ""
+        response = client.get("/auth/status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is False
+        assert data["has_password"] is False
+    finally:
+        settings.auth_password = orig_password
+        settings.secret_key = orig_key
+
+
+def test_login_returns_valid_token(client: TestClient):
+    orig_password = settings.auth_password
+    orig_key = settings.secret_key
+    try:
+        settings.secret_key = "test-secret-key-for-auth-router"
+        settings.auth_password = hash_password("s3cret")
+        response = client.post("/auth/login", params={"password": "s3cret", "username": "alice"})
+        assert response.status_code == 200
+        token = response.json()["access_token"]
+        # The token should be verifiable with the same secret.
+        from services.auth_service import get_current_user_id
+
+        assert get_current_user_id(token) == 1
+    finally:
+        settings.auth_password = orig_password
+        settings.secret_key = orig_key


### PR DESCRIPTION
## Summary

Adds unit tests for 4 of the most critical/tractable untested components identified in issue #402, raising backend test coverage for previously uncovered services and routers.

Closes #402 (partial — covers 4 of the 8 routers / 11 services flagged).

## Components tested

### 1. `api/services/response_cache.py` — TTL cache (13 tests)
- Cache hit on repeat call (function not re-executed)
- Cache miss on different args / kwargs
- `cache_clear()` resets the cache
- `clear_api_caches()` invokes registered clearers
- `get_cache_stats()` returns correct hits/misses/hit_rate
- TTL expiry (small TTL + `time.sleep`) re-executes expired entries
- `ignore_params` excludes params from cache key
- `db` param always ignored (defensive default)
- `max_entries` eviction (oldest + stale-first)

### 2. `api/services/push_service.py` — WebPush wrapper (6 tests)
- Successful push to single subscription (mocked `webpush`)
- Successful push to multiple subscriptions
- No subscriptions → `webpush` not called
- `WebPushException` does not raise (failure logged, not propagated)
- Failure on one sub continues to next sub
- No VAPID key configured → push skipped

### 3. `api/services/personal_streak_service.py` — Streak calculations (13 tests)
- `compute_streak`: empty, single check-in, consecutive increment, missed-today counts yesterday
- Streak breaking on gap (current resets, longest preserved)
- Longest run is max across gaps
- `every_n` frequency: gap within N preserves, gap beyond N breaks
- `calculate_streak_stats`: reflects check-ins, handles no check-ins
- `backfill_streak_history`: generates missing check-ins, no-op without start_date, `every_n` frequency backfill

### 4. `api/routers/auth.py` — Auth router (7 tests)
- `/auth/login` with valid credentials → 200 + token
- `/auth/login` with invalid credentials → 401
- `/auth/login` without password configured → 200 (auth bypass)
- `/auth/login` without secret key → 500
- `/auth/status` when configured → enabled/has_password true
- `/auth/status` when not configured → enabled/has_password false
- `/auth/login` returns a verifiable token (user_id=1)

## Test plan checklist

- [x] `python -m py_compile api/tests/test_*.py` — all 4 files pass
- [x] `ruff check` + `ruff format` — clean
- [x] `response_cache` tests pass (13/13)
- [x] `push_service` tests pass (6/6)
- [x] `personal_streak_service` tests pass (13/13)
- [x] `auth` router tests follow existing `test_routers_*.py` TestClient pattern
- [x] All test files stub `sqlite_vec` per repo convention
- [x] Service tests use in-memory SQLite (`sqlite:///:memory:`)
- [x] `unittest.TestCase` style for service tests; pytest function style for router tests (matches repo convention)

## Notes

- Router tests (`test_routers_auth.py`) use the existing `client` fixture from `conftest.py`, consistent with `test_routers_goals.py` / `test_routers_notes.py`.
- `push_service` tests mock `pywebpush.webpush` so no real FCM/network traffic occurs.

Generated with [Devin](https://devin.ai)