### PR TITLE
feat(frontend): i18n infrastructure + migrate critical UI strings (#370)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "html-to-image": "^1.11.13",
         "lucide-svelte": "^1.0.1",
         "marked": "^12.0.0",
+        "svelte-i18n": "^4.0.1",
         "turndown": "^7.2.4"
       },
       "devDependencies": {
@@ -932,6 +933,57 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3176,6 +3228,22 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/cli-color": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.4.tgz",
+      "integrity": "sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.64",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.15",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3258,6 +3326,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/d3": {
@@ -3725,7 +3806,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -3739,7 +3819,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3828,6 +3907,58 @@
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -4028,6 +4159,21 @@
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
       "license": "MIT"
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/espree": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
@@ -4103,7 +4249,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esutils": {
@@ -4116,6 +4261,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -4124,6 +4279,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4307,6 +4471,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "license": "MIT"
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4415,6 +4591,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
@@ -4466,6 +4654,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "license": "MIT"
     },
     "node_modules/is-reference": {
@@ -4716,6 +4910,15 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "node_modules/lucide-svelte": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-1.0.1.tgz",
@@ -4792,6 +4995,25 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/memoizee": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "es5-ext": "^0.10.64",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -4812,7 +5034,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -4860,6 +5081,12 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
     },
     "node_modules/obug": {
       "version": "2.1.4",
@@ -5554,7 +5781,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
       "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mri": "^1.1.0"
@@ -5828,6 +6054,436 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/svelte-i18n": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte-i18n/-/svelte-i18n-4.0.1.tgz",
+      "integrity": "sha512-jaykGlGT5PUaaq04JWbJREvivlCnALtT+m87Kbm0fxyYHynkQaxQMnIKHLm2WeIuBRoljzwgyvz0Z6/CMwfdmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-color": "^2.0.3",
+        "deepmerge": "^4.2.2",
+        "esbuild": "^0.19.2",
+        "estree-walker": "^2",
+        "intl-messageformat": "^10.5.3",
+        "sade": "^1.8.1",
+        "tiny-glob": "^0.2.9"
+      },
+      "bin": {
+        "svelte-i18n": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/android-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/android-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/android-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/linux-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/@esbuild/win32-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/svelte-i18n/node_modules/esbuild": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
+      }
+    },
     "node_modules/svelte/node_modules/aria-query": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
@@ -5852,6 +6508,29 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/timers-ext": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/tiny-glob": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "license": "MIT",
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -5972,6 +6651,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/turndown": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
@@ -5984,6 +6669,12 @@
         "node": ">=18",
         "npm": ">=9"
       }
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,6 +64,7 @@
     "html-to-image": "^1.11.13",
     "lucide-svelte": "^1.0.1",
     "marked": "^12.0.0",
+    "svelte-i18n": "^4.0.1",
     "turndown": "^7.2.4"
   },
   "type": "module"

--- a/frontend/src/lib/components/OnboardingTour.svelte
+++ b/frontend/src/lib/components/OnboardingTour.svelte
@@ -3,6 +3,7 @@
   import { highlightElement, clearHighlight } from '$lib/utils/spotlight';
   import { fly, fade } from 'svelte/transition';
   import { ArrowRight, ArrowLeft, X, Check } from 'lucide-svelte';
+  import { t } from 'svelte-i18n';
 
   $: step = ONBOARDING_STEPS[$onboarding.currentStep];
   $: isLastStep = $onboarding.currentStep === ONBOARDING_STEPS.length - 1;
@@ -68,23 +69,21 @@
         <div class="progress-fill" style="width: {progress}%"></div>
       </div>
 
-      <button
-        class="skip-btn"
-        onclick={handleSkip}
-        aria-label="Saltar tour de bienvenida"
-      >
+      <button class="skip-btn" onclick={handleSkip} aria-label={$t('onboarding.skipTour')}>
         <X size={16} />
-        <span>Saltar</span>
+        <span>{$t('common.skip')}</span>
       </button>
 
       <div class="content">
-        <h2 id="onboarding-title" class="title">{step.title}</h2>
-        <p class="description">{step.content}</p>
+        <h2 id="onboarding-title" class="title">{step ? $t(step.titleKey) : ''}</h2>
+        <p class="description">{step ? $t(step.contentKey) : ''}</p>
       </div>
 
       <div class="footer">
         <span class="step-indicator" aria-live="polite">
-          Paso {$onboarding.currentStep + 1} de {ONBOARDING_STEPS.length}
+          {$t('onboarding.stepIndicator', {
+            values: { current: $onboarding.currentStep + 1, total: ONBOARDING_STEPS.length },
+          })}
         </span>
 
         <div class="actions">
@@ -92,29 +91,33 @@
             <button
               class="btn btn-secondary"
               onclick={() => onboarding.prevStep()}
-              aria-label="Paso anterior"
+              aria-label={$t('onboarding.previousStep')}
             >
               <ArrowLeft size={16} />
-              <span>Anterior</span>
+              <span>{$t('common.previous')}</span>
             </button>
           {/if}
 
           {#if isLastStep && step.id === 'obsidian'}
             <button class="btn btn-secondary" onclick={handleSkip}>
-              Saltar por ahora
+              {$t('onboarding.skipForNow')}
             </button>
             <button class="btn btn-primary" onclick={openSettings}>
-              <span>Configurar Obsidian</span>
+              <span>{$t('onboarding.configureObsidian')}</span>
               <ArrowRight size={16} />
             </button>
           {:else if isLastStep}
             <button class="btn btn-primary" onclick={handleNext}>
               <Check size={16} />
-              <span>Comenzar</span>
+              <span>{$t('common.start')}</span>
             </button>
           {:else}
-            <button class="btn btn-primary" onclick={handleNext} aria-label="Siguiente paso">
-              <span>Siguiente</span>
+            <button
+              class="btn btn-primary"
+              onclick={handleNext}
+              aria-label={$t('onboarding.nextStep')}
+            >
+              <span>{$t('common.next')}</span>
               <ArrowRight size={16} />
             </button>
           {/if}
@@ -314,7 +317,9 @@
     position: absolute;
     border: 2px solid var(--xp);
     border-radius: var(--r);
-    box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.4), 0 0 20px rgba(0, 0, 0, 0.5);
+    box-shadow:
+      0 0 0 4px rgba(0, 0, 0, 0.4),
+      0 0 20px rgba(0, 0, 0, 0.5);
     pointer-events: none;
     transition: all 0.25s ease;
   }

--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -2,17 +2,33 @@
   import { createEventDispatcher, onMount, onDestroy } from 'svelte';
   import { browser } from '$app/environment';
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
-  import { accentColors, activeIconPack, showFrontmatter, showTrash, showHiddenFiles, writeInObsidian, use24HourClock, hideTagsLine, darkMode, devMode, themeMode, type IconPack, type ThemeMode, MAX_COLORS } from '$lib/stores/settings';
+  import {
+    accentColors,
+    activeIconPack,
+    showFrontmatter,
+    showTrash,
+    showHiddenFiles,
+    writeInObsidian,
+    use24HourClock,
+    hideTagsLine,
+    darkMode,
+    devMode,
+    themeMode,
+    type IconPack,
+    type ThemeMode,
+    MAX_COLORS,
+  } from '$lib/stores/settings';
   import { api } from '$lib/api';
   import { logger } from '$lib/utils/logger';
   import { deferredPrompt, isAppInstalled, showInstallBanner } from '$lib/stores/pwa';
   import { showNotification } from '$lib/stores/notifications';
+  import { locale as localeStore, setLocale } from '$lib/stores/locale';
+  import { t } from 'svelte-i18n';
+  import { mapToSupportedLocale, SUPPORTED_LOCALES, type SupportedLocale } from '$lib/i18n';
 
   export let open = false;
 
   const dispatch = createEventDispatcher<{ close: void }>();
-
-  
 
   let configLoaded = false;
   let configSaving = false;
@@ -105,7 +121,6 @@
       const status = await api.github.status();
       githubConnected = status.connected;
       githubUsername = status.username || '';
-  
     } catch (e) {
       githubConnected = false;
       githubUsername = '';
@@ -200,11 +215,21 @@
     showNotification('GitHub desconectado', 'info');
   }
 
-  async function openGoogleCalendarLink() { window.open('https://calendar.google.com', '_blank'); }
-  async function openGoogleTasksLink() { window.open('https://tasksboard.com', '_blank'); }
-  async function openGoogleContactsLink() { window.open('https://contacts.google.com', '_blank'); }
-  async function openStravaLink() { window.open('https://strava.com', '_blank'); }
-  async function openGmailLink() { window.open('https://mail.google.com', '_blank'); }
+  async function openGoogleCalendarLink() {
+    window.open('https://calendar.google.com', '_blank');
+  }
+  async function openGoogleTasksLink() {
+    window.open('https://tasksboard.com', '_blank');
+  }
+  async function openGoogleContactsLink() {
+    window.open('https://contacts.google.com', '_blank');
+  }
+  async function openStravaLink() {
+    window.open('https://strava.com', '_blank');
+  }
+  async function openGmailLink() {
+    window.open('https://mail.google.com', '_blank');
+  }
 
   async function checkGoogleStatus() {
     try {
@@ -233,7 +258,10 @@
         }
       }, 3000);
       // Stop polling after 5 minutes
-      setTimeout(() => { clearInterval(pollInterval); googleConnecting = false; }, 300000);
+      setTimeout(() => {
+        clearInterval(pollInterval);
+        googleConnecting = false;
+      }, 300000);
     } catch (e: any) {
       googleError = e.message || 'Error iniciando autenticación con Google';
       googleConnecting = false;
@@ -262,7 +290,7 @@
       configuredKeys = Object.entries(configToSave)
         .filter(([k, v]) => v && k !== 'telegram_bot_token' && k !== 'telegram_allowed_user_id')
         .map(([k, v]) => k);
-      setTimeout(() => configMessage = '', 3000);
+      setTimeout(() => (configMessage = ''), 3000);
     } catch (e: any) {
       configMessage = 'Error: ' + (e.message || 'Failed to save');
     } finally {
@@ -274,11 +302,25 @@
     return configuredKeys.includes(key);
   }
 
-  const ICON_PACKS: { value: IconPack, label: string }[] = [
+  const ICON_PACKS: { value: IconPack; label: string }[] = [
     { value: 'lucide', label: 'Lucide (Por Defecto)' },
     { value: 'phosphor', label: 'Phosphor' },
-    { value: 'material', label: 'Material' }
+    { value: 'material', label: 'Material' },
   ];
+
+  // Language selector options (#370). The store holds the full BCP-47 tag
+  // (e.g. "es-CL"); we map it to a supported base locale for the dropdown.
+  const LANGUAGE_OPTIONS: { value: SupportedLocale; label: string }[] = [
+    { value: 'es', label: 'Español' },
+    { value: 'en', label: 'English' },
+  ];
+
+  $: currentLocale = mapToSupportedLocale($localeStore);
+
+  function onLocaleChange(e: Event) {
+    const value = (e.target as HTMLSelectElement).value as SupportedLocale;
+    setLocale(value);
+  }
 
   function toggleTheme() {
     darkMode.toggle();
@@ -294,9 +336,10 @@
     if (/^#[0-9a-fA-F]{6}$/.test(full)) accentColors.setColor(i, full);
   }
 
-  $: gradientPreview = $accentColors.length === 1
-    ? $accentColors[0]
-    : `linear-gradient(to right, ${$accentColors.join(', ')})`;
+  $: gradientPreview =
+    $accentColors.length === 1
+      ? $accentColors[0]
+      : `linear-gradient(to right, ${$accentColors.join(', ')})`;
 
   let offsetPx = 0;
   let isDragging = false;
@@ -322,16 +365,16 @@
   }
 
   function lerp(c1: string, c2: string, t: number): string {
-    const r1 = parseInt(c1.slice(1,3), 16);
-    const g1 = parseInt(c1.slice(3,5), 16);
-    const b1 = parseInt(c1.slice(5,7), 16);
-    const r2 = parseInt(c2.slice(1,3), 16);
-    const g2 = parseInt(c2.slice(3,5), 16);
-    const b2 = parseInt(c2.slice(5,7), 16);
+    const r1 = parseInt(c1.slice(1, 3), 16);
+    const g1 = parseInt(c1.slice(3, 5), 16);
+    const b1 = parseInt(c1.slice(5, 7), 16);
+    const r2 = parseInt(c2.slice(1, 3), 16);
+    const g2 = parseInt(c2.slice(3, 5), 16);
+    const b2 = parseInt(c2.slice(5, 7), 16);
     const r = Math.round(r1 + (r2 - r1) * t);
     const g = Math.round(g1 + (g2 - g1) * t);
     const b = Math.round(b1 + (b2 - b1) * t);
-    return `#${r.toString(16).padStart(2,'0')}${g.toString(16).padStart(2,'0')}${b.toString(16).padStart(2,'0')}`;
+    return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
   }
 
   function onGradientMouseDown(e: MouseEvent) {
@@ -384,61 +427,101 @@
   <div class="backdrop" role="presentation" onclick={onBackdropClick}>
     <div class="panel">
       <div class="panel-header">
-        <span class="mono" style="font-size:12px; letter-spacing:0.08em;">AJUSTES</span>
-        <button class="close-btn" onclick={close} aria-label="Cerrar"><DynamicIcon name="X" size={14} /></button>
+        <span class="mono" style="font-size:12px; letter-spacing:0.08em;"
+          >{$t('settings.title')}</span
+        >
+        <button class="close-btn" onclick={close} aria-label={$t('common.close')}
+          ><DynamicIcon name="X" size={14} /></button
+        >
       </div>
 
       <div class="panel-body">
-
         <!-- Apariencia -->
         <section class="section">
-          <div class="section-title" style="color: var(--xp, var(--accent));">Apariencia</div>
+          <div class="section-title" style="color: var(--xp, var(--accent));">
+            {$t('settings.appearance')}
+          </div>
           <div class="row">
             <div class="row-label">
-              {#if $darkMode}<DynamicIcon name="Moon" size={13} />{:else}<DynamicIcon name="Sun" size={13} />{/if}
-              <span>Tema</span>
+              {#if $darkMode}<DynamicIcon name="Moon" size={13} />{:else}<DynamicIcon
+                  name="Sun"
+                  size={13}
+                />{/if}
+              <span>{$t('settings.theme')}</span>
             </div>
             <button class="toggle" onclick={toggleTheme}>
-              <span class:active={$darkMode}>oscuro</span>
+              <span class:active={$darkMode}>{$t('settings.dark')}</span>
               <span class="divider">|</span>
-              <span class:active={!$darkMode}>claro</span>
+              <span class:active={!$darkMode}>{$t('settings.light')}</span>
             </button>
           </div>
 
           <div class="row" style="flex-direction: column; align-items: stretch; gap: 8px;">
             <div class="row-label">
               <DynamicIcon name="Sparkles" size={13} />
-              <span>Modo de tema</span>
+              <span>{$t('settings.themeMode')}</span>
             </div>
             <div class="theme-mode-options">
               <label class="theme-mode-option" class:active={$themeMode === 'light'}>
-                <input type="radio" name="theme-mode" value="light" checked={$themeMode === 'light'} onchange={() => themeMode.set('light')} />
-                <span>Claro</span>
+                <input
+                  type="radio"
+                  name="theme-mode"
+                  value="light"
+                  checked={$themeMode === 'light'}
+                  onchange={() => themeMode.set('light')}
+                />
+                <span>{$t('settings.themeLight')}</span>
               </label>
               <label class="theme-mode-option" class:active={$themeMode === 'dark'}>
-                <input type="radio" name="theme-mode" value="dark" checked={$themeMode === 'dark'} onchange={() => themeMode.set('dark')} />
-                <span>Oscuro</span>
+                <input
+                  type="radio"
+                  name="theme-mode"
+                  value="dark"
+                  checked={$themeMode === 'dark'}
+                  onchange={() => themeMode.set('dark')}
+                />
+                <span>{$t('settings.themeDark')}</span>
               </label>
               <label class="theme-mode-option" class:active={$themeMode === 'auto'}>
-                <input type="radio" name="theme-mode" value="auto" checked={$themeMode === 'auto'} onchange={() => themeMode.set('auto')} />
-                <span>Automático</span>
+                <input
+                  type="radio"
+                  name="theme-mode"
+                  value="auto"
+                  checked={$themeMode === 'auto'}
+                  onchange={() => themeMode.set('auto')}
+                />
+                <span>{$t('settings.themeAuto')}</span>
               </label>
             </div>
             {#if $themeMode === 'auto'}
-              <p class="hint" style="margin-top: 2px;">El tema cambiará según la hora del día y la estación</p>
+              <p class="hint" style="margin-top: 2px;">{$t('settings.themeAutoHint')}</p>
             {/if}
           </div>
 
           <div class="row">
             <div class="row-label">
               <DynamicIcon name="Clock3" size={13} />
-              <span>Formato de hora</span>
+              <span>{$t('settings.timeFormat')}</span>
             </div>
             <button class="toggle" onclick={() => use24HourClock.toggle()}>
               <span class:active={$use24HourClock}>24h</span>
               <span class="sep">/</span>
               <span class:active={!$use24HourClock}>12h</span>
             </button>
+          </div>
+
+          <!-- Language selector (#370) -->
+          <div class="row" style="flex-direction: column; align-items: stretch; gap: 8px;">
+            <div class="row-label">
+              <DynamicIcon name="Languages" size={13} />
+              <span>{$t('settings.language')}</span>
+            </div>
+            <select class="setting-input mono" value={currentLocale} onchange={onLocaleChange}>
+              {#each LANGUAGE_OPTIONS as lang}
+                <option value={lang.value}>{lang.label}</option>
+              {/each}
+            </select>
+            <p class="hint" style="margin-top: 2px;">{$t('settings.languageHint')}</p>
           </div>
 
           <!-- Gradient preview bar -->
@@ -472,7 +555,12 @@
                   placeholder="#c8a96e"
                 />
                 {#if $accentColors.length > 1}
-                  <button class="color-rm" onclick={() => accentColors.removeColor(i)} title="Quitar" aria-label="Quitar">
+                  <button
+                    class="color-rm"
+                    onclick={() => accentColors.removeColor(i)}
+                    title="Quitar"
+                    aria-label="Quitar"
+                  >
                     <DynamicIcon name="Minus" size={10} />
                   </button>
                 {/if}
@@ -487,16 +575,21 @@
           {/if}
 
           <!-- Icon Packs Selector -->
-          <div class="row" style="margin-top: 16px; flex-direction: column; align-items: stretch; gap: 8px;">
+          <div
+            class="row"
+            style="margin-top: 16px; flex-direction: column; align-items: stretch; gap: 8px;"
+          >
             <div class="row-label"><span>Set de Iconos (Alternativa Emojis)</span></div>
             <select class="setting-input mono" bind:value={$activeIconPack}>
               {#each ICON_PACKS as pack}
                 <option value={pack.value}>{pack.label}</option>
               {/each}
             </select>
-            <p class="hint" style="margin-top: 2px;">Los iconos cambiarán en los conectores y notas.</p>
+            <p class="hint" style="margin-top: 2px;">
+              Los iconos cambiarán en los conectores y notas.
+            </p>
           </div>
-</section>
+        </section>
 
         <!-- Avanzado -->
         <section class="section">
@@ -563,9 +656,18 @@
               <span>Directorio del Vault</span>
               {#if isConfigured('obsidian_vault_path')}<span class="configured-badge">✓</span>{/if}
             </div>
-            <div style="display: flex; align-items: center; gap: 2px; padding: 0 10px; background: var(--elevated); border: 1px solid var(--border); border-radius: var(--r);" class="input-wrapper">
+            <div
+              style="display: flex; align-items: center; gap: 2px; padding: 0 10px; background: var(--elevated); border: 1px solid var(--border); border-radius: var(--r);"
+              class="input-wrapper"
+            >
               <span class="mono" style="color: var(--text-disabled); font-size: 11px;">~</span>
-              <input type="text" class="setting-input mono" style="border: none; background: transparent; flex: 1; padding-left: 2px;" placeholder="/Documentos/ObsidianVault" bind:value={systemConfig.obsidian_vault_path} />
+              <input
+                type="text"
+                class="setting-input mono"
+                style="border: none; background: transparent; flex: 1; padding-left: 2px;"
+                placeholder="/Documentos/ObsidianVault"
+                bind:value={systemConfig.obsidian_vault_path}
+              />
             </div>
           </div>
           <div class="row" style="flex-direction: column; align-items: stretch; gap: 8px;">
@@ -573,9 +675,18 @@
               <span>Carpeta de notas diarias</span>
               {#if isConfigured('daily_notes_folder')}<span class="configured-badge">✓</span>{/if}
             </div>
-            <div style="display: flex; align-items: center; gap: 2px; padding: 0 10px; background: var(--elevated); border: 1px solid var(--border); border-radius: var(--r);" class="input-wrapper">
+            <div
+              style="display: flex; align-items: center; gap: 2px; padding: 0 10px; background: var(--elevated); border: 1px solid var(--border); border-radius: var(--r);"
+              class="input-wrapper"
+            >
               <span class="mono" style="color: var(--text-disabled); font-size: 11px;">~</span>
-              <input type="text" class="setting-input mono" style="border: none; background: transparent; flex: 1; padding-left: 2px;" placeholder="Ejemplo/Daily" bind:value={systemConfig.daily_notes_folder} />
+              <input
+                type="text"
+                class="setting-input mono"
+                style="border: none; background: transparent; flex: 1; padding-left: 2px;"
+                placeholder="Ejemplo/Daily"
+                bind:value={systemConfig.daily_notes_folder}
+              />
             </div>
           </div>
           <div class="row">
@@ -598,7 +709,7 @@
           </p>
         </section>
 
-                <!-- Integraciones -->
+        <!-- Integraciones -->
         <section class="section">
           <div class="section-title" style="color: var(--xp, var(--accent));">
             <DynamicIcon name="GitBranch" size={12} /> Integraciones
@@ -619,15 +730,22 @@
             {:else if githubConnected}
               <div style="display:flex; align-items:center; gap:8px;">
                 <span class="mono" style="font-size:12px; color: var(--xp);">{githubUsername}</span>
-                <button class="link-btn" onclick={disconnectGithub} style="background:var(--border); color:var(--text-secondary);">Desconectar</button>
+                <button
+                  class="link-btn"
+                  onclick={disconnectGithub}
+                  style="background:var(--border); color:var(--text-secondary);">Desconectar</button
+                >
               </div>
             {:else}
-              <button class="link-btn" onclick={startGithubAuth} disabled={githubAuthLoading}>Enlazar</button>
+              <button class="link-btn" onclick={startGithubAuth} disabled={githubAuthLoading}
+                >Enlazar</button
+              >
             {/if}
           </div>
           {#if githubAuthLoading && githubUserCode}
             <p class="hint">
-              Abre <a href={githubVerificationUri} target="_blank">{githubVerificationUri}</a> e introduce el código <code>{githubUserCode}</code> para autorizar a Joidy.
+              Abre <a href={githubVerificationUri} target="_blank">{githubVerificationUri}</a> e
+              introduce el código <code>{githubUserCode}</code> para autorizar a Joidy.
               {#if githubAuthError}
                 <br /><span style="color:var(--danger)">{githubAuthError}</span>
               {/if}
@@ -666,12 +784,19 @@
           <div class="row">
             <div class="row-label">
               <span>Google Calendar & Tasks</span>
-              {#if googleConnected}<span class="badge badge-on" style="margin-left:4px">Conectado</span>{/if}
+              {#if googleConnected}<span class="badge badge-on" style="margin-left:4px"
+                  >Conectado</span
+                >{/if}
             </div>
             {#if googleConnecting}
-              <span class="mono" style="font-size:12px; color: var(--text-muted);">Conectando…</span>
+              <span class="mono" style="font-size:12px; color: var(--text-muted);">Conectando…</span
+              >
             {:else if googleConnected}
-              <button class="link-btn" onclick={disconnectGoogle} style="background:var(--border); color:var(--text-secondary);">Desconectar</button>
+              <button
+                class="link-btn"
+                onclick={disconnectGoogle}
+                style="background:var(--border); color:var(--text-secondary);">Desconectar</button
+              >
             {:else}
               <button class="link-btn" onclick={startGoogleAuth}>Enlazar</button>
             {/if}
@@ -692,11 +817,14 @@
               {#if isConfigured('gemini_api_key')}<span class="configured-badge">✓</span>{/if}
               <span class="badge badge-off" style="margin-left:auto">En desarrollo (#41)</span>
             </div>
-            <input type="password" class="setting-input mono" placeholder="AIzaSy..." bind:value={systemConfig.gemini_api_key} />
+            <input
+              type="password"
+              class="setting-input mono"
+              placeholder="AIzaSy..."
+              bind:value={systemConfig.gemini_api_key}
+            />
           </div>
-          <p class="hint">
-            Habilita auto-tagging y búsqueda semántica.
-          </p>
+          <p class="hint">Habilita auto-tagging y búsqueda semántica.</p>
         </section>
 
         <!-- Aplicación (PWA) -->
@@ -706,15 +834,21 @@
               <DynamicIcon name="DownloadCloud" size={12} /> Aplicación
             </div>
             <div class="row" style="flex-direction: column; align-items: stretch; gap: 8px;">
-              <p class="hint" style="margin-top: 0;">Instala Joidy en tu dispositivo para acceso rápido y sin conexión.</p>
-              <button class="save-config-btn" style="background: var(--xp);" onclick={async () => {
-                $deferredPrompt.prompt();
-                const { outcome } = await $deferredPrompt.userChoice;
-                if (outcome === 'accepted') {
-                  showInstallBanner.set(false);
-                }
-                deferredPrompt.set(null);
-              }}>
+              <p class="hint" style="margin-top: 0;">
+                Instala Joidy en tu dispositivo para acceso rápido y sin conexión.
+              </p>
+              <button
+                class="save-config-btn"
+                style="background: var(--xp);"
+                onclick={async () => {
+                  $deferredPrompt.prompt();
+                  const { outcome } = await $deferredPrompt.userChoice;
+                  if (outcome === 'accepted') {
+                    showInstallBanner.set(false);
+                  }
+                  deferredPrompt.set(null);
+                }}
+              >
                 <DynamicIcon name="Download" size={12} /> Instalar Joidy
               </button>
             </div>
@@ -725,7 +859,13 @@
         <section class="section">
           <div class="row">
             <div class="row-label"><span>Repositorio</span></div>
-            <a href="https://github.com/Axel-DaMage/joidy" target="_blank" rel="noopener" class="mono" style="font-size:11px; color: var(--text-secondary);">github.com/Axel-DaMage/joidy</a>
+            <a
+              href="https://github.com/Axel-DaMage/joidy"
+              target="_blank"
+              rel="noopener"
+              class="mono"
+              style="font-size:11px; color: var(--text-secondary);">github.com/Axel-DaMage/joidy</a
+            >
           </div>
         </section>
 
@@ -735,28 +875,28 @@
             <DynamicIcon name="Download" size={12} /> Exportar Datos
           </div>
           <div style="display: flex; flex-direction: column; gap: 8px; margin-top: 10px;">
-            <a 
-              href={api.export.markdownUrl()} 
-              download 
-              class="save-config-btn" 
+            <a
+              href={api.export.markdownUrl()}
+              download
+              class="save-config-btn"
               style="display: flex; align-items: center; justify-content: center; gap: 8px; text-decoration: none; text-align: center; height: 32px; background: var(--elevated); border: 1px solid var(--border); color: var(--text-primary); font-size: 11px;"
             >
               <DynamicIcon name="FileText" size={12} /> Descargar Markdown Único
             </a>
-            
-            <a 
-              href={api.export.htmlUrl()} 
-              download 
-              class="save-config-btn" 
+
+            <a
+              href={api.export.htmlUrl()}
+              download
+              class="save-config-btn"
               style="display: flex; align-items: center; justify-content: center; gap: 8px; text-decoration: none; text-align: center; height: 32px; background: var(--elevated); border: 1px solid var(--border); color: var(--text-primary); font-size: 11px;"
             >
               <DynamicIcon name="Code" size={12} /> Descargar HTML Único
             </a>
-            
-            <a 
-              href={api.export.zipUrl()} 
-              download 
-              class="save-config-btn" 
+
+            <a
+              href={api.export.zipUrl()}
+              download
+              class="save-config-btn"
               style="display: flex; align-items: center; justify-content: center; gap: 8px; text-decoration: none; text-align: center; height: 32px; background: var(--elevated); border: 1px solid var(--border); color: var(--text-primary); font-size: 11px;"
             >
               <DynamicIcon name="FolderArchive" size={12} /> Descargar Todas en ZIP
@@ -783,23 +923,16 @@
               <span class:active={$devMode}>on</span>
             </button>
           </div>
-          <p class="hint">
-            Activa para mostrar páginas en desarrollo y contenido avanzado.
-          </p>
+          <p class="hint">Activa para mostrar páginas en desarrollo y contenido avanzado.</p>
         </section>
-
       </div>
 
       <div class="panel-footer">
-        <button
-          class="save-config-btn fixed-save"
-          onclick={saveConfig}
-          disabled={configSaving}
-        >
+        <button class="save-config-btn fixed-save" onclick={saveConfig} disabled={configSaving}>
           {#if configSaving}
-            Guardando...
+            {$t('common.saving')}
           {:else}
-            <DynamicIcon name="Save" size={12} /> Guardar
+            <DynamicIcon name="Save" size={12} /> {$t('common.save')}
           {/if}
         </button>
         {#if configMessage}
@@ -832,8 +965,14 @@
   }
 
   @keyframes slideIn {
-    from { transform: translateX(100%); opacity: 0; }
-    to   { transform: translateX(0);    opacity: 1; }
+    from {
+      transform: translateX(100%);
+      opacity: 0;
+    }
+    to {
+      transform: translateX(0);
+      opacity: 1;
+    }
   }
 
   .panel-header {
@@ -856,7 +995,9 @@
     border-radius: var(--r);
     transition: color var(--t-fast);
   }
-  .close-btn:hover { color: var(--text-primary); }
+  .close-btn:hover {
+    color: var(--text-primary);
+  }
 
   .panel-body {
     flex: 1;
@@ -948,9 +1089,16 @@
     white-space: nowrap;
     transition: border-color var(--t-fast);
   }
-  .toggle:hover { border-color: var(--text-muted); }
-  .toggle .active { color: var(--text-primary); }
-  .toggle .sep, .toggle .divider { color: var(--border); }
+  .toggle:hover {
+    border-color: var(--text-muted);
+  }
+  .toggle .active {
+    color: var(--text-primary);
+  }
+  .toggle .sep,
+  .toggle .divider {
+    color: var(--border);
+  }
 
   .link-btn {
     background: var(--accent);
@@ -962,14 +1110,18 @@
     cursor: pointer;
     font-family: var(--font-mono);
   }
-  .link-btn:hover { opacity: 0.9; }
+  .link-btn:hover {
+    opacity: 0.9;
+  }
 
   .link-btn.disabled {
     background: var(--border);
     color: var(--text-muted);
     cursor: not-allowed;
   }
-  .link-btn.disabled:hover { opacity: 0.6; }
+  .link-btn.disabled:hover {
+    opacity: 0.6;
+  }
 
   .row-label.disabled {
     color: var(--text-muted);
@@ -1094,7 +1246,9 @@
     outline: none;
     transition: border-color var(--t-fast);
   }
-  .hex-input:focus { border-color: var(--text-muted); }
+  .hex-input:focus {
+    border-color: var(--text-muted);
+  }
 
   .setting-input {
     background: var(--elevated);
@@ -1107,8 +1261,10 @@
     transition: border-color var(--t-fast);
     width: 100%;
   }
-  .setting-input:focus { outline: none; }
-  
+  .setting-input:focus {
+    outline: none;
+  }
+
   .input-wrapper:focus-within {
     border-color: var(--text-muted);
   }
@@ -1125,9 +1281,14 @@
     color: var(--text-muted);
     cursor: pointer;
     flex-shrink: 0;
-    transition: color var(--t-fast), border-color var(--t-fast);
+    transition:
+      color var(--t-fast),
+      border-color var(--t-fast);
   }
-  .color-rm:hover { color: var(--error); border-color: var(--error); }
+  .color-rm:hover {
+    color: var(--error);
+    border-color: var(--error);
+  }
 
   .add-color-btn {
     display: flex;
@@ -1143,9 +1304,14 @@
     cursor: pointer;
     width: 100%;
     justify-content: center;
-    transition: color var(--t-fast), border-color var(--t-fast);
+    transition:
+      color var(--t-fast),
+      border-color var(--t-fast);
   }
-  .add-color-btn:hover { color: var(--text-secondary); border-color: var(--text-muted); }
+  .add-color-btn:hover {
+    color: var(--text-secondary);
+    border-color: var(--text-muted);
+  }
   .add-color-btn:focus-visible {
     outline: none;
     border-color: var(--xp);
@@ -1174,8 +1340,13 @@
     cursor: pointer;
     transition: opacity var(--t-fast);
   }
-  .save-config-btn:hover:not(:disabled) { opacity: 0.9; }
-  .save-config-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .save-config-btn:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+  .save-config-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 
   .config-message {
     font-size: 11px;
@@ -1203,9 +1374,21 @@
     font-family: var(--font-mono);
     color: var(--text-muted);
     cursor: pointer;
-    transition: border-color var(--t-fast), color var(--t-fast);
+    transition:
+      border-color var(--t-fast),
+      color var(--t-fast);
   }
-  .theme-mode-option:hover { border-color: var(--text-muted); }
-  .theme-mode-option.active { border-color: var(--xp); color: var(--text-primary); }
-  .theme-mode-option input { position: absolute; opacity: 0; width: 0; height: 0; }
+  .theme-mode-option:hover {
+    border-color: var(--text-muted);
+  }
+  .theme-mode-option.active {
+    border-color: var(--xp);
+    color: var(--text-primary);
+  }
+  .theme-mode-option input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
 </style>

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -1,0 +1,51 @@
+import { init, addMessages, locale as svelteI18nLocale } from 'svelte-i18n';
+import { get } from 'svelte/store';
+import { locale as localeStore } from '$lib/stores/locale';
+import esCommon from '../locales/es/common.json';
+import enCommon from '../locales/en/common.json';
+
+export const SUPPORTED_LOCALES = ['es', 'en'] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+export const DEFAULT_LOCALE: SupportedLocale = 'es';
+
+/**
+ * Map a full BCP-47 locale (e.g. "es-CL", "en-US") to one of the supported
+ * svelte-i18n locale keys. Falls back to {@link DEFAULT_LOCALE} when no match.
+ */
+export function mapToSupportedLocale(raw: string): SupportedLocale {
+  const base = raw.toLowerCase().split('-')[0];
+  if (SUPPORTED_LOCALES.includes(base as SupportedLocale)) {
+    return base as SupportedLocale;
+  }
+  return DEFAULT_LOCALE;
+}
+
+let initialized = false;
+
+/**
+ * Initialize svelte-i18n with the bundled locale messages and sync it with the
+ * existing `stores/locale` store (which handles detection + persistence).
+ *
+ * Must be called once at app start (e.g. from the root layout). Subsequent
+ * calls are no-ops. Changing the locale via `setLocale()` from `stores/locale`
+ * automatically propagates to svelte-i18n through the subscription set up here.
+ */
+export function initI18n(): void {
+  if (initialized) return;
+  initialized = true;
+
+  addMessages('es', esCommon);
+  addMessages('en', enCommon);
+
+  init({
+    fallbackLocale: DEFAULT_LOCALE,
+    initialLocale: mapToSupportedLocale(get(localeStore)),
+  });
+
+  // Keep svelte-i18n's locale in sync with the app locale store. The store
+  // holds the full BCP-47 tag (e.g. "es-CL") for Intl date/time formatting,
+  // while svelte-i18n only needs the base language key ("es").
+  localeStore.subscribe((fullLocale) => {
+    svelteI18nLocale.set(mapToSupportedLocale(fullLocale));
+  });
+}

--- a/frontend/src/lib/stores/onboarding.ts
+++ b/frontend/src/lib/stores/onboarding.ts
@@ -6,8 +6,9 @@ const ONBOARDING_KEY = 'joidy-onboarding-complete';
 
 export interface OnboardingStep {
   id: string;
-  title: string;
-  content: string;
+  /** i18n key prefix, e.g. "onboarding.welcome" — title/content resolved via $t(). */
+  titleKey: string;
+  contentKey: string;
   /** CSS selector for the element to spotlight. null = centered (no target). */
   target: string | null;
 }
@@ -15,44 +16,38 @@ export interface OnboardingStep {
 export const ONBOARDING_STEPS: OnboardingStep[] = [
   {
     id: 'welcome',
-    title: 'Bienvenida a Joidy',
-    content:
-      'Tu sistema personal de gestión del conocimiento con gamificación. Aquí tomarás notas, establecerás metas y harás crecer una planta mientras mantienes rachas diarias.',
+    titleKey: 'onboarding.welcome.title',
+    contentKey: 'onboarding.welcome.content',
     target: null,
   },
   {
     id: 'notes',
-    title: 'Crea tu primera nota',
-    content:
-      'En la página de Notas puedes crear y organizar tu conocimiento. Cada nota admite etiquetas, iconos y colores, y se sincroniza con tu bóveda de Obsidian.',
+    titleKey: 'onboarding.notes.title',
+    contentKey: 'onboarding.notes.content',
     target: 'a.nav-item[href="/notes"]',
   },
   {
     id: 'tags',
-    title: 'Tags y grafo',
-    content:
-      'Etiqueta tus notas para conectarlas. El Grafo visualiza cómo se relacionan tus notas a través de los tags, revelando patrones y temas en tu conocimiento.',
+    titleKey: 'onboarding.tags.title',
+    contentKey: 'onboarding.tags.content',
     target: 'a.nav-item[href="/graph"]',
   },
   {
     id: 'goals',
-    title: 'Tu primera meta',
-    content:
-      'Establece metas con temporalidades (diaria, semanal, mensual o anual). Completar metas te da XP y alimenta tu progreso. Empieza con algo pequeño y alcanzable.',
+    titleKey: 'onboarding.goals.title',
+    contentKey: 'onboarding.goals.content',
     target: 'a.nav-item[href="/goals"]',
   },
   {
     id: 'streaks',
-    title: 'Rachas y planta',
-    content:
-      'Mantén una racha diaria de actividad. Cada día que interactúas con Joidy ganas XP y tu planta crece: de semilla a árbol. ¡No rompas la cadena!',
+    titleKey: 'onboarding.streaks.title',
+    contentKey: 'onboarding.streaks.content',
     target: 'a.nav-item[href="/streaks"]',
   },
   {
     id: 'obsidian',
-    title: 'Conecta Obsidian (opcional)',
-    content:
-      'Joidy se sincroniza con tu bóveda de Obsidian para mantener tus notas en formato Markdown. Puedes configurarlo ahora desde Ajustes, o saltar este paso y hacerlo más tarde.',
+    titleKey: 'onboarding.obsidian.title',
+    contentKey: 'onboarding.obsidian.content',
     target: null,
   },
 ];
@@ -114,11 +109,11 @@ function createOnboardingStore() {
       }
     },
     startTour() {
-      update(state => ({ ...state, currentStep: 0, active: true }));
+      update((state) => ({ ...state, currentStep: 0, active: true }));
       if (browser) localStorage.removeItem(ONBOARDING_KEY);
     },
     nextStep() {
-      update(state => {
+      update((state) => {
         const next = state.currentStep + 1;
         if (next >= ONBOARDING_STEPS.length) {
           markCompleted();
@@ -128,7 +123,7 @@ function createOnboardingStore() {
       });
     },
     prevStep() {
-      update(state => ({ ...state, currentStep: Math.max(0, state.currentStep - 1) }));
+      update((state) => ({ ...state, currentStep: Math.max(0, state.currentStep - 1) }));
     },
     skipTour() {
       markCompleted();
@@ -144,7 +139,7 @@ function createOnboardingStore() {
       set({ completed: true, currentStep: 0, active: false });
     },
     close() {
-      update(state => ({ ...state, active: false }));
+      update((state) => ({ ...state, active: false }));
     },
   };
 }

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -1,0 +1,85 @@
+{
+  "nav": {
+    "home": "Home",
+    "notes": "Notes",
+    "graph": "Graph",
+    "skills": "Skills",
+    "ai": "AI",
+    "goals": "Goals",
+    "streaks": "Streaks"
+  },
+  "common": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "search": "Search",
+    "close": "Close",
+    "settings": "Settings",
+    "install": "Install",
+    "skip": "Skip",
+    "previous": "Previous",
+    "next": "Next",
+    "start": "Start",
+    "saving": "Saving...",
+    "tasks": "tasks",
+    "level": "LVL"
+  },
+  "status": {
+    "offline": "Offline",
+    "online": "Online",
+    "pendingStreaks": "Pending streaks",
+    "requiresDevMode": "Requires Dev Mode"
+  },
+  "pwa": {
+    "installPrompt": "Install Joidy for quick access",
+    "closeInstallNotice": "Close install notice",
+    "installed": "Joidy installed! You can now access it from your desktop."
+  },
+  "onboarding": {
+    "skipTour": "Skip welcome tour",
+    "stepIndicator": "Step {current} of {total}",
+    "previousStep": "Previous step",
+    "nextStep": "Next step",
+    "skipForNow": "Skip for now",
+    "configureObsidian": "Configure Obsidian",
+    "welcome": {
+      "title": "Welcome to Joidy",
+      "content": "Your personal knowledge management system with gamification. Here you'll take notes, set goals, and grow a plant while keeping daily streaks."
+    },
+    "notes": {
+      "title": "Create your first note",
+      "content": "On the Notes page you can create and organize your knowledge. Each note supports tags, icons, and colors, and syncs with your Obsidian vault."
+    },
+    "tags": {
+      "title": "Tags and graph",
+      "content": "Tag your notes to connect them. The Graph visualizes how your notes relate through tags, revealing patterns and themes in your knowledge."
+    },
+    "goals": {
+      "title": "Your first goal",
+      "content": "Set goals with timeframes (daily, weekly, monthly, or yearly). Completing goals gives you XP and fuels your progress. Start with something small and achievable."
+    },
+    "streaks": {
+      "title": "Streaks and plant",
+      "content": "Keep a daily activity streak. Every day you interact with Joidy you earn XP and your plant grows: from seed to tree. Don't break the chain!"
+    },
+    "obsidian": {
+      "title": "Connect Obsidian (optional)",
+      "content": "Joidy syncs with your Obsidian vault to keep your notes in Markdown format. You can set it up now from Settings, or skip this step and do it later."
+    }
+  },
+  "settings": {
+    "title": "SETTINGS",
+    "appearance": "Appearance",
+    "theme": "Theme",
+    "dark": "dark",
+    "light": "light",
+    "themeMode": "Theme mode",
+    "themeLight": "Light",
+    "themeDark": "Dark",
+    "themeAuto": "Automatic",
+    "themeAutoHint": "The theme will change based on the time of day and season",
+    "timeFormat": "Time format",
+    "language": "Language",
+    "languageHint": "The interface language"
+  }
+}

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -1,0 +1,85 @@
+{
+  "nav": {
+    "home": "Inicio",
+    "notes": "Notas",
+    "graph": "Grafo",
+    "skills": "Habilidades",
+    "ai": "IA",
+    "goals": "Objetivos",
+    "streaks": "Rachas"
+  },
+  "common": {
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "delete": "Eliminar",
+    "search": "Buscar",
+    "close": "Cerrar",
+    "settings": "Ajustes",
+    "install": "Instalar",
+    "skip": "Saltar",
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "start": "Comenzar",
+    "saving": "Guardando...",
+    "tasks": "tareas",
+    "level": "NVL"
+  },
+  "status": {
+    "offline": "Sin conexión",
+    "online": "Conectado",
+    "pendingStreaks": "Rachas pendientes",
+    "requiresDevMode": "Requiere Dev Mode"
+  },
+  "pwa": {
+    "installPrompt": "Instala Joidy para acceso rápido",
+    "closeInstallNotice": "Cerrar aviso de instalación",
+    "installed": "¡Joidy instalado! Ahora puedes acceder desde tu escritorio."
+  },
+  "onboarding": {
+    "skipTour": "Saltar tour de bienvenida",
+    "stepIndicator": "Paso {current} de {total}",
+    "previousStep": "Paso anterior",
+    "nextStep": "Siguiente paso",
+    "skipForNow": "Saltar por ahora",
+    "configureObsidian": "Configurar Obsidian",
+    "welcome": {
+      "title": "Bienvenida a Joidy",
+      "content": "Tu sistema personal de gestión del conocimiento con gamificación. Aquí tomarás notas, establecerás metas y harás crecer una planta mientras mantienes rachas diarias."
+    },
+    "notes": {
+      "title": "Crea tu primera nota",
+      "content": "En la página de Notas puedes crear y organizar tu conocimiento. Cada nota admite etiquetas, iconos y colores, y se sincroniza con tu bóveda de Obsidian."
+    },
+    "tags": {
+      "title": "Tags y grafo",
+      "content": "Etiqueta tus notas para conectarlas. El Grafo visualiza cómo se relacionan tus notas a través de los tags, revelando patrones y temas en tu conocimiento."
+    },
+    "goals": {
+      "title": "Tu primera meta",
+      "content": "Establece metas con temporalidades (diaria, semanal, mensual o anual). Completar metas te da XP y alimenta tu progreso. Empieza con algo pequeño y alcanzable."
+    },
+    "streaks": {
+      "title": "Rachas y planta",
+      "content": "Mantén una racha diaria de actividad. Cada día que interactúas con Joidy ganas XP y tu planta crece: de semilla a árbol. ¡No rompas la cadena!"
+    },
+    "obsidian": {
+      "title": "Conecta Obsidian (opcional)",
+      "content": "Joidy se sincroniza con tu bóveda de Obsidian para mantener tus notas en formato Markdown. Puedes configurarlo ahora desde Ajustes, o saltar este paso y hacerlo más tarde."
+    }
+  },
+  "settings": {
+    "title": "AJUSTES",
+    "appearance": "Apariencia",
+    "theme": "Tema",
+    "dark": "oscuro",
+    "light": "claro",
+    "themeMode": "Modo de tema",
+    "themeLight": "Claro",
+    "themeDark": "Oscuro",
+    "themeAuto": "Automático",
+    "themeAutoHint": "El tema cambiará según la hora del día y la estación",
+    "timeFormat": "Formato de hora",
+    "language": "Idioma",
+    "languageHint": "El idioma de la interfaz"
+  }
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -14,16 +14,32 @@
   import SetupWizard from '$lib/components/SetupWizard.svelte';
   import { api, type Goal, type PersonalStreak } from '$lib/api';
   import { session, isAuthenticated, getToken } from '$lib/stores/session';
-  import { totalXP, loadStats, pingActivity, globalLevel, nextStageXP, showNotification } from '$lib/stores/gamification';
+  import {
+    totalXP,
+    loadStats,
+    pingActivity,
+    globalLevel,
+    nextStageXP,
+    showNotification,
+  } from '$lib/stores/gamification';
   import { running, secondsLeft, phase } from '$lib/stores/pomodoro';
   import { initPomodoroSettings } from '$lib/stores/pomodoro';
-  import { accentColors, activeIconPack, use24HourClock, initTheme, devMode, themeMode } from '$lib/stores/settings';
+  import {
+    accentColors,
+    activeIconPack,
+    use24HourClock,
+    initTheme,
+    devMode,
+    themeMode,
+  } from '$lib/stores/settings';
   import { getCachedData, setCachedData } from '$lib/utils/userSettings';
   import { initKeyboardNavigation } from '$lib/utils/keyboardNavigation';
   import { initPushNotifications } from '$lib/push';
   import { logger } from '$lib/utils/logger';
   import { onboarding } from '$lib/stores/onboarding';
   import { locale as localeStore } from '$lib/stores/locale';
+  import { initI18n } from '$lib/i18n';
+  import { t } from 'svelte-i18n';
   import OnboardingTour from '$lib/components/OnboardingTour.svelte';
   import { achievements } from '$lib/stores/achievements';
   import { initConnectionStore } from '$lib/stores/connection';
@@ -39,15 +55,19 @@
 
   type NavItemStatus = 'ready' | 'dev' | 'placeholder';
 
-  const navItems: { href: string; label: string; icon: string; status: NavItemStatus }[] = [
-    { href: '/',        label: 'Inicio',      icon: 'Home',     status: 'ready' },
-    { href: '/notes',   label: 'Notas',       icon: 'BookOpen', status: 'ready' },
-    { href: '/graph',   label: 'Grafo',       icon: 'Network',  status: 'dev' },
-    { href: '/skills',  label: 'Habilidades', icon: 'Zap',      status: 'dev' },
-    { href: '/ai',      label: 'IA',          icon: 'Brain',    status: 'ready' },
-    { href: '/goals',   label: 'Objetivos',   icon: 'Target',   status: 'ready' },
-    { href: '/streaks', label: 'Rachas',      icon: 'Flame',    status: 'ready' },
-  ];
+  // Initialize i18n once — syncs svelte-i18n with the locale store (#370).
+  initI18n();
+
+  // Reactive so labels re-render when the locale changes.
+  $: navItems = [
+    { href: '/', label: $t('nav.home'), icon: 'Home', status: 'ready' },
+    { href: '/notes', label: $t('nav.notes'), icon: 'BookOpen', status: 'ready' },
+    { href: '/graph', label: $t('nav.graph'), icon: 'Network', status: 'dev' },
+    { href: '/skills', label: $t('nav.skills'), icon: 'Zap', status: 'dev' },
+    { href: '/ai', label: $t('nav.ai'), icon: 'Brain', status: 'ready' },
+    { href: '/goals', label: $t('nav.goals'), icon: 'Target', status: 'ready' },
+    { href: '/streaks', label: $t('nav.streaks'), icon: 'Flame', status: 'ready' },
+  ] as { href: string; label: string; icon: string; status: NavItemStatus }[];
 
   let settingsOpen = false;
   let now = new Date();
@@ -67,7 +87,7 @@
   $: currentDate = now.toLocaleDateString($localeStore, {
     weekday: 'short',
     day: '2-digit',
-    month: 'short'
+    month: 'short',
   });
 
   let mounted = false;
@@ -76,14 +96,15 @@
 
   onMount(() => {
     mounted = true;
-    
+
     // Check setup status
-    api.config.setupStatus()
-      .then(res => {
+    api.config
+      .setupStatus()
+      .then((res) => {
         needsSetup = res.needs_setup;
         checkingSetup = false;
       })
-      .catch(err => {
+      .catch((err) => {
         logger.error('Failed to check setup status:', err);
         checkingSetup = false;
       });
@@ -104,9 +125,12 @@
 
     // First-use detection: start the onboarding tour for brand-new users.
     if ($isAuthenticated) {
-      onboarding.shouldShowOnboarding().then((show: boolean) => {
-        if (show) onboarding.startTour();
-      }).catch((e: unknown) => logger.warn('[layout] onboarding detection failed:', e));
+      onboarding
+        .shouldShowOnboarding()
+        .then((show: boolean) => {
+          if (show) onboarding.startTour();
+        })
+        .catch((e: unknown) => logger.warn('[layout] onboarding detection failed:', e));
     }
 
     // Connect to WebSocket for real-time notifications
@@ -126,7 +150,7 @@
         logger.info('[layout] Tab hidden, skipping WebSocket reconnect');
         return;
       }
-      
+
       const host = window.location.hostname;
       const wsProto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
       // Derive the WebSocket URL from VITE_API_URL (which already reflects the
@@ -156,7 +180,7 @@
         try {
           const msg = JSON.parse(event.data);
           logger.info('[layout] WebSocket message received:', msg);
-          
+
           if (msg.type === 'note_created') {
             queueNotificationIfActive(`Nueva nota creada: "${msg.title}"`, 'success');
             loadNotes(undefined, true).catch(() => {});
@@ -205,7 +229,7 @@
     }
 
     const handleAppInstalled = () => {
-      showNotification("¡Joidy instalado! Ahora puedes acceder desde tu escritorio.", "success");
+      showNotification('¡Joidy instalado! Ahora puedes acceder desde tu escritorio.', 'success');
     };
     window.addEventListener('appinstalled', handleAppInstalled);
 
@@ -222,9 +246,11 @@
         pendingTasks = cachedGoals.filter((goal: Goal) => !goal.is_completed).length;
       }
       if (cachedStreaks) {
-        pendingStreaks = cachedStreaks.filter((streak: PersonalStreak) => !streak.today_checked && !streak.is_archived).length;
+        pendingStreaks = cachedStreaks.filter(
+          (streak: PersonalStreak) => !streak.today_checked && !streak.is_archived
+        ).length;
       }
-      
+
       try {
         const goals = await api.goals.list();
         pendingTasks = goals.filter((goal) => !goal.is_completed).length;
@@ -235,10 +261,12 @@
 
       try {
         const streaks = await api.personalStreaks.list({ include_archived: false });
-        const newPendingStreaks = streaks.filter((streak) => !streak.today_checked && !streak.is_archived).length;
+        const newPendingStreaks = streaks.filter(
+          (streak) => !streak.today_checked && !streak.is_archived
+        ).length;
         pendingStreaks = newPendingStreaks;
         setCachedData('streaks', streaks);
-        
+
         if (newPendingStreaks > 0 && !streaksNotified) {
           streaksNotified = true;
           showNotification(`Tienes ${newPendingStreaks} rachas pendientes hoy!`, 'info');
@@ -317,14 +345,18 @@
 
     const handleWindowFocus = () => {
       if (document.visibilityState === 'visible') {
-        loadFooterStats(true).catch((e) => logger.error('[layout] footer stats refresh failed:', e));
+        loadFooterStats(true).catch((e) =>
+          logger.error('[layout] footer stats refresh failed:', e)
+        );
       }
     };
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
         if (Date.now() - lastFooterStatsFetch > 60000) {
-          loadFooterStats(true).catch((e) => logger.error('[layout] footer stats refresh failed:', e));
+          loadFooterStats(true).catch((e) =>
+            logger.error('[layout] footer stats refresh failed:', e)
+          );
         }
         if (!ws || (ws.readyState !== WebSocket.OPEN && ws.readyState !== WebSocket.CONNECTING)) {
           if (wsReconnectTimeout) clearTimeout(wsReconnectTimeout);
@@ -429,129 +461,169 @@
   <Login />
   <Toast />
 {:else}
-<div class="app-shell">
-  <!-- Header -->
-  <header class="app-header">
-    <span class="logo mono">JOIDY</span>
-    
-    {#if $showInstallBanner}
-      <div class="pwa-banner" transition:fade={{ duration: 150 }}>
-        <DynamicIcon name="DownloadCloud" size={13} />
-        <span>Instala Joidy para acceso rápido</span>
-        <div class="pwa-actions">
-          <button class="pwa-btn pwa-install" onclick={async () => {
-            if ($deferredPrompt) {
-              $deferredPrompt.prompt();
-              const { outcome } = await $deferredPrompt.userChoice;
-              if (outcome === 'accepted') {
+  <div class="app-shell">
+    <!-- Header -->
+    <header class="app-header">
+      <span class="logo mono">JOIDY</span>
+
+      {#if $showInstallBanner}
+        <div class="pwa-banner" transition:fade={{ duration: 150 }}>
+          <DynamicIcon name="DownloadCloud" size={13} />
+          <span>{$t('pwa.installPrompt')}</span>
+          <div class="pwa-actions">
+            <button
+              class="pwa-btn pwa-install"
+              onclick={async () => {
+                if ($deferredPrompt) {
+                  $deferredPrompt.prompt();
+                  const { outcome } = await $deferredPrompt.userChoice;
+                  if (outcome === 'accepted') {
+                    showInstallBanner.set(false);
+                  }
+                  deferredPrompt.set(null);
+                }
+              }}>{$t('common.install')}</button
+            >
+            <button
+              class="pwa-btn pwa-dismiss"
+              aria-label={$t('pwa.closeInstallNotice')}
+              onclick={() => {
                 showInstallBanner.set(false);
-              }
-              deferredPrompt.set(null);
-            }
-          }}>Instalar</button>
-          <button class="pwa-btn pwa-dismiss" aria-label="Cerrar aviso de instalación" onclick={() => {
-            showInstallBanner.set(false);
-            localStorage.setItem('joidy-pwa-dismissed', 'true');
-          }}>
-            <DynamicIcon name="X" size={12} />
-          </button>
+                localStorage.setItem('joidy-pwa-dismissed', 'true');
+              }}
+            >
+              <DynamicIcon name="X" size={12} />
+            </button>
+          </div>
         </div>
-      </div>
-    {/if}
+      {/if}
 
-    <div style="flex:1;"></div>
+      <div style="flex:1;"></div>
 
-    <!-- Connectivity Indicator -->
-    {#if !$isOnline}
-      <div class="connectivity-pill offline" transition:fade={{ duration: 150 }}>
-        <span class="pulse-dot red"></span>
-        <span>Sin conexión</span>
-      </div>
-    {:else if showConnectedPill}
-      <div class="connectivity-pill online" transition:fade={{ duration: 150 }}>
-        <span class="pulse-dot green"></span>
-        <span>Conectado</span>
-      </div>
-    {/if}
-    <span class="mono" style="font-size:13px; color: var(--xp); display: flex; align-items: center; gap: 8px;">
-      <span>
-        {#if $nextStageXP}
-          {$totalXP.toLocaleString()}
-          <span style="font-size:10px; color: var(--text-muted);">/ {$nextStageXP.toLocaleString()} xp</span>
-        {:else}
-          <span style="font-size:12px; font-weight: 700;">MAX</span>
-        {/if}
-      </span>
-      <span style="font-size:11px; color: var(--text-primary); background: var(--surface); border: 1px solid var(--border); padding: 2px 6px; border-radius: 4px;">NVL {$globalLevel}</span>
-    </span>
-    <button
-      class="btn btn-ghost btn-icon"
-      title="Ajustes"
-      aria-label="Ajustes"
-      style="color: var(--text-muted);"
-      onclick={() => window.dispatchEvent(new CustomEvent('joidy:open-settings'))}
-    >
-      <DynamicIcon name="Settings" size={14} />
-    </button>
-  </header>
-
-  <!-- Sidebar -->
-  <nav class="app-sidebar">
-    {#each navItems as { href, label, icon, status }}
-      {#if status === 'ready' || $devMode}
-        {@const active = $page.url.pathname === href || ($page.url.pathname.startsWith(href) && href !== '/')}
-        <a {href} class="nav-item" class:active class:nav-dev={status === 'dev'} class:nav-placeholder={status === 'placeholder'} title={label}>
-          <DynamicIcon name={icon} size={16} />
-          {#if status === 'dev'}
-            <span class="nav-dev-dot" title="Requiere Dev Mode"></span>
-          {:else if status === 'placeholder'}
-            <!-- Pronto badge removed -->
+      <!-- Connectivity Indicator -->
+      {#if !$isOnline}
+        <div class="connectivity-pill offline" transition:fade={{ duration: 150 }}>
+          <span class="pulse-dot red"></span>
+          <span>{$t('status.offline')}</span>
+        </div>
+      {:else if showConnectedPill}
+        <div class="connectivity-pill online" transition:fade={{ duration: 150 }}>
+          <span class="pulse-dot green"></span>
+          <span>{$t('status.online')}</span>
+        </div>
+      {/if}
+      <span
+        class="mono"
+        style="font-size:13px; color: var(--xp); display: flex; align-items: center; gap: 8px;"
+      >
+        <span>
+          {#if $nextStageXP}
+            {$totalXP.toLocaleString()}
+            <span style="font-size:10px; color: var(--text-muted);"
+              >/ {$nextStageXP.toLocaleString()} xp</span
+            >
+          {:else}
+            <span style="font-size:12px; font-weight: 700;">MAX</span>
           {/if}
-          <span class="tooltip">{label}</span>
-        </a>
-      {/if}
-    {/each}
-  </nav>
-
-  <!-- Main content -->
-  <main class="app-main">
-    <slot />
-  </main>
-
-  <!-- Status bar -->
-  <footer class="app-statusbar">
-    <span style="color: var(--text-muted); cursor: pointer;" title="Click para notificación de prueba" onclick={() => { showNotification('Notificación de prueba - Info', 'info'); setTimeout(() => showNotification('Notificación de prueba - Success', 'success'), 600); setTimeout(() => showNotification('Notificación de prueba - Level up!', 'level'), 1200); }}>joidy v0.1</span>
-
-    <div class="status-live" title="Estado actual">
-      <span class="status-pill status-time mono">{currentTime}</span>
-      <span class="status-pill status-date">{currentDate}</span>
-      <span class="status-pill status-tasks">{pendingTasks} tareas</span>
-      {#if pendingStreaks > 0}
-        <span class="status-pill status-streak-alert" title="Rachas pendientes">
-          <DynamicIcon name="Flame" size={12} color="var(--xp)" />
-          <span>{pendingStreaks}</span>
         </span>
-      {/if}
-    </div>
+        <span
+          style="font-size:11px; color: var(--text-primary); background: var(--surface); border: 1px solid var(--border); padding: 2px 6px; border-radius: 4px;"
+          >{$t('common.level')} {$globalLevel}</span
+        >
+      </span>
+      <button
+        class="btn btn-ghost btn-icon"
+        title={$t('common.settings')}
+        aria-label={$t('common.settings')}
+        style="color: var(--text-muted);"
+        onclick={() => window.dispatchEvent(new CustomEvent('joidy:open-settings'))}
+      >
+        <DynamicIcon name="Settings" size={14} />
+      </button>
+    </header>
 
-    <div style="flex:1;"></div>
+    <!-- Sidebar -->
+    <nav class="app-sidebar">
+      {#each navItems as { href, label, icon, status }}
+        {#if status === 'ready' || $devMode}
+          {@const active =
+            $page.url.pathname === href || ($page.url.pathname.startsWith(href) && href !== '/')}
+          <a
+            {href}
+            class="nav-item"
+            class:active
+            class:nav-dev={status === 'dev'}
+            class:nav-placeholder={status === 'placeholder'}
+            title={label}
+          >
+            <DynamicIcon name={icon} size={16} />
+            {#if status === 'dev'}
+              <span class="nav-dev-dot" title={$t('status.requiresDevMode')}></span>
+            {:else if status === 'placeholder'}
+              <!-- Pronto badge removed -->
+            {/if}
+            <span class="tooltip">{label}</span>
+          </a>
+        {/if}
+      {/each}
+    </nav>
 
-    <!-- Mini global Pomodoro -->
-    <div class="mini-pomo" class:is-running={$running} class:is-break={$phase !== 'work'} title="Temporizador global">
-      <span class="mono p-timer">{String(Math.floor($secondsLeft / 60)).padStart(2, '0')}:{String($secondsLeft % 60).padStart(2, '0')}</span>
-      <span class="p-dot" class:beat={$running}></span>
-    </div>
-  </footer>
-</div>
+    <!-- Main content -->
+    <main class="app-main">
+      <slot />
+    </main>
 
-<SettingsPanel bind:open={settingsOpen} on:close={() => settingsOpen = false} />
-<CommandPalette />
-<FocusMode />
-<Toast />
-<OnboardingTour />
-<ConflictResolutionModal />
-<OfflineIndicator />
-<ShareAchievementModal />
+    <!-- Status bar -->
+    <footer class="app-statusbar">
+      <span
+        style="color: var(--text-muted); cursor: pointer;"
+        title="Click para notificación de prueba"
+        onclick={() => {
+          showNotification('Notificación de prueba - Info', 'info');
+          setTimeout(() => showNotification('Notificación de prueba - Success', 'success'), 600);
+          setTimeout(() => showNotification('Notificación de prueba - Level up!', 'level'), 1200);
+        }}>joidy v0.1</span
+      >
+
+      <div class="status-live" title="Estado actual">
+        <span class="status-pill status-time mono">{currentTime}</span>
+        <span class="status-pill status-date">{currentDate}</span>
+        <span class="status-pill status-tasks">{pendingTasks} {$t('common.tasks')}</span>
+        {#if pendingStreaks > 0}
+          <span class="status-pill status-streak-alert" title={$t('status.pendingStreaks')}>
+            <DynamicIcon name="Flame" size={12} color="var(--xp)" />
+            <span>{pendingStreaks}</span>
+          </span>
+        {/if}
+      </div>
+
+      <div style="flex:1;"></div>
+
+      <!-- Mini global Pomodoro -->
+      <div
+        class="mini-pomo"
+        class:is-running={$running}
+        class:is-break={$phase !== 'work'}
+        title="Temporizador global"
+      >
+        <span class="mono p-timer"
+          >{String(Math.floor($secondsLeft / 60)).padStart(2, '0')}:{String(
+            $secondsLeft % 60
+          ).padStart(2, '0')}</span
+        >
+        <span class="p-dot" class:beat={$running}></span>
+      </div>
+    </footer>
+  </div>
+
+  <SettingsPanel bind:open={settingsOpen} on:close={() => (settingsOpen = false)} />
+  <CommandPalette />
+  <FocusMode />
+  <Toast />
+  <OnboardingTour />
+  <ConflictResolutionModal />
+  <OfflineIndicator />
+  <ShareAchievementModal />
 {/if}
 
 <style>
@@ -619,9 +691,18 @@
     color: var(--text-disabled);
     transition: all var(--t-normal);
   }
-  .mini-pomo.is-running { color: var(--xp); border-color: var(--xp); background: color-mix(in srgb, var(--xp) 5%, transparent); }
-  .mini-pomo.is-break { color: var(--success); border-color: var(--success); }
-  .p-timer { font-size: 11px; }
+  .mini-pomo.is-running {
+    color: var(--xp);
+    border-color: var(--xp);
+    background: color-mix(in srgb, var(--xp) 5%, transparent);
+  }
+  .mini-pomo.is-break {
+    color: var(--success);
+    border-color: var(--success);
+  }
+  .p-timer {
+    font-size: 11px;
+  }
 
   .status-live {
     display: flex;
@@ -684,8 +765,16 @@
     animation: p-beat 1.5s infinite;
   }
   @keyframes p-beat {
-    0%, 100% { opacity: 0.3; transform: scale(0.9); }
-    50%      { opacity: 1; transform: scale(1.1); box-shadow: 0 0 5px currentColor; }
+    0%,
+    100% {
+      opacity: 0.3;
+      transform: scale(0.9);
+    }
+    50% {
+      opacity: 1;
+      transform: scale(1.1);
+      box-shadow: 0 0 5px currentColor;
+    }
   }
 
   /* Connectivity Pill & Pulse Dot Styles */
@@ -714,7 +803,7 @@
     color: var(--success);
     box-shadow: 0 0 10px color-mix(in srgb, var(--success) 10%, transparent);
   }
-  
+
   .pulse-dot {
     width: 6px;
     height: 6px;
@@ -729,16 +818,28 @@
     background-color: var(--success, #22c55e);
     animation: green-pulse 1.5s infinite;
   }
-  
+
   @keyframes red-pulse {
-    0% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4); }
-    70% { box-shadow: 0 0 0 6px rgba(239, 68, 68, 0); }
-    100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0); }
+    0% {
+      box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4);
+    }
+    70% {
+      box-shadow: 0 0 0 6px rgba(239, 68, 68, 0);
+    }
+    100% {
+      box-shadow: 0 0 0 0 rgba(239, 68, 68, 0);
+    }
   }
   @keyframes green-pulse {
-    0% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.4); }
-    70% { box-shadow: 0 0 0 6px rgba(34, 197, 94, 0); }
-    100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+    0% {
+      box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.4);
+    }
+    70% {
+      box-shadow: 0 0 0 6px rgba(34, 197, 94, 0);
+    }
+    100% {
+      box-shadow: 0 0 0 0 rgba(34, 197, 94, 0);
+    }
   }
 
   .nav-dev-dot {
@@ -750,8 +851,14 @@
     animation: dev-dot-pulse 2s infinite;
   }
   @keyframes dev-dot-pulse {
-    0%, 100% { opacity: 0.6; }
-    50%      { opacity: 1; box-shadow: 0 0 4px var(--warning, #f59e0b); }
+    0%,
+    100% {
+      opacity: 0.6;
+    }
+    50% {
+      opacity: 1;
+      box-shadow: 0 0 4px var(--warning, #f59e0b);
+    }
   }
   .nav-item.nav-dev .tooltip::after {
     content: ' (dev)';


### PR DESCRIPTION
## Summary

Phase 1 of i18n — infrastructure setup + critical strings migrated. Addresses issue #370 (hardcoded Spanish strings and embedded `'es-CL'` locale without any i18n system).

## What's done

- **svelte-i18n installed** (`^4.0.1`) and wired into the app
- **Locale files created**: `frontend/src/locales/{es,en}/common.json` with Spanish (default) and English translations
- **i18n initialization** (`frontend/src/lib/i18n.ts`): initializes svelte-i18n, maps the full BCP-47 locale from the existing `stores/locale.ts` store to a supported base locale (`es`/`en`), and keeps svelte-i18n's locale in sync with the app locale store
- **Layout integration** (`+layout.svelte`): i18n init called at app start; navigation labels, status bar, connectivity pills, PWA banner, and settings button migrated to `$t()` calls
- **Onboarding migration**: `ONBOARDING_STEPS` now uses i18n keys (`onboarding.welcome.title`, etc.) instead of hardcoded Spanish strings; `OnboardingTour.svelte` renders via `$t()`
- **Settings panel**: language selector dropdown (Español / English) added, wired to the existing `setLocale()` from `stores/locale.ts`; appearance section strings migrated
- **`toLocaleTimeString` / `toLocaleDateString`** already use `$localeStore` (the locale store) — no hardcoded `'es-CL'` remains in the layout
- Spanish remains the default locale (preserves current behavior)

## What's pending (future phases)

- Remaining string extraction across all components/pages (notes, goals, streaks, AI, graph, skills, etc.)
- WebSocket notification messages, toast messages, and error strings
- Additional locale files beyond `es`/`en` if needed

## Test plan

- [x] `npm run check` passes (0 errors, 119 pre-existing warnings)
- [ ] Manual verification: Spanish still renders correctly as default
- [ ] Manual verification: switching to English in Settings updates all migrated strings
- [ ] Manual verification: onboarding tour displays in the selected language

Closes #370

---

Generated with [Devin](https://devin.ai)