### PR TITLE
test(backend): critical test coverage phase 2 — vault writer, token service, webhook sync (#402)

### DIFF
--- a/api/tests/test_google_token_service.py
+++ b/api/tests/test_google_token_service.py
@@ -1,0 +1,337 @@
+"""Unit tests for google_token_service — Fernet encryption/decryption roundtrip,
+token storage, connection checks, and async token refresh logic (mocked HTTP).
+
+This service is security-critical: it stores the OAuth refresh token encrypted
+with Fernet derived from the app SECRET_KEY, and refreshes access tokens via
+Google's token endpoint. Bugs here could leak refresh tokens or break Calendar/
+Tasks integrations silently (#402).
+"""
+
+import asyncio
+import sys
+import types
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Stub sqlite_vec before importing app modules (matches conftest pattern).
+if "sqlite_vec" not in sys.modules:
+    _stub = types.ModuleType("sqlite_vec")
+    _stub.load = lambda _conn: None  # type: ignore
+    sys.modules["sqlite_vec"] = _stub
+
+from config import settings
+from database import Base
+from models.google_token import GoogleToken
+from services.google_token_service import (
+    clear_tokens,
+    decrypt_token,
+    encrypt_token,
+    get_stored_token,
+    get_valid_access_token,
+    is_connected,
+    store_tokens,
+)
+
+
+class GoogleTokenTestBase(unittest.TestCase):
+    """Base class with in-memory SQLite and a fixed SECRET_KEY for Fernet."""
+
+    def setUp(self) -> None:
+        self._orig_secret = settings.secret_key
+        settings.secret_key = "test-secret-key-for-fernet-derivation"
+
+        self._orig_client_id = settings.google_client_id
+        self._orig_client_secret = settings.google_client_secret
+        settings.google_client_id = "test-client-id"
+        settings.google_client_secret = "test-client-secret"
+
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+
+    def tearDown(self) -> None:
+        settings.secret_key = self._orig_secret
+        settings.google_client_id = self._orig_client_id
+        settings.google_client_secret = self._orig_client_secret
+        self.engine.dispose()
+
+
+class TokenEncryptionTest(GoogleTokenTestBase):
+    def test_encrypt_decrypt_roundtrip(self) -> None:
+        original = "ya29.a0ARrdaM_refresh_secret_token_value"
+        encrypted = encrypt_token(original)
+        self.assertNotEqual(encrypted, original)
+        self.assertEqual(decrypt_token(encrypted), original)
+
+    def test_encrypt_produces_different_ciphertext(self) -> None:
+        """Fernet includes a timestamp + IV, so encrypting the same token twice
+        should yield different ciphertexts."""
+        token = "my-refresh-token"
+        c1 = encrypt_token(token)
+        c2 = encrypt_token(token)
+        self.assertNotEqual(c1, c2)
+        # Both decrypt to the same plaintext.
+        self.assertEqual(decrypt_token(c1), token)
+        self.assertEqual(decrypt_token(c2), token)
+
+    def test_decrypt_invalid_token_returns_none(self) -> None:
+        self.assertIsNone(decrypt_token("not-a-valid-fernet-token"))
+
+    def test_decrypt_garbage_bytes_returns_none(self) -> None:
+        self.assertIsNone(decrypt_token(""))
+
+    def test_decrypt_with_wrong_secret_returns_none(self) -> None:
+        encrypted = encrypt_token("secret-refresh-token")
+        # Change the secret key — decryption should fail closed.
+        settings.secret_key = "a-completely-different-secret-key"
+        self.assertIsNone(decrypt_token(encrypted))
+
+
+class StoreTokensTest(GoogleTokenTestBase):
+    def test_store_tokens_creates_row(self) -> None:
+        with self.Session() as db:
+            row = store_tokens(
+                db,
+                access_token="access-123",
+                refresh_token="refresh-456",
+                expires_in=3600,
+            )
+            self.assertEqual(row.user_id, 1)
+            self.assertEqual(row.access_token, "access-123")
+            self.assertIsNotNone(row.refresh_token_encrypted)
+            self.assertNotEqual(row.refresh_token_encrypted, "refresh-456")
+            self.assertEqual(row.token_type, "Bearer")
+            self.assertIsNotNone(row.expires_at)
+
+    def test_store_tokens_updates_existing_row(self) -> None:
+        with self.Session() as db:
+            store_tokens(
+                db,
+                access_token="first-access",
+                refresh_token="first-refresh",
+                expires_in=3600,
+            )
+            row = store_tokens(
+                db,
+                access_token="second-access",
+                refresh_token="second-refresh",
+                expires_in=7200,
+            )
+            self.assertEqual(row.access_token, "second-access")
+            # Only one row for user_id=1.
+            self.assertEqual(db.query(GoogleToken).count(), 1)
+
+    def test_store_tokens_without_refresh_keeps_old(self) -> None:
+        with self.Session() as db:
+            store_tokens(
+                db,
+                access_token="first-access",
+                refresh_token="first-refresh",
+                expires_in=3600,
+            )
+            old_encrypted = get_stored_token(db).refresh_token_encrypted
+            # Second store without refresh_token should not overwrite.
+            store_tokens(
+                db,
+                access_token="second-access",
+                refresh_token=None,
+                expires_in=3600,
+            )
+            row = get_stored_token(db)
+            self.assertEqual(row.access_token, "second-access")
+            self.assertEqual(row.refresh_token_encrypted, old_encrypted)
+
+    def test_store_tokens_sets_expiry(self) -> None:
+        with self.Session() as db:
+            before = datetime.now(timezone.utc)
+            row = store_tokens(
+                db,
+                access_token="access",
+                refresh_token="refresh",
+                expires_in=3600,
+            )
+            after = datetime.now(timezone.utc)
+            expected_min = before + timedelta(seconds=3600)
+            expected_max = after + timedelta(seconds=3600)
+            expires_at = row.expires_at
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=timezone.utc)
+            self.assertGreaterEqual(expires_at, expected_min - timedelta(seconds=2))
+            self.assertLessEqual(expires_at, expected_max + timedelta(seconds=2))
+
+
+class IsConnectedTest(GoogleTokenTestBase):
+    def test_not_connected_when_no_row(self) -> None:
+        with self.Session() as db:
+            self.assertFalse(is_connected(db))
+
+    def test_not_connected_when_no_refresh_token(self) -> None:
+        with self.Session() as db:
+            store_tokens(
+                db,
+                access_token="access",
+                refresh_token=None,
+                expires_in=3600,
+            )
+            self.assertFalse(is_connected(db))
+
+    def test_connected_when_refresh_token_stored(self) -> None:
+        with self.Session() as db:
+            store_tokens(
+                db,
+                access_token="access",
+                refresh_token="refresh",
+                expires_in=3600,
+            )
+            self.assertTrue(is_connected(db))
+
+
+class ClearTokensTest(GoogleTokenTestBase):
+    def test_clear_tokens_removes_row(self) -> None:
+        with self.Session() as db:
+            store_tokens(
+                db,
+                access_token="access",
+                refresh_token="refresh",
+                expires_in=3600,
+            )
+            self.assertTrue(is_connected(db))
+            clear_tokens(db)
+            self.assertFalse(is_connected(db))
+            self.assertIsNone(get_stored_token(db))
+
+    def test_clear_tokens_no_row_is_noop(self) -> None:
+        with self.Session() as db:
+            # Should not raise when there's nothing to delete.
+            clear_tokens(db)
+            self.assertIsNone(get_stored_token(db))
+
+
+class GetValidAccessTokenTest(GoogleTokenTestBase):
+    """Tests for the async get_valid_access_token — HTTP calls are mocked."""
+
+    def _run(self, coro):
+        return asyncio.new_event_loop().run_until_complete(coro)
+
+    def test_returns_none_when_not_connected(self) -> None:
+        with self.Session() as db:
+            result = self._run(get_valid_access_token(db))
+            self.assertIsNone(result)
+
+    def test_returns_none_when_no_refresh_token(self) -> None:
+        with self.Session() as db:
+            store_tokens(
+                db,
+                access_token="access",
+                refresh_token=None,
+                expires_in=3600,
+            )
+            result = self._run(get_valid_access_token(db))
+            self.assertIsNone(result)
+
+    def test_returns_cached_token_when_still_valid(self) -> None:
+        with self.Session() as db:
+            store_tokens(
+                db,
+                access_token="valid-access-token",
+                refresh_token="refresh",
+                expires_in=3600,
+            )
+            # Token expires in 1 hour, well beyond the 60s buffer.
+            result = self._run(get_valid_access_token(db))
+            self.assertEqual(result, "valid-access-token")
+
+    def test_refreshes_expired_token(self) -> None:
+        with self.Session() as db:
+            store_tokens(
+                db,
+                access_token="old-access",
+                refresh_token="my-refresh",
+                expires_in=-100,  # Already expired.
+            )
+
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_response.json.return_value = {
+                "access_token": "new-access-token",
+                "expires_in": 3600,
+            }
+
+            mock_client = MagicMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client.post = AsyncMock(return_value=mock_response)
+
+            with patch("services.google_token_service.httpx.AsyncClient", return_value=mock_client):
+                result = self._run(get_valid_access_token(db))
+
+            self.assertEqual(result, "new-access-token")
+            # Verify the refresh request was made with correct payload.
+            mock_client.post.assert_awaited_once()
+            call_args = mock_client.post.call_args
+            self.assertEqual(call_args.kwargs["data"]["grant_type"], "refresh_token")
+            self.assertEqual(call_args.kwargs["data"]["refresh_token"], "my-refresh")
+            self.assertEqual(call_args.kwargs["data"]["client_id"], "test-client-id")
+
+            # DB should be updated with the new access token.
+            row = get_stored_token(db)
+            self.assertEqual(row.access_token, "new-access-token")
+
+    def test_returns_none_on_http_error(self) -> None:
+        with self.Session() as db:
+            store_tokens(
+                db,
+                access_token="old-access",
+                refresh_token="my-refresh",
+                expires_in=-100,
+            )
+
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock(side_effect=Exception("HTTP 400"))
+
+            mock_client = MagicMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client.post = AsyncMock(return_value=mock_response)
+
+            with patch("services.google_token_service.httpx.AsyncClient", return_value=mock_client):
+                result = self._run(get_valid_access_token(db))
+
+            self.assertIsNone(result)
+
+    def test_returns_none_when_client_credentials_missing(self) -> None:
+        settings.google_client_id = ""
+        settings.google_client_secret = ""
+        with self.Session() as db:
+            store_tokens(
+                db,
+                access_token="old-access",
+                refresh_token="my-refresh",
+                expires_in=-100,
+            )
+            result = self._run(get_valid_access_token(db))
+            self.assertIsNone(result)
+
+    def test_returns_none_when_refresh_token_undecryptable(self) -> None:
+        with self.Session() as db:
+            store_tokens(
+                db,
+                access_token="old-access",
+                refresh_token="my-refresh",
+                expires_in=-100,
+            )
+            # Corrupt the encrypted refresh token.
+            row = get_stored_token(db)
+            row.refresh_token_encrypted = "corrupted-encrypted-data"
+            db.commit()
+
+            result = self._run(get_valid_access_token(db))
+            self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/tests/test_joidy_vault_writer.py
+++ b/api/tests/test_joidy_vault_writer.py
@@ -1,0 +1,447 @@
+"""Unit tests for joidy_vault_writer — vault file I/O, markdown generation,
+goal file CRUD, daily journal writing, and goal restoration from vault.
+
+The vault writer is the core integration between Joidy and Obsidian: it writes
+Joidy-owned files into _joidy/ and Objetivos/ inside the vault. Bugs here could
+corrupt user vault files or lose goal data (#402). All filesystem operations use
+tempfile.TemporaryDirectory so tests never touch a real vault.
+"""
+
+import sys
+import tempfile
+import types
+import unittest
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+# Stub sqlite_vec before importing app modules (matches conftest pattern).
+if "sqlite_vec" not in sys.modules:
+    _stub = types.ModuleType("sqlite_vec")
+    _stub.load = lambda _conn: None  # type: ignore
+    sys.modules["sqlite_vec"] = _stub
+
+from config import settings
+from database import Base
+from models.gamification import StreakRecord, UserStats
+from models.goal import Goal
+from models.note import Note, NoteTag, Tag
+from models.skill import Skill
+import services.joidy_vault_writer as vault_writer
+from services.joidy_vault_writer import (
+    JOIDY_DIR,
+    JOIDY_HEADER,
+    OBJECTIVES_DIR,
+    _parse_goal_content,
+    delete_goal_file,
+    get_objectives_dir,
+    get_vault_path,
+    read_goal_file,
+    restore_goals_from_vault,
+    slugify,
+    update_goal_file,
+    write_daily,
+    write_objectives,
+    write_readme,
+    write_skills,
+)
+
+
+class VaultWriterTestBase(unittest.TestCase):
+    """Base class with a temporary vault directory and in-memory SQLite DB."""
+
+    def setUp(self) -> None:
+        self._orig_vault = settings.obsidian_vault_path
+        self._tmpdir = tempfile.TemporaryDirectory()
+        settings.obsidian_vault_path = self._tmpdir.name
+
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        with self.engine.begin() as conn:
+            try:
+                conn.execute(
+                    text(
+                        "CREATE TABLE IF NOT EXISTS tag_cooccurrences "
+                        "(tag_a_id INTEGER, tag_b_id INTEGER, weight INTEGER, "
+                        "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP)"
+                    )
+                )
+            except Exception:
+                pass
+        self.Session = sessionmaker(bind=self.engine)
+
+    def tearDown(self) -> None:
+        settings.obsidian_vault_path = self._orig_vault
+        self._tmpdir.cleanup()
+        self.engine.dispose()
+
+
+class GetVaultPathTest(VaultWriterTestBase):
+    def test_returns_path_when_vault_exists(self) -> None:
+        path = get_vault_path()
+        self.assertIsNotNone(path)
+        self.assertTrue(path.exists())
+
+    def test_returns_none_when_vault_not_set(self) -> None:
+        settings.obsidian_vault_path = ""
+        self.assertIsNone(get_vault_path())
+
+    def test_returns_none_when_vault_does_not_exist(self) -> None:
+        settings.obsidian_vault_path = "/nonexistent/path/that/does/not/exist"
+        self.assertIsNone(get_vault_path())
+
+
+class GetObjectivesDirTest(VaultWriterTestBase):
+    def test_creates_objectives_dir(self) -> None:
+        obj_dir = get_objectives_dir()
+        self.assertIsNotNone(obj_dir)
+        self.assertTrue(obj_dir.exists())
+        self.assertEqual(obj_dir.name, OBJECTIVES_DIR)
+
+    def test_returns_none_when_no_vault(self) -> None:
+        settings.obsidian_vault_path = ""
+        self.assertIsNone(get_objectives_dir())
+
+
+class SlugifyTest(unittest.TestCase):
+    def test_lowercases_text(self) -> None:
+        self.assertEqual(slugify("Hello World"), "hello-world")
+
+    def test_replaces_spaces_with_hyphens(self) -> None:
+        self.assertEqual(slugify("my  goal"), "my-goal")
+
+    def test_replaces_underscores_with_hyphens(self) -> None:
+        self.assertEqual(slugify("my_goal"), "my-goal")
+
+    def test_strips_special_chars(self) -> None:
+        self.assertEqual(slugify("goal! @#$%"), "goal")
+
+    def test_collapses_multiple_hyphens(self) -> None:
+        self.assertEqual(slugify("a---b"), "a-b")
+
+    def test_strips_leading_trailing_hyphens(self) -> None:
+        self.assertEqual(slugify("--test--"), "test")
+
+    def test_empty_string(self) -> None:
+        self.assertEqual(slugify(""), "")
+
+
+class ParseGoalContentTest(unittest.TestCase):
+    def test_parses_frontmatter_and_body(self) -> None:
+        content = "---\ngoal_id: 1\ntitle: My Goal\njoidy_managed: true\n---\n# My Goal\n\nDescription here"
+        parsed = _parse_goal_content(content)
+        self.assertEqual(parsed["goal_id"], "1")
+        self.assertEqual(parsed["title"], "My Goal")
+        self.assertEqual(parsed["joidy_managed"], "true")
+        self.assertEqual(parsed["content"], "Description here")
+
+    def test_falls_back_to_heading_title(self) -> None:
+        content = "---\n---\n# Heading Title\n\nBody text"
+        parsed = _parse_goal_content(content)
+        self.assertEqual(parsed["title"], "Heading Title")
+        self.assertEqual(parsed["content"], "Body text")
+
+    def test_no_frontmatter(self) -> None:
+        content = "# Just a Title\n\nBody"
+        parsed = _parse_goal_content(content)
+        self.assertEqual(parsed["title"], "Just a Title")
+        self.assertEqual(parsed["content"], "Body")
+
+
+class UpdateGoalFileTest(VaultWriterTestBase):
+    def test_creates_new_goal_file(self) -> None:
+        result = update_goal_file(1, "My Goal", "Description", {"temporality": "DAILY"})
+        self.assertTrue(result)
+
+        obj_dir = get_objectives_dir()
+        files = list(obj_dir.glob("1_*.md"))
+        self.assertEqual(len(files), 1)
+        content = files[0].read_text(encoding="utf-8")
+        self.assertIn("goal_id: 1", content)
+        self.assertIn("joidy_managed: True", content)
+        self.assertIn("# My Goal", content)
+        self.assertIn("Description", content)
+
+    def test_updates_existing_goal_file(self) -> None:
+        update_goal_file(2, "Original Title", "Original", {"state": "ACTIVE"})
+        update_goal_file(2, "Updated Title", "Updated content", {"state": "COMPLETED"})
+
+        obj_dir = get_objectives_dir()
+        files = list(obj_dir.glob("2_*.md"))
+        self.assertEqual(len(files), 1)
+        content = files[0].read_text(encoding="utf-8")
+        self.assertIn("# Updated Title", content)
+        self.assertIn("Updated content", content)
+        self.assertIn("state: COMPLETED", content)
+
+    def test_metadata_none_values_excluded(self) -> None:
+        update_goal_file(3, "Goal", "Body", {"note_id": None, "tag_id": 5})
+        obj_dir = get_objectives_dir()
+        content = list(obj_dir.glob("3_*.md"))[0].read_text(encoding="utf-8")
+        self.assertNotIn("note_id", content)
+        self.assertIn("tag_id: 5", content)
+
+    def test_returns_false_when_no_vault(self) -> None:
+        settings.obsidian_vault_path = ""
+        result = update_goal_file(1, "Goal", "Body", {})
+        self.assertFalse(result)
+
+
+class ReadGoalFileTest(VaultWriterTestBase):
+    def test_reads_existing_goal_file(self) -> None:
+        # Write a goal file directly with frontmatter title (the format
+        # _parse_goal_content expects for title extraction).
+        obj_dir = get_objectives_dir()
+        filepath = obj_dir / "5_readable-goal.md"
+        filepath.write_text(
+            "---\ngoal_id: 5\ntitle: Readable Goal\nstate: ACTIVE\n---\n# Readable Goal\n\nContent here",
+            encoding="utf-8",
+        )
+        parsed = read_goal_file(5)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["title"], "Readable Goal")
+        self.assertEqual(parsed["content"], "Content here")
+        self.assertEqual(parsed["state"], "ACTIVE")
+
+    def test_reads_goal_file_with_heading_title(self) -> None:
+        """When no frontmatter title, the H1 heading is used as fallback."""
+        obj_dir = get_objectives_dir()
+        filepath = obj_dir / "6_heading-title.md"
+        filepath.write_text(
+            "---\ngoal_id: 6\n---\n# Heading Title\n\nBody text",
+            encoding="utf-8",
+        )
+        parsed = read_goal_file(6)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["title"], "Heading Title")
+        self.assertEqual(parsed["content"], "Body text")
+
+    def test_returns_none_when_goal_not_found(self) -> None:
+        self.assertIsNone(read_goal_file(999))
+
+    def test_returns_none_when_no_vault(self) -> None:
+        settings.obsidian_vault_path = ""
+        self.assertIsNone(read_goal_file(1))
+
+
+class DeleteGoalFileTest(VaultWriterTestBase):
+    def test_deletes_existing_goal_file(self) -> None:
+        update_goal_file(7, "Delete Me", "Content", {})
+        self.assertTrue(delete_goal_file(7))
+
+        obj_dir = get_objectives_dir()
+        self.assertEqual(len(list(obj_dir.glob("7_*.md"))), 0)
+
+    def test_returns_false_when_goal_not_found(self) -> None:
+        self.assertFalse(delete_goal_file(999))
+
+    def test_returns_false_when_no_vault(self) -> None:
+        settings.obsidian_vault_path = ""
+        self.assertFalse(delete_goal_file(1))
+
+
+class WriteObjectivesTest(VaultWriterTestBase):
+    def test_writes_all_goals_to_vault(self) -> None:
+        with self.Session() as db:
+            db.add(Goal(id=1, title="First Goal", description="Desc 1"))
+            db.add(Goal(id=2, title="Second Goal", description="Desc 2"))
+            db.commit()
+
+            result = write_objectives(db)
+            self.assertTrue(result)
+
+        obj_dir = get_objectives_dir()
+        files = sorted(obj_dir.glob("*.md"))
+        self.assertEqual(len(files), 2)
+        content1 = files[0].read_text(encoding="utf-8")
+        self.assertIn("goal_id: 1", content1)
+        self.assertIn("# First Goal", content1)
+
+    def test_returns_false_when_no_vault(self) -> None:
+        settings.obsidian_vault_path = ""
+        with self.Session() as db:
+            self.assertFalse(write_objectives(db))
+
+
+class WriteDailyTest(VaultWriterTestBase):
+    def test_writes_daily_journal(self) -> None:
+        target = date(2025, 6, 15)
+        with self.Session() as db:
+            db.add(UserStats(id=1, total_xp=500, current_streak=7))
+            db.commit()
+            result = write_daily(db, target_date=target)
+            self.assertTrue(result)
+
+        daily_path = Path(settings.obsidian_vault_path) / JOIDY_DIR / "daily" / "2025-06-15.md"
+        self.assertTrue(daily_path.exists())
+        content = daily_path.read_text(encoding="utf-8")
+        self.assertIn(JOIDY_HEADER, content)
+        self.assertIn("date: 2025-06-15", content)
+        self.assertIn("Daily Journal", content)
+        self.assertIn("XP ganado: **0**", content)
+        self.assertIn("Racha: **7 días**", content)
+
+    def test_daily_includes_streak_xp(self) -> None:
+        target = date(2025, 6, 15)
+        with self.Session() as db:
+            db.add(UserStats(id=1, total_xp=100, current_streak=3))
+            db.add(StreakRecord(activity_date=target, xp_earned=25))
+            db.commit()
+            write_daily(db, target_date=target)
+
+        content = (Path(settings.obsidian_vault_path) / JOIDY_DIR / "daily" / "2025-06-15.md").read_text("utf-8")
+        self.assertIn("xp_earned: 25", content)
+        self.assertIn("XP ganado: **25**", content)
+
+    def test_returns_false_when_no_vault(self) -> None:
+        settings.obsidian_vault_path = ""
+        with self.Session() as db:
+            self.assertFalse(write_daily(db))
+
+
+class WriteSkillsTest(VaultWriterTestBase):
+    def test_writes_skills_file(self) -> None:
+        with self.Session() as db:
+            tag = Tag(name="python")
+            db.add(tag)
+            db.flush()
+            db.add(Skill(tag_id=tag.id, note_count=5, level="journeyman"))
+            db.commit()
+
+            result = write_skills(db)
+            self.assertTrue(result)
+
+        skills_path = Path(settings.obsidian_vault_path) / JOIDY_DIR / "skills.md"
+        self.assertTrue(skills_path.exists())
+        content = skills_path.read_text(encoding="utf-8")
+        self.assertIn(JOIDY_HEADER, content)
+        self.assertIn("Árbol de Habilidades", content)
+        self.assertIn("python", content)
+
+    def test_writes_empty_skills_message(self) -> None:
+        with self.Session() as db:
+            write_skills(db)
+
+        content = (Path(settings.obsidian_vault_path) / JOIDY_DIR / "skills.md").read_text("utf-8")
+        self.assertIn("Sin habilidades aún", content)
+
+    def test_returns_false_when_no_vault(self) -> None:
+        settings.obsidian_vault_path = ""
+        with self.Session() as db:
+            self.assertFalse(write_skills(db))
+
+
+class WriteReadmeTest(VaultWriterTestBase):
+    def test_writes_readme_if_not_exists(self) -> None:
+        vault = Path(settings.obsidian_vault_path)
+        write_readme(vault)
+        readme = vault / JOIDY_DIR / "README.md"
+        self.assertTrue(readme.exists())
+        content = readme.read_text(encoding="utf-8")
+        self.assertIn("Carpeta administrada por Joidy", content)
+
+    def test_does_not_overwrite_existing_readme(self) -> None:
+        vault = Path(settings.obsidian_vault_path)
+        joidy_dir = vault / JOIDY_DIR
+        joidy_dir.mkdir(parents=True, exist_ok=True)
+        readme = joidy_dir / "README.md"
+        readme.write_text("custom content", encoding="utf-8")
+
+        write_readme(vault)
+        self.assertEqual(readme.read_text(encoding="utf-8"), "custom content")
+
+
+class RestoreGoalsFromVaultTest(VaultWriterTestBase):
+    def test_restores_missing_goals(self) -> None:
+        # Write a joidy_managed goal file directly with frontmatter title
+        # (the format restore_goals_from_vault expects).
+        obj_dir = get_objectives_dir()
+        (obj_dir / "10_restored-goal.md").write_text(
+            "---\n"
+            "goal_id: 10\n"
+            "joidy_managed: true\n"
+            "title: Restored Goal\n"
+            "temporality: WEEKLY\n"
+            "measurement_type: COUNT\n"
+            "target_value: 5.0\n"
+            "current_value: 2.0\n"
+            "state: ACTIVE\n"
+            "fail_config: STATIC\n"
+            "fail_emoji: \U0001f534\n"
+            "color: #c8a96e\n"
+            "theme: solid\n"
+            "---\n"
+            "# Restored Goal\n\nDescription",
+            encoding="utf-8",
+        )
+
+        with self.Session() as db:
+            result = restore_goals_from_vault(db)
+            self.assertEqual(result["status"], "ok")
+            self.assertEqual(result["restored"], 1)
+            self.assertEqual(result["skipped"], 0)
+
+            goal = db.query(Goal).filter(Goal.id == 10).first()
+            self.assertIsNotNone(goal)
+            self.assertEqual(goal.title, "Restored Goal")
+            self.assertEqual(goal.description, "Description")
+
+    def test_skips_existing_goals(self) -> None:
+        obj_dir = get_objectives_dir()
+        (obj_dir / "11_existing-goal.md").write_text(
+            "---\ngoal_id: 11\njoidy_managed: true\ntitle: Vault Goal\n---\n# Vault Goal\n\nDesc",
+            encoding="utf-8",
+        )
+
+        with self.Session() as db:
+            db.add(Goal(id=11, title="Already in DB", description="DB desc"))
+            db.commit()
+            result = restore_goals_from_vault(db)
+            self.assertEqual(result["restored"], 0)
+            self.assertEqual(result["skipped"], 1)
+
+            goal = db.query(Goal).filter(Goal.id == 11).first()
+            self.assertEqual(goal.title, "Already in DB")
+
+    def test_ignores_non_joidy_files(self) -> None:
+        obj_dir = get_objectives_dir()
+        (obj_dir / "manual_note.md").write_text("---\n---\n# Manual Note\n\nNot joidy managed", encoding="utf-8")
+
+        with self.Session() as db:
+            result = restore_goals_from_vault(db)
+            self.assertEqual(result["restored"], 0)
+
+    def test_returns_no_vault_when_path_unset(self) -> None:
+        settings.obsidian_vault_path = ""
+        with self.Session() as db:
+            result = restore_goals_from_vault(db)
+            self.assertEqual(result["status"], "no_vault")
+
+
+class FilePathHandlingTest(VaultWriterTestBase):
+    def test_goal_file_uses_slugified_filename(self) -> None:
+        update_goal_file(20, "My Complex Goal Title!", "Content", {})
+        obj_dir = get_objectives_dir()
+        files = list(obj_dir.glob("20_*.md"))
+        self.assertEqual(len(files), 1)
+        self.assertIn("my-complex-goal-title", files[0].name)
+
+    def test_joidy_dir_created_on_daily_write(self) -> None:
+        with self.Session() as db:
+            write_daily(db, target_date=date(2025, 1, 1))
+        joidy_dir = Path(settings.obsidian_vault_path) / JOIDY_DIR
+        self.assertTrue(joidy_dir.exists())
+        self.assertTrue((joidy_dir / "daily").exists())
+
+    def test_joidy_dir_created_on_skills_write(self) -> None:
+        with self.Session() as db:
+            write_skills(db)
+        joidy_dir = Path(settings.obsidian_vault_path) / JOIDY_DIR
+        self.assertTrue(joidy_dir.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/tests/test_webhook_sync.py
+++ b/api/tests/test_webhook_sync.py
@@ -33,11 +33,13 @@ class WebhookSyncTestBase(unittest.TestCase):
         Base.metadata.create_all(self.engine)
         with self.engine.begin() as conn:
             try:
-                conn.execute(text(
-                    "CREATE TABLE IF NOT EXISTS tag_cooccurrences "
-                    "(tag_a_id INTEGER, tag_b_id INTEGER, weight INTEGER, "
-                    "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP)"
-                ))
+                conn.execute(
+                    text(
+                        "CREATE TABLE IF NOT EXISTS tag_cooccurrences "
+                        "(tag_a_id INTEGER, tag_b_id INTEGER, weight INTEGER, "
+                        "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP)"
+                    )
+                )
             except Exception:
                 pass
         self.Session = sessionmaker(bind=self.engine)
@@ -281,6 +283,144 @@ class TestProcessWebhookValidation(WebhookSyncTestBase):
                     content=None,
                     source="obsidian",
                 )
+
+
+class TestProcessWebhookConflict(WebhookSyncTestBase):
+    """Conflict detection — when remote mtime diverges from local mtime beyond
+    the tolerance window, the sync state should be flagged as conflicted (#402)."""
+
+    def test_no_conflict_when_local_mtime_missing(self) -> None:
+        """A note with no prior local_mtime (fresh from vault) should not be
+        flagged as conflicted even if a remote mtime is provided."""
+        with self.Session() as db:
+            result = process_webhook_event(
+                db,
+                event="create",
+                path="/vault/no-conflict.md",
+                content="content",
+                mtime=1700000000,
+                source="obsidian",
+            )
+            db.commit()
+        self.assertFalse(result["conflict"])
+
+    def test_conflict_detected_on_diverging_mtimes(self) -> None:
+        """When local_mtime was set (note edited in Joidy) and the remote
+        mtime differs significantly, a conflict should be flagged."""
+        from services.sync_service import update_local_mtime
+
+        with self.Session() as db:
+            # Create the note first.
+            create_result = process_webhook_event(
+                db,
+                event="create",
+                path="/vault/conflict-note.md",
+                content="original",
+                mtime=1700000000,
+                source="obsidian",
+            )
+            db.commit()
+            note_id = create_result["note_id"]
+
+            # Simulate a local edit (sets local_mtime to now).
+            update_local_mtime(db, note_id)
+            db.commit()
+
+            # Now a webhook update arrives with a remote mtime far in the past.
+            result = process_webhook_event(
+                db,
+                event="update",
+                path="/vault/conflict-note.md",
+                content="remote content",
+                mtime=1600000000,  # ~2020, far from local_mtime
+                source="obsidian",
+            )
+            db.commit()
+
+        self.assertTrue(result["conflict"])
+
+    def test_no_conflict_when_mtimes_within_tolerance(self) -> None:
+        """When local and remote mtimes are within the 2s tolerance window,
+        no conflict should be flagged."""
+        import time
+
+        from services.sync_service import update_local_mtime
+
+        with self.Session() as db:
+            create_result = process_webhook_event(
+                db,
+                event="create",
+                path="/vault/synced-note.md",
+                content="original",
+                mtime=1700000000,
+                source="obsidian",
+            )
+            db.commit()
+            note_id = create_result["note_id"]
+
+            update_local_mtime(db, note_id)
+            db.commit()
+
+            # Remote mtime within ~1s of local (now) — should not conflict.
+            now_ts = int(time.time())
+            result = process_webhook_event(
+                db,
+                event="update",
+                path="/vault/synced-note.md",
+                content="updated content",
+                mtime=now_ts,  # ~now, within tolerance
+                source="obsidian",
+            )
+            db.commit()
+
+        self.assertFalse(result["conflict"])
+
+    def test_sync_state_remote_mtime_set(self) -> None:
+        """The SyncState record should store the remote mtime from the webhook."""
+        with self.Session() as db:
+            result = process_webhook_event(
+                db,
+                event="create",
+                path="/vault/mtime-test.md",
+                content="content",
+                mtime=1700000123,
+                source="obsidian",
+            )
+            db.commit()
+
+        with self.Session() as db:
+            sync = db.query(SyncState).filter(SyncState.note_id == result["note_id"]).first()
+            self.assertIsNotNone(sync)
+            self.assertIsNotNone(sync.remote_mtime)
+            self.assertIsNotNone(sync.last_synced_at)
+
+    def test_delete_removes_sync_state(self) -> None:
+        """Deleting a note via webhook should also remove its SyncState to
+        avoid orphaned FK references."""
+        with self.Session() as db:
+            create_result = process_webhook_event(
+                db,
+                event="create",
+                path="/vault/delete-sync.md",
+                content="content",
+                mtime=1700000000,
+                source="obsidian",
+            )
+            db.commit()
+            note_id = create_result["note_id"]
+
+        with self.Session() as db:
+            process_webhook_event(
+                db,
+                event="delete",
+                path="/vault/delete-sync.md",
+                source="obsidian",
+            )
+            db.commit()
+
+        with self.Session() as db:
+            sync = db.query(SyncState).filter(SyncState.note_id == note_id).first()
+            self.assertIsNone(sync)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Continuation of #537 (issue #402). This PR adds comprehensive unit tests for 3 critical backend services that previously had no test coverage:

### 1. `google_token_service.py` — 21 tests (new file)
Security-critical service handling OAuth token encryption and refresh.
- **Token encryption/decryption roundtrip**: Fernet encryption with SECRET_KEY derivation, ciphertext uniqueness, wrong-secret failure
- **Token storage**: `store_tokens` create/update/upsert behavior, expiry calculation, refresh token preservation
- **Connection checks**: `is_connected` for missing row, missing refresh token, valid token
- **Token clear**: `clear_tokens` removal and noop on empty
- **Async token refresh** (mocked HTTP via `unittest.mock`):
  - Returns cached token when still valid (within 60s buffer)
  - Refreshes expired token via Google token endpoint with correct payload
  - Returns `None` on HTTP error, missing client credentials, undecryptable refresh token, no connection

### 2. `webhook_sync.py` — 5 new tests (extended existing file)
Data integrity service for webhook-driven sync. The existing file covered create/update/delete processing; this PR adds **conflict detection** tests:
- No conflict when local_mtime is missing (fresh vault import)
- Conflict detected when local and remote mtimes diverge beyond 2s tolerance
- No conflict when mtimes are within tolerance window
- SyncState stores remote_mtime and last_synced_at
- Delete event removes SyncState (no orphaned FK references)

### 3. `joidy_vault_writer.py` — 43 tests (new file)
Core vault integration service writing Joidy-owned files to Obsidian vault. Uses `tempfile.TemporaryDirectory` for all file I/O:
- **Vault path handling**: `get_vault_path` / `get_objectives_dir` with existing, missing, and unset paths
- **Slugify**: lowercasing, hyphen normalization, special char stripping, edge cases
- **Markdown parsing**: `_parse_goal_content` frontmatter extraction, heading title fallback, no-frontmatter
- **Goal file CRUD**: `update_goal_file` create/update/metadata filtering, `read_goal_file` with frontmatter/heading titles, `delete_goal_file`
- **Daily journal**: `write_daily` markdown generation with XP/streak data, streak record XP, directory creation
- **Skills file**: `write_skills` with skill tree, empty state message, directory creation
- **README**: `write_readme` creation and no-overwrite protection
- **Goal restoration**: `restore_goals_from_vault` restores missing goals, skips existing, ignores non-joidy files, handles no-vault
- **File path handling**: slugified filenames, `_joidy/` directory creation

## Test plan checklist
- [x] `python -m py_compile` passes on all 3 test files
- [x] `ruff format` applied to all test files
- [x] All 86 tests pass locally (21 + 22 + 43)
- [x] `unittest.TestCase` style (repo convention)
- [x] `sqlite_vec` stubbed at top of each test file
- [x] In-memory SQLite (`sqlite:///:memory:`) for DB-dependent tests
- [x] `unittest.mock.patch` / `AsyncMock` for HTTP calls
- [x] `tempfile.TemporaryDirectory` for all filesystem operations
- [x] No real vault or network access in tests

Closes #402 (continuation of #537).

Generated with [Devin](https://devin.ai)