### PR TITLE
feat(frontend): quick capture widget on dashboard (#392)

### DIFF
--- a/frontend/src/lib/components/QuickCaptureWidget.svelte
+++ b/frontend/src/lib/components/QuickCaptureWidget.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  import { _ } from 'svelte-i18n';
+  import { createNote } from '$lib/stores/notes';
+  import { showNotification } from '$lib/stores/notifications';
+  import { showXPGain } from '$lib/stores/gamification';
+  import { Send } from 'lucide-svelte';
+
+  let text = $state('');
+  let submitting = $state(false);
+
+  async function handleCapture(e: MouseEvent) {
+    const trimmed = text.trim();
+    if (!trimmed || submitting) return;
+    submitting = true;
+    const title = trimmed.split('\n')[0].slice(0, 60) || $_('quickCapture.defaultTitle');
+    const note = await createNote(title, trimmed, ['inbox'], null);
+    submitting = false;
+    if (note) {
+      text = '';
+      showNotification($_('quickCapture.created'), 'success');
+      showXPGain(10, e.clientX, e.clientY);
+    } else {
+      showNotification($_('quickCapture.error'), 'error');
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      handleCapture(e as unknown as MouseEvent);
+    }
+  }
+</script>
+
+<div class="quick-capture">
+  <textarea
+    bind:value={text}
+    placeholder={$_('quickCapture.placeholder')}
+    onkeydown={handleKeydown}
+    rows="2"
+    aria-label={$_('quickCapture.placeholder')}
+  ></textarea>
+  <button
+    class="qc-btn"
+    onclick={handleCapture}
+    disabled={submitting || !text.trim()}
+    aria-label={$_('common.save')}
+  >
+    {#if submitting}
+      <span class="qc-spinner"></span>
+    {:else}
+      <Send size={14} />
+    {/if}
+    <span>{submitting ? $_('common.saving') : $_('common.save')}</span>
+  </button>
+</div>
+
+<style>
+  .quick-capture {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+  }
+
+  textarea {
+    width: 100%;
+    min-height: 44px;
+    max-height: 120px;
+    resize: vertical;
+    background: var(--surface, rgba(255, 255, 255, 0.05));
+    border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+    border-radius: 8px;
+    padding: 8px 10px;
+    font-size: 13px;
+    font-family: inherit;
+    color: var(--text, inherit);
+    line-height: 1.4;
+  }
+
+  textarea:focus {
+    outline: none;
+    border-color: var(--accent, #4f9cf9);
+  }
+
+  textarea::placeholder {
+    color: var(--text-muted, rgba(255, 255, 255, 0.4));
+  }
+
+  .qc-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border: none;
+    border-radius: 8px;
+    background: var(--accent, #4f9cf9);
+    color: white;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.15s;
+    align-self: flex-end;
+  }
+
+  .qc-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .qc-btn:not(:disabled):hover {
+    opacity: 0.85;
+  }
+
+  .qc-spinner {
+    width: 12px;
+    height: 12px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: white;
+    border-radius: 50%;
+    animation: qc-spin 0.6s linear infinite;
+  }
+
+  @keyframes qc-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+</style>

--- a/frontend/src/lib/stores/layout.ts
+++ b/frontend/src/lib/stores/layout.ts
@@ -8,6 +8,7 @@ export type WidgetId =
   | 'time-widget'
   | 'weather-widget'
   | 'pomodoro'
+  | 'quick-capture'
   | 'recent-notes'
   | 'github-issues';
 
@@ -24,6 +25,7 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetMeta> = {
   'time-widget':       { id: 'time-widget',       label: 'Reloj',                  panel: 'left'  },
   'weather-widget': { id: 'weather-widget', label: 'Clima',         panel: 'left'  },
   'pomodoro':       { id: 'pomodoro',        label: 'Pomodoro',     panel: 'left'  },
+  'quick-capture':  { id: 'quick-capture',   label: 'Captura rápida', panel: 'left' },
   'recent-notes':   { id: 'recent-notes',    label: 'Notas',        panel: 'right' },
   'github-issues':  { id: 'github-issues',   label: 'GitHub',       panel: 'right' },
 };
@@ -35,7 +37,7 @@ export interface DashboardLayout {
 }
 
 const DEFAULT: DashboardLayout = {
-  left:  ['plant-carousel', 'stats-xp', 'activity-progress', 'time-widget', 'pomodoro'],
+  left:  ['plant-carousel', 'stats-xp', 'activity-progress', 'time-widget', 'pomodoro', 'quick-capture'],
   right: ['recent-notes', 'github-issues'],
 };
 

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -81,5 +81,11 @@
     "timeFormat": "Time format",
     "language": "Language",
     "languageHint": "The interface language"
+  },
+  "quickCapture": {
+    "placeholder": "Capture a quick idea...",
+    "defaultTitle": "Quick note",
+    "created": "Note created!",
+    "error": "Could not create note"
   }
 }

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -81,5 +81,11 @@
     "timeFormat": "Formato de hora",
     "language": "Idioma",
     "languageHint": "El idioma de la interfaz"
+  },
+  "quickCapture": {
+    "placeholder": "Captura una idea rápida...",
+    "defaultTitle": "Nota rápida",
+    "created": "¡Nota creada!",
+    "error": "No se pudo crear la nota"
   }
 }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -12,6 +12,7 @@
   import XPBar          from '$lib/components/XPBar.svelte';
   import NoteCard       from '$lib/components/NoteCard.svelte';
   import PomodoroWidget from '$lib/components/PomodoroWidget.svelte';
+  import QuickCaptureWidget from '$lib/components/QuickCaptureWidget.svelte';
   import { Target } from 'lucide-svelte';
   import { startFocusMode } from '$lib/stores/focusMode';
   import TimeWidget from '$lib/components/TimeWidget.svelte';
@@ -373,6 +374,8 @@
       <Target size={16} />
       Modo Enfoque
     </button>
+  {:else if wid === 'quick-capture'}
+    <QuickCaptureWidget />
   {:else if wid === 'recent-notes'}
     <div class="section-header">
       <h4 style="color: {$accentColors[0]}">Notas recientes</h4>


### PR DESCRIPTION
## Summary
- Add a Quick Capture widget to the homescreen dashboard
- Users can instantly create a note with auto-tag "inbox" via textarea + Cmd/Ctrl+Enter or button click
- Uses existing `createNote()` store function which handles offline queueing, gamification XP, and toast notifications

### Changes
- New `QuickCaptureWidget.svelte` component (Svelte 5 runes mode)
- Registered as `'quick-capture'` in `WidgetId` type and `WIDGET_REGISTRY`
- Added to default left panel layout
- i18n strings for es/en locales (`quickCapture.placeholder`, `quickCapture.created`, etc.)

#### Test plan
- [x] `npm run check` passes (0 errors, 119 pre-existing warnings)
- [ ] CI passes
- [ ] Manual: type text, click save → note created with tag "inbox"
- [ ] Manual: Cmd/Ctrl+Enter creates note
- [ ] Manual: XP animation shows on create
- [ ] Manual: empty input disables button

Generated with [Devin](https://devin.ai)