### PR TITLE
perf(frontend): lazy-load heavy route components (#347)

### DIFF
--- a/frontend/src/routes/ai/+page.svelte
+++ b/frontend/src/routes/ai/+page.svelte
@@ -2,11 +2,20 @@
   import { onMount } from 'svelte';
   import { api } from '$lib/api';
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
-  import ChatInterface from '$lib/components/ChatInterface.svelte';
   import { devMode } from '$lib/stores/settings';
 
   let usage = $state<{ ai_enabled: boolean; estimated_cost_usd: number } | null>(null);
   let loadingUsage = $state(true);
+
+  // Lazy-load the heavy ChatInterface (376 lines, pulls in marked, dompurify)
+  // so it is split into a separate chunk and only downloaded when the AI page
+  // is opened (#347).
+  let ChatInterface = $state<typeof import('$lib/components/ChatInterface.svelte').default | null>(null);
+  $effect(() => {
+    if (!ChatInterface) {
+      import('$lib/components/ChatInterface.svelte').then(m => ChatInterface = m.default);
+    }
+  });
 
   // Lazy-load DeadLetterQueue — only shown in dev mode, so defer the chunk
   // until the user actually enables it (#347).
@@ -44,7 +53,11 @@
   </div>
 
   <div class="ai-content">
-    <ChatInterface />
+    {#if ChatInterface}
+      <svelte:component this={ChatInterface} />
+    {:else}
+      <div class="caption" style="padding: 24px; text-align: center; color: var(--text-muted);">Cargando chat...</div>
+    {/if}
   </div>
 
   {#if $devMode}

--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -13,10 +13,19 @@
   import { logger } from '$lib/utils/logger';
   import { GOAL_COLOR_PRESETS, DEFAULT_GOAL_COLOR, TEMPORALITY_COLORS } from '$lib/utils/goalColors';
   import StreakIcon from '$lib/components/StreakIcon.svelte';
-  import StreakHeatmap from '$lib/components/StreakHeatmap.svelte';
   import GoalCard from '$lib/components/GoalCard.svelte';
   import LazyIconPicker from '$lib/components/LazyIconPicker.svelte';
   import ModalDialog from '$lib/components/ModalDialog.svelte';
+
+  // Lazy-load the heavy StreakHeatmap (561 lines) so it is split into a
+  // separate chunk and only downloaded when the planning or history tab is
+  // active — the only tabs that render it (#347).
+  let StreakHeatmap = $state<typeof import('$lib/components/StreakHeatmap.svelte').default | null>(null);
+  $effect(() => {
+    if ((currentTab === 'planning' || currentTab === 'history') && !StreakHeatmap) {
+      import('$lib/components/StreakHeatmap.svelte').then(m => StreakHeatmap = m.default);
+    }
+  });
 
   let goals = $state<Goal[]>([]);
   let tags = $state<TagType[]>([]);
@@ -1168,13 +1177,16 @@
             <span class="section-title" style="margin:0;">Calendario</span>
           </div>
           <div class="history-heatmap-wrap">
-            <StreakHeatmap
-              history={historyData}
-              color="var(--success)"
-              selectedDate={selectedPlanningDate}
-              onselect={(date) => selectedPlanningDate = date}
-              maxFutureMonths={1200}
-            />
+            {#if StreakHeatmap}
+              <svelte:component
+                this={StreakHeatmap}
+                history={historyData}
+                color="var(--success)"
+                selectedDate={selectedPlanningDate}
+                onselect={(date) => selectedPlanningDate = date}
+                maxFutureMonths={1200}
+              />
+            {/if}
           </div>
         </div>
 
@@ -1248,12 +1260,15 @@
             <div class="empty-state">Aún no hay actividad registrada.</div>
           {:else}
             <div class="history-heatmap-wrap">
-              <StreakHeatmap
-                history={historyData}
-                color="var(--success)"
-                selectedDate={selectedHistoryDate}
-                onselect={(date) => selectedHistoryDate = date}
-              />
+              {#if StreakHeatmap}
+                <svelte:component
+                  this={StreakHeatmap}
+                  history={historyData}
+                  color="var(--success)"
+                  selectedDate={selectedHistoryDate}
+                  onselect={(date) => selectedHistoryDate = date}
+                />
+              {/if}
             </div>
           {/if}
         </div>

--- a/frontend/src/routes/goals/[id]/+page.svelte
+++ b/frontend/src/routes/goals/[id]/+page.svelte
@@ -4,10 +4,19 @@
   import { goto } from '$app/navigation';
   import { api, type Goal, type Tag as TagType, type Note } from '$lib/api';
   import { logger } from '$lib/utils/logger';
-  import GoalEditor from '$lib/components/GoalEditor.svelte';
   import LazyIconPicker from '$lib/components/LazyIconPicker.svelte';
   import StreakIcon from '$lib/components/StreakIcon.svelte';
   import { GOAL_COLOR_PRESETS, DEFAULT_GOAL_COLOR } from '$lib/utils/goalColors';
+
+  // Lazy-load the heavy GoalEditor (461 lines, pulls in marked, dompurify,
+  // highlight.js) so it is split into a separate chunk and only downloaded
+  // when the goal detail/edit page is opened (#347).
+  let GoalEditor: typeof import('$lib/components/GoalEditor.svelte').default | null = null;
+  function ensureGoalEditor() {
+    if (!GoalEditor) {
+      import('$lib/components/GoalEditor.svelte').then(m => GoalEditor = m.default);
+    }
+  }
 
   let goal: Goal | null = null;
   let goalContent: string = '';
@@ -54,6 +63,7 @@
   $: goalId = parseInt($page.params.id || "0");
 
   onMount(async () => {
+    ensureGoalEditor();
     await Promise.all([loadGoal(), loadMeta()]);
   });
 
@@ -173,13 +183,18 @@
   {:else if loadError}
     <div class="error">{loadError}</div>
   {:else if goal}
-    <GoalEditor
-      {goal}
-      content={goalContent}
-      on:save={handleSave}
-      on:edit={openSettings}
-      on:cancel={handleCancel}
-    />
+    {#if GoalEditor}
+      <svelte:component
+        this={GoalEditor}
+        {goal}
+        content={goalContent}
+        on:save={handleSave}
+        on:edit={openSettings}
+        on:cancel={handleCancel}
+      />
+    {:else}
+      <div class="loading">Cargando editor...</div>
+    {/if}
   {:else}
     <div class="error">Objetivo no encontrado</div>
   {/if}

--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -4,8 +4,17 @@
   import { goto } from '$app/navigation';
   import { Search, Plus, X, List, FolderTree, ChevronRight, FileEdit, FolderPlus, ChevronsUpDown, ArrowUpDown, Settings } from 'lucide-svelte';
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
-  import NoteEditor from '$lib/components/NoteEditor.svelte';
   import NoteCard from '$lib/components/NoteCard.svelte';
+
+  // Lazy-load the heavy NoteEditor (1631 lines, pulls in highlight.js, marked,
+  // dompurify, tiptap) so it is split into a separate chunk and only
+  // downloaded when the user actually opens a note for editing (#347).
+  let NoteEditor: typeof import('$lib/components/NoteEditor.svelte').default | null = null;
+  function ensureNoteEditor() {
+    if (!NoteEditor) {
+      import('$lib/components/NoteEditor.svelte').then(m => NoteEditor = m.default);
+    }
+  }
   import LazyIconPicker from '$lib/components/LazyIconPicker.svelte';
   import VirtualList from '$lib/components/VirtualList.svelte';
   import { notes, notesLoading, loadNotes, createNote, updateNote, deleteNote, aiSuggestions, notesLoadedOnce, selectedNoteIds, bulkMode, toggleNoteSelection, selectAllNotes, clearNoteSelection, deleteSelectedNotes, tagSelectedNotes, untagSelectedNotes } from '$lib/stores/notes';
@@ -486,6 +495,7 @@
     showEditor = true;
     editingNew = false;
     aiSuggestions.set([]);
+    ensureNoteEditor();
   }
 
   function openNew() {
@@ -496,6 +506,7 @@
     dailySourcePath = null;
     dailyInitialTitle = '';
     aiSuggestions.set([]);
+    ensureNoteEditor();
   }
 
   function openMomentary() {
@@ -505,6 +516,7 @@
     isMomentary = true;
     dailySourcePath = null;
     dailyInitialTitle = '';
+    ensureNoteEditor();
   }
 
   function normalizeVaultFolder(path: string): string {
@@ -542,6 +554,7 @@
     dailyInitialTitle = today;
     dailySourcePath = buildDailySourcePath(vaultPath, dailyFolder, `${today}.md`);
     aiSuggestions.set([]);
+    ensureNoteEditor();
   }
 
   function closeEditor() {
@@ -950,18 +963,23 @@
     {/if}
     {#if showEditor}
       {#key editingNew ? (isMomentary ? 'momentary' : 'new') : selectedNote?.id}
-        <NoteEditor
-          note={editorNote}
-          momentary={isMomentary}
-          initialTitle={dailyInitialTitle}
-          {hasPrev}
-          {hasNext}
-          on:save={handleSave}
-          on:cancel={closeEditor}
-          on:delete={handleDelete}
-          on:prev={goToPrev}
-          on:next={goToNext}
-        />
+        {#if NoteEditor}
+          <svelte:component
+            this={NoteEditor}
+            note={editorNote}
+            momentary={isMomentary}
+            initialTitle={dailyInitialTitle}
+            {hasPrev}
+            {hasNext}
+            on:save={handleSave}
+            on:cancel={closeEditor}
+            on:delete={handleDelete}
+            on:prev={goToPrev}
+            on:next={goToNext}
+          />
+        {:else}
+          <div class="editor-loading caption">Cargando editor...</div>
+        {/if}
       {/key}
     {:else}
       <div class="empty-dashboard">

--- a/frontend/src/routes/skills/+page.svelte
+++ b/frontend/src/routes/skills/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import SkillTree from '$lib/components/SkillTree.svelte';
   import { api, type Skill, type SkillTree as SkillTreeData } from '$lib/api';
   import { logger } from '$lib/utils/logger';
   import { displayTagName } from '$lib/utils/format';
@@ -8,6 +7,15 @@
   import { devMode } from '$lib/stores/settings';
   import { openShare } from '$lib/stores/shareAchievement';
   import { Search, X, Share2 } from 'lucide-svelte';
+
+  // Lazy-load the heavy SkillTree (236 lines, pulls in d3) so it is split
+  // into a separate chunk and only downloaded when dev mode is on (#347).
+  let SkillTree = $state<typeof import('$lib/components/SkillTree.svelte').default | null>(null);
+  $effect(() => {
+    if ($devMode && !SkillTree) {
+      import('$lib/components/SkillTree.svelte').then(m => SkillTree = m.default);
+    }
+  });
 
   let skills: Skill[] = $state([]);
   let treeData: SkillTreeData = $state({ nodes: [], edges: [] });
@@ -89,8 +97,10 @@
         <div class="loading-state caption">
           Agrega 3+ notas con un tag para desbloquear una habilidad.
         </div>
+      {:else if SkillTree}
+        <svelte:component this={SkillTree} data={treeData} width={560} height={420} />
       {:else}
-        <SkillTree data={treeData} width={560} height={420} />
+        <div class="loading-state caption">Cargando árbol...</div>
       {/if}
     </div>
 

--- a/frontend/src/routes/streaks/+page.svelte
+++ b/frontend/src/routes/streaks/+page.svelte
@@ -4,8 +4,6 @@
   import { X, Snowflake, ChevronRight } from 'lucide-svelte';
     import { Shuffle, CheckCheck } from 'lucide-svelte';
   import StreakListItem from '$lib/components/StreakListItem.svelte';
-  import StreakCreateModal from '$lib/components/StreakCreateModal.svelte';
-  import StreakHeatmap from '$lib/components/StreakHeatmap.svelte';
   import StreakStatsPanel from '$lib/components/StreakStatsPanel.svelte';
   import StreakListPanel from '$lib/components/StreakListPanel.svelte';
   import { api, type PersonalStreak, type StreakStats } from '$lib/api';
@@ -15,6 +13,23 @@
   import { openShare } from '$lib/stores/shareAchievement';
   import { logger } from '$lib/utils/logger';
   import { Share2 } from 'lucide-svelte';
+
+  // Lazy-load heavy components so they are split into separate chunks and
+  // only downloaded when actually needed (#347).
+  // StreakCreateModal (558 lines) — loaded when the user opens the create/edit modal.
+  let StreakCreateModal: typeof import('$lib/components/StreakCreateModal.svelte').default | null = null;
+  function ensureStreakCreateModal() {
+    if (!StreakCreateModal) {
+      import('$lib/components/StreakCreateModal.svelte').then(m => StreakCreateModal = m.default);
+    }
+  }
+  // StreakHeatmap (561 lines) — loaded when a streak is selected for detail view.
+  let StreakHeatmap: typeof import('$lib/components/StreakHeatmap.svelte').default | null = null;
+  function ensureStreakHeatmap() {
+    if (!StreakHeatmap) {
+      import('$lib/components/StreakHeatmap.svelte').then(m => StreakHeatmap = m.default);
+    }
+  }
 
   let streaks: PersonalStreak[] = [];
   let stats: StreakStats | null = null;
@@ -81,6 +96,7 @@
       selectedId = snap.state.selectedId ?? null;
       showArchived = snap.state.showArchived ?? false;
       searchQuery = snap.state.searchQuery ?? '';
+      if (selectedId) ensureStreakHeatmap();
     }
     
     const cached = getCachedData<PersonalStreak[]>('streaks');
@@ -105,6 +121,7 @@
       }
     } finally {
       if (selectedId && !streaks.find(s => s.id === selectedId)) selectedId = streaks[0]?.id ?? null;
+      if (selectedId) ensureStreakHeatmap();
     }
 
     window.addEventListener('beforeunload', handleBeforeUnload);
@@ -137,6 +154,7 @@
         // Force reactivity
         streaks = streaks;
         selectedId = created.id;
+        ensureStreakHeatmap();
       }
       stats = await api.personalStreaks.stats();
       notifyStreaksUpdated();
@@ -202,6 +220,7 @@
     if (filteredStreaks.length === 0) return;
     const next = filteredStreaks[Math.floor(Math.random() * filteredStreaks.length)];
     selectedId = next.id;
+    ensureStreakHeatmap();
   }
 
   function toggleArchivedView() {
@@ -275,11 +294,13 @@
   function openCreate() {
     editTarget = null;
     showModal = true;
+    ensureStreakCreateModal();
   }
 
   function openEdit(s: PersonalStreak) {
     editTarget = s;
     showModal = true;
+    ensureStreakCreateModal();
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────────
@@ -346,7 +367,7 @@
         {getDaysForCompletion}
         onToggleArchive={toggleArchivedView}
         onCreate={openCreate}
-        onSelect={(id) => selectedId = id}
+        onSelect={(id) => { selectedId = id; ensureStreakHeatmap(); }}
         onEdit={openEdit}
         onDelete={deleteStreak}
       />
@@ -431,12 +452,17 @@
 
             <!-- Activity calendar -->
             <div class="heatmap-section">
-              <StreakHeatmap
-                history={selected.history}
-                color={selected.color || 'var(--xp)'}
-                startDate={selected.start_date}
-                targetDate={selected.target_date}
-              />
+              {#if StreakHeatmap}
+                <svelte:component
+                  this={StreakHeatmap}
+                  history={selected.history}
+                  color={selected.color || 'var(--xp)'}
+                  startDate={selected.start_date}
+                  targetDate={selected.target_date}
+                />
+              {:else}
+                <div class="caption" style="padding: 24px; text-align: center; color: var(--text-muted);">Cargando calendario...</div>
+              {/if}
             </div>
 
             <!-- Footer: dates + actions, sticky at bottom -->
@@ -531,13 +557,16 @@
   </div>
 {/if}
 
-<StreakCreateModal
-  bind:open={showModal}
-  editStreak={editTarget}
-  on:close={() => { showModal = false; editTarget = null; }}
-  on:save={handleSave}
-  on:archive={() => editTarget?.id != null && archiveStreak(editTarget.id, !editTarget.is_archived)}
-/>
+{#if StreakCreateModal}
+  <svelte:component
+    this={StreakCreateModal}
+    bind:open={showModal}
+    editStreak={editTarget}
+    on:close={() => { showModal = false; editTarget = null; }}
+    on:save={handleSave}
+    on:archive={() => editTarget?.id != null && archiveStreak(editTarget.id, !editTarget.is_archived)}
+  />
+{/if}
 
 <style>
   .streaks-page {


### PR DESCRIPTION
## Summary

Implements lazy loading for heavy components in routes that were missing it, following the existing pattern used in `graph/+page.svelte` and `ai/+page.svelte` (for `DeadLetterQueue`).

Closes #347.

### Routes & components made lazy:

| Route | Component | Lines | Heavy deps | Load condition |
|-------|-----------|-------|------------|----------------|
| `notes/+page.svelte` | `NoteEditor` | 1631 | highlight.js, marked, dompurify, tiptap | When a note is opened for editing |
| `skills/+page.svelte` | `SkillTree` | 236 | d3 | When dev mode is on |
| `streaks/+page.svelte` | `StreakCreateModal` | 558 | — | When user clicks create/edit streak |
| `streaks/+page.svelte` | `StreakHeatmap` | 561 | — | When a streak is selected |
| `goals/+page.svelte` | `StreakHeatmap` | 561 | — | When planning or history tab is active |
| `goals/[id]/+page.svelte` | `GoalEditor` | 461 | marked, dompurify, highlight.js | On mount (goal edit page) |
| `ai/+page.svelte` | `ChatInterface` | 376 | marked, dompurify | On mount |

### Implementation details

- **Runes-mode pages** (`skills`, `ai`, `goals`): Use `$state` for the lazy-loaded component variable + `$effect` to trigger the dynamic import when the load condition is met. This ensures the UI re-renders when the chunk finishes loading.
- **Legacy-mode pages** (`notes`, `streaks`, `goals/[id]`): Use plain `let` + an `ensure*()` helper function called at the exact points where the component is needed (e.g., `openNote()`, `openCreate()`, `onSelect`).
- All components are rendered via `{#if Component}<svelte:component this={Component} {...props} />{/if}` with loading placeholders where appropriate.
- No business logic changed — only the loading strategy (static import → dynamic import).

## Test plan

- [x] `npm run check` passes (0 errors, 119 warnings — all pre-existing)
- [ ] Manual verification: navigate to each route and confirm components still render correctly
- [ ] Manual verification: check Network tab to confirm heavy chunks are split and loaded on demand

Generated with [Devin](https://devin.ai)