### PR TITLE
perf(frontend): Vite manual chunks for d3, markdown, and tiptap (#347)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,5 +22,32 @@ export default defineConfig({
   },
   ssr: {
     noExternal: ['phosphor-svelte', 'svelte-hero-icons', 'svelte-bootstrap-icons', 'svelte-radix']
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          // Visualization: d3 + force-graph (used by SkillTree, KnowledgeGraph)
+          d3: ['d3', 'force-graph'],
+          // Markdown rendering: marked + dompurify + highlight.js (used by
+          // NoteEditor, GoalEditor, ChatInterface, WysiwygEditor)
+          markdown: ['marked', 'dompurify', 'highlight.js'],
+          // Rich text editor: TipTap + extensions (used by WysiwygEditor)
+          tiptap: [
+            '@tiptap/core',
+            '@tiptap/starter-kit',
+            '@tiptap/pm',
+            '@tiptap/extension-code-block-lowlight',
+            '@tiptap/extension-image',
+            '@tiptap/extension-link',
+            '@tiptap/extension-placeholder',
+            '@tiptap/extension-strike',
+            '@tiptap/extension-task-item',
+            '@tiptap/extension-task-list',
+            '@tiptap/extension-underline'
+          ]
+        }
+      }
+    }
   }
 });


### PR DESCRIPTION
## Summary
- Configure Vite `manualChunks` to split heavy third-party dependencies into separate chunks
- Improves initial page load by deferring large libs until needed
- Enables better browser caching (these libs rarely change)

### Chunks created
- **d3**: `d3` + `force-graph` (visualization, used by SkillTree/KnowledgeGraph)
- **markdown**: `marked` + `dompurify` + `highlight.js` (rendering, used by NoteEditor/GoalEditor/ChatInterface)
- **tiptap**: `@tiptap/*` (rich text editor, used by WysiwygEditor)

Complements the component-level lazy loading from #538.

#### Test plan
- [x] `npm run check` passes (0 errors, 119 pre-existing warnings)
- [ ] CI Docker Build & Smoke Test passes
- [ ] Manual: verify initial page load is faster
- [ ] Manual: verify graph/skills/notes routes still work after chunks load

Generated with [Devin](https://devin.ai)