### PR TITLE
feat: mood tracker widget — model, API, and dashboard integration (#392)

### DIFF
--- a/api/alembic/versions/f6a7b8c9d0e1_add_mood_entries.py
+++ b/api/alembic/versions/f6a7b8c9d0e1_add_mood_entries.py
@@ -1,0 +1,46 @@
+"""add mood_entries table for daily mood tracking
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-08-02 18:30:00.000000
+
+Mood Tracker widget (#392) — records a daily mood score (1-5) with an
+optional note. One entry per user per day enforced by a unique constraint.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f6a7b8c9d0e1"
+down_revision: Union[str, None] = "e5f6a7b8c9d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mood_entries",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("score", sa.Integer(), nullable=False),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("entry_date", sa.Date(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "entry_date", name="uq_mood_entry_user_date"),
+    )
+    op.create_index(op.f("ix_mood_entries_id"), "mood_entries", ["id"], unique=False)
+    op.create_index(op.f("ix_mood_entries_user_id"), "mood_entries", ["user_id"], unique=False)
+    op.create_index("ix_mood_entries_entry_date", "mood_entries", ["entry_date"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_mood_entries_entry_date", table_name="mood_entries")
+    op.drop_index(op.f("ix_mood_entries_user_id"), table_name="mood_entries")
+    op.drop_index(op.f("ix_mood_entries_id"), table_name="mood_entries")
+    op.drop_table("mood_entries")

--- a/api/main.py
+++ b/api/main.py
@@ -21,6 +21,7 @@ from routers import (
     gamification,
     goals,
     metrics,
+    mood,
     notes,
     obsidian,
     personal_streaks,
@@ -139,6 +140,7 @@ app = FastAPI(
         {"name": "vault", "description": "Obsidian vault sync status"},
         {"name": "ai", "description": "AI classification and RAG endpoints"},
         {"name": "personal_streaks", "description": "Personal streak tracking and analytics"},
+        {"name": "mood", "description": "Daily mood tracking and analytics"},
     ],
 )
 
@@ -170,6 +172,7 @@ app.add_middleware(RequestIdMiddleware)
 app.include_router(notes.router, dependencies=[Depends(get_current_user)])
 app.include_router(config.router)
 app.include_router(metrics.router, dependencies=[Depends(get_current_user)])
+app.include_router(mood.router, dependencies=[Depends(get_current_user)])
 app.include_router(tags.router, dependencies=[Depends(get_current_user)])
 app.include_router(skills.router, dependencies=[Depends(get_current_user)])
 app.include_router(goals.router, dependencies=[Depends(get_current_user)])

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -3,6 +3,7 @@ from .gamification import *
 from .github import *
 from .goal import *
 from .google_token import *
+from .mood_entry import *
 from .note import *
 from .personal_streaks import *
 from .planning import *

--- a/api/models/mood_entry.py
+++ b/api/models/mood_entry.py
@@ -1,0 +1,26 @@
+from datetime import date, datetime
+
+from database import Base
+from sqlalchemy import Date, DateTime, Index, Integer, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class MoodEntry(Base):
+    """Daily mood entry — one per user per day (1-5 scale)."""
+
+    __tablename__ = "mood_entries"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    score: Mapped[int] = mapped_column(Integer, nullable=False)  # 1-5
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    entry_date: Mapped[date] = mapped_column(Date, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        # One mood entry per user per day.
+        UniqueConstraint("user_id", "entry_date", name="uq_mood_entry_user_date"),
+        # History queries filter/order by entry_date.
+        Index("ix_mood_entries_entry_date", "entry_date"),
+    )

--- a/api/routers/mood.py
+++ b/api/routers/mood.py
@@ -1,0 +1,83 @@
+from database import get_db
+from fastapi import APIRouter, Depends, Query
+from models.mood_entry import MoodEntry
+from pydantic import BaseModel, field_validator
+from services.auth_service import get_current_user
+from services.mood_service import (
+    create_or_update_mood,
+    get_mood_history,
+    get_mood_stats,
+    get_today_mood,
+)
+from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/mood", tags=["mood"])
+
+
+class MoodCreate(BaseModel):
+    """Schema for creating/updating today's mood."""
+
+    score: int
+    note: str | None = None
+
+    @field_validator("score")
+    @classmethod
+    def score_range(cls, v: int) -> int:
+        if v < 1 or v > 5:
+            raise ValueError("score must be between 1 and 5")
+        return v
+
+
+def _serialize_mood(entry: MoodEntry) -> dict:
+    return {
+        "id": entry.id,
+        "user_id": entry.user_id,
+        "score": entry.score,
+        "note": entry.note,
+        "entry_date": entry.entry_date.isoformat(),
+        "created_at": entry.created_at.isoformat() if entry.created_at else None,
+        "updated_at": entry.updated_at.isoformat() if entry.updated_at else None,
+    }
+
+
+@router.post("/")
+def create_mood(
+    data: MoodCreate,
+    db: Session = Depends(get_db),
+    user_id: int = Depends(get_current_user),
+):
+    """Create or update today's mood entry."""
+    entry = create_or_update_mood(db, user_id, data.score, data.note)
+    return _serialize_mood(entry)
+
+
+@router.get("/today")
+def get_today(
+    db: Session = Depends(get_db),
+    user_id: int = Depends(get_current_user),
+):
+    """Get today's mood entry, or null if not yet recorded."""
+    entry = get_today_mood(db, user_id)
+    if not entry:
+        return None
+    return _serialize_mood(entry)
+
+
+@router.get("/history")
+def get_history(
+    days: int = Query(30, ge=1, le=366),
+    db: Session = Depends(get_db),
+    user_id: int = Depends(get_current_user),
+):
+    """Get mood history for the last N days (oldest → newest)."""
+    entries = get_mood_history(db, user_id, days)
+    return [_serialize_mood(e) for e in entries]
+
+
+@router.get("/stats")
+def get_stats(
+    db: Session = Depends(get_db),
+    user_id: int = Depends(get_current_user),
+):
+    """Get mood statistics: average, streak, total entries, notes correlation."""
+    return get_mood_stats(db, user_id)

--- a/api/services/mood_service.py
+++ b/api/services/mood_service.py
@@ -1,0 +1,97 @@
+"""Mood Tracker Service — daily mood recording and analytics."""
+
+from datetime import date, datetime, timedelta, timezone
+
+from models.mood_entry import MoodEntry
+from sqlalchemy.orm import Session
+
+
+def _today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def create_or_update_mood(db: Session, user_id: int, score: int, note: str | None = None) -> MoodEntry:
+    """Create or update today's mood entry for a user (upsert by date)."""
+    today = _today()
+    entry = db.query(MoodEntry).filter(MoodEntry.user_id == user_id, MoodEntry.entry_date == today).first()
+    if entry:
+        entry.score = score
+        entry.note = note
+    else:
+        entry = MoodEntry(
+            user_id=user_id,
+            score=score,
+            note=note,
+            entry_date=today,
+        )
+        db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+def get_today_mood(db: Session, user_id: int) -> MoodEntry | None:
+    """Get today's mood entry for a user, or None if not yet recorded."""
+    return db.query(MoodEntry).filter(MoodEntry.user_id == user_id, MoodEntry.entry_date == _today()).first()
+
+
+def get_mood_history(db: Session, user_id: int, days: int = 30) -> list[MoodEntry]:
+    """Get mood entries for the last N days, ordered oldest → newest."""
+    if days < 1:
+        days = 1
+    if days > 366:
+        days = 366
+    since = _today() - timedelta(days=days)
+    return (
+        db.query(MoodEntry)
+        .filter(
+            MoodEntry.user_id == user_id,
+            MoodEntry.entry_date >= since,
+        )
+        .order_by(MoodEntry.entry_date.asc())
+        .all()
+    )
+
+
+def get_mood_stats(db: Session, user_id: int) -> dict:
+    """Compute mood statistics: average score, current streak, and note correlation.
+
+    - ``average``: mean score across all entries (rounded to 2 decimals).
+    - ``streak``: consecutive days (ending today or yesterday) with a mood entry.
+    - ``total_entries``: total number of recorded mood entries.
+    - ``notes_correlation``: how many mood entries include a note vs. total.
+    """
+    entries = db.query(MoodEntry).filter(MoodEntry.user_id == user_id).order_by(MoodEntry.entry_date.asc()).all()
+
+    if not entries:
+        return {
+            "average": 0.0,
+            "streak": 0,
+            "total_entries": 0,
+            "notes_correlation": 0.0,
+        }
+
+    # Average score
+    avg = round(sum(e.score for e in entries) / len(entries), 2)
+
+    # Current streak — consecutive days ending today or yesterday
+    dates_set = {e.entry_date for e in entries}
+    today = _today()
+    cursor = today
+    if cursor not in dates_set:
+        cursor -= timedelta(days=1)
+    streak = 0
+    while cursor in dates_set:
+        streak += 1
+        cursor -= timedelta(days=1)
+
+    # Correlation: fraction of entries that include a note
+    with_note = sum(1 for e in entries if e.note and e.note.strip())
+    notes_correlation = round(with_note / len(entries), 2)
+
+    return {
+        "average": avg,
+        "streak": streak,
+        "total_entries": len(entries),
+        "notes_correlation": notes_correlation,
+    }

--- a/api/tests/test_mood_service.py
+++ b/api/tests/test_mood_service.py
@@ -1,0 +1,210 @@
+"""Unit tests for mood_service — create/update (upsert), get today, history, and stats.
+
+Uses in-memory SQLite and stubs sqlite_vec (matches conftest pattern).
+"""
+
+import sys
+import types
+import unittest
+from datetime import UTC, date, datetime, timedelta
+
+# Stub sqlite_vec before importing app modules (matches conftest pattern).
+if "sqlite_vec" not in sys.modules:
+    _stub = types.ModuleType("sqlite_vec")
+    _stub.load = lambda _conn: None  # type: ignore
+    sys.modules["sqlite_vec"] = _stub
+
+from database import Base
+from models.mood_entry import MoodEntry
+from services.mood_service import (
+    create_or_update_mood,
+    get_mood_history,
+    get_mood_stats,
+    get_today_mood,
+)
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+
+class MoodServiceTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        # tag_cooccurrences is referenced by some models but not always
+        # created cleanly on SQLite; ensure it exists to avoid spurious errors.
+        with self.engine.begin() as conn:
+            try:
+                conn.execute(
+                    text(
+                        "CREATE TABLE IF NOT EXISTS tag_cooccurrences "
+                        "(tag_a_id INTEGER, tag_b_id INTEGER, weight INTEGER, "
+                        "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP)"
+                    )
+                )
+            except Exception:
+                pass
+        self.Session = sessionmaker(bind=self.engine)
+
+    def tearDown(self) -> None:
+        self.engine.dispose()
+
+    def _today(self) -> date:
+        return datetime.now(UTC).date()
+
+
+class CreateOrUpdateMoodTest(MoodServiceTestBase):
+    def test_create_today_mood(self):
+        db = self.Session()
+        entry = create_or_update_mood(db, user_id=1, score=4, note="Good day")
+        self.assertEqual(entry.score, 4)
+        self.assertEqual(entry.note, "Good day")
+        self.assertEqual(entry.entry_date, self._today())
+        self.assertEqual(entry.user_id, 1)
+        db.close()
+
+    def test_update_today_mood_upsert(self):
+        db = self.Session()
+        create_or_update_mood(db, user_id=1, score=3)
+        # Second call on the same day should update, not create a new entry.
+        entry = create_or_update_mood(db, user_id=1, score=5, note="Great!")
+        self.assertEqual(entry.score, 5)
+        self.assertEqual(entry.note, "Great!")
+        # Only one entry for today.
+        count = db.query(MoodEntry).filter(MoodEntry.user_id == 1, MoodEntry.entry_date == self._today()).count()
+        self.assertEqual(count, 1)
+        db.close()
+
+    def test_different_users_separate_entries(self):
+        db = self.Session()
+        create_or_update_mood(db, user_id=1, score=2)
+        create_or_update_mood(db, user_id=2, score=5)
+        e1 = get_today_mood(db, user_id=1)
+        e2 = get_today_mood(db, user_id=2)
+        self.assertEqual(e1.score, 2)
+        self.assertEqual(e2.score, 5)
+        db.close()
+
+
+class GetTodayMoodTest(MoodServiceTestBase):
+    def test_no_entry_returns_none(self):
+        db = self.Session()
+        result = get_today_mood(db, user_id=1)
+        self.assertIsNone(result)
+        db.close()
+
+    def test_returns_entry_after_creation(self):
+        db = self.Session()
+        create_or_update_mood(db, user_id=1, score=3)
+        entry = get_today_mood(db, user_id=1)
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.score, 3)
+        db.close()
+
+
+class GetMoodHistoryTest(MoodServiceTestBase):
+    def test_empty_history(self):
+        db = self.Session()
+        history = get_mood_history(db, user_id=1, days=7)
+        self.assertEqual(len(history), 0)
+        db.close()
+
+    def test_history_returns_entries_in_range(self):
+        db = self.Session()
+        today = self._today()
+        # Create entries for today and 3 days ago.
+        db.add(MoodEntry(user_id=1, score=4, entry_date=today))
+        db.add(MoodEntry(user_id=1, score=2, entry_date=today - timedelta(days=3)))
+        db.commit()
+        history = get_mood_history(db, user_id=1, days=7)
+        self.assertEqual(len(history), 2)
+        # Ordered oldest → newest.
+        self.assertEqual(history[0].entry_date, today - timedelta(days=3))
+        self.assertEqual(history[1].entry_date, today)
+        db.close()
+
+    def test_history_excludes_old_entries(self):
+        db = self.Session()
+        today = self._today()
+        db.add(MoodEntry(user_id=1, score=4, entry_date=today))
+        db.add(MoodEntry(user_id=1, score=1, entry_date=today - timedelta(days=10)))
+        db.commit()
+        history = get_mood_history(db, user_id=1, days=7)
+        self.assertEqual(len(history), 1)
+        self.assertEqual(history[0].entry_date, today)
+        db.close()
+
+    def test_history_days_clamped(self):
+        db = self.Session()
+        # days < 1 should be clamped to 1, days > 366 to 366 — no crash.
+        history = get_mood_history(db, user_id=1, days=0)
+        self.assertEqual(len(history), 0)
+        history = get_mood_history(db, user_id=1, days=999)
+        self.assertEqual(len(history), 0)
+        db.close()
+
+
+class GetMoodStatsTest(MoodServiceTestBase):
+    def test_no_entries_returns_zeros(self):
+        db = self.Session()
+        stats = get_mood_stats(db, user_id=1)
+        self.assertEqual(stats["average"], 0.0)
+        self.assertEqual(stats["streak"], 0)
+        self.assertEqual(stats["total_entries"], 0)
+        self.assertEqual(stats["notes_correlation"], 0.0)
+        db.close()
+
+    def test_average_score(self):
+        db = self.Session()
+        today = self._today()
+        db.add(MoodEntry(user_id=1, score=3, entry_date=today))
+        db.add(MoodEntry(user_id=1, score=5, entry_date=today - timedelta(days=1)))
+        db.commit()
+        stats = get_mood_stats(db, user_id=1)
+        self.assertEqual(stats["average"], 4.0)
+        self.assertEqual(stats["total_entries"], 2)
+        db.close()
+
+    def test_streak_consecutive_days(self):
+        db = self.Session()
+        today = self._today()
+        for i in range(3):
+            db.add(MoodEntry(user_id=1, score=4, entry_date=today - timedelta(days=i)))
+        db.commit()
+        stats = get_mood_stats(db, user_id=1)
+        self.assertEqual(stats["streak"], 3)
+        db.close()
+
+    def test_streak_broken_by_gap(self):
+        db = self.Session()
+        today = self._today()
+        # Today and 2 days ago, but not yesterday — streak is 1.
+        db.add(MoodEntry(user_id=1, score=4, entry_date=today))
+        db.add(MoodEntry(user_id=1, score=3, entry_date=today - timedelta(days=2)))
+        db.commit()
+        stats = get_mood_stats(db, user_id=1)
+        self.assertEqual(stats["streak"], 1)
+        db.close()
+
+    def test_streak_counts_yesterday_if_no_today(self):
+        db = self.Session()
+        yesterday = self._today() - timedelta(days=1)
+        db.add(MoodEntry(user_id=1, score=4, entry_date=yesterday))
+        db.commit()
+        stats = get_mood_stats(db, user_id=1)
+        self.assertEqual(stats["streak"], 1)
+        db.close()
+
+    def test_notes_correlation(self):
+        db = self.Session()
+        today = self._today()
+        db.add(MoodEntry(user_id=1, score=4, entry_date=today, note="Good"))
+        db.add(MoodEntry(user_id=1, score=2, entry_date=today - timedelta(days=1), note=None))
+        db.commit()
+        stats = get_mood_stats(db, user_id=1)
+        # 1 of 2 entries has a note → 0.5
+        self.assertEqual(stats["notes_correlation"], 0.5)
+        db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -255,6 +255,23 @@ export interface StreakStats {
   days_tracked: number;
 }
 
+export interface MoodEntry {
+  id: number;
+  user_id: number;
+  score: number;
+  note: string | null;
+  entry_date: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface MoodStats {
+  average: number;
+  streak: number;
+  total_entries: number;
+  notes_correlation: number;
+}
+
 // ── Notes ─────────────────────────────────────────────────────────────────────
 
 export interface SyncConflict {
@@ -364,6 +381,14 @@ export const api = {
     stats:    ()                  => req<StreakStats>('GET', '/personal-streaks/stats'),
     categories: ()                => req<string[]>('GET', '/personal-streaks/categories'),
     history:  (id: number, days = 90) => req<{ date: string; note: string; mood: number | null; created_at: string }[]>('GET', `/personal-streaks/${id}/history?days=${days}`),
+  },
+
+  mood: {
+    create: (data: { score: number; note?: string | null }) =>
+      req<MoodEntry>('POST', '/mood/', data),
+    today:  () => req<MoodEntry | null>('GET', '/mood/today'),
+    history: (days = 30) => req<MoodEntry[]>('GET', `/mood/history?days=${days}`),
+    stats:   () => req<MoodStats>('GET', '/mood/stats'),
   },
 
   ai: {

--- a/frontend/src/lib/components/MoodWidget.svelte
+++ b/frontend/src/lib/components/MoodWidget.svelte
@@ -1,0 +1,319 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { t } from 'svelte-i18n';
+  import { todayMood, moodHistory, moodStats, loadMood, saveMood } from '$lib/stores/mood';
+  import { showNotification } from '$lib/stores/notifications';
+
+  const MOODS = [
+    { score: 1, emoji: '😞' },
+    { score: 2, emoji: '😟' },
+    { score: 3, emoji: '😐' },
+    { score: 4, emoji: '🙂' },
+    { score: 5, emoji: '😄' },
+  ];
+
+  let selectedScore = $state<number | null>(null);
+  let noteText = $state('');
+  let saving = $state(false);
+
+  // Sync local state when today's mood loads/changes.
+  $effect(() => {
+    if ($todayMood) {
+      selectedScore = $todayMood.score;
+      noteText = $todayMood.note ?? '';
+    }
+  });
+
+  // Last 7 days of history for the mini bar chart (newest last).
+  const recentHistory = $derived($moodHistory.slice(-7));
+
+  function barHeight(score: number): string {
+    return `${(score / 5) * 100}%`;
+  }
+
+  onMount(() => {
+    loadMood();
+  });
+
+  async function handleSelect(score: number) {
+    selectedScore = score;
+    saving = true;
+    const entry = await saveMood(score, noteText.trim() || null);
+    saving = false;
+    if (entry) {
+      showNotification($t('mood.saved'), 'success');
+    } else {
+      showNotification($t('mood.error'), 'error');
+    }
+  }
+
+  async function handleSaveNote() {
+    if (selectedScore === null) return;
+    saving = true;
+    const entry = await saveMood(selectedScore, noteText.trim() || null);
+    saving = false;
+    if (entry) {
+      showNotification($t('mood.saved'), 'success');
+    } else {
+      showNotification($t('mood.error'), 'error');
+    }
+  }
+</script>
+
+<div class="mood-widget">
+  <span class="mood-title mono">{$t('mood.title')}</span>
+
+  <!-- Emoji selector -->
+  <div class="mood-selector">
+    {#each MOODS as m}
+      <button
+        class="mood-btn"
+        class:selected={selectedScore === m.score}
+        onclick={() => handleSelect(m.score)}
+        aria-label={$t('mood.scoreLabel', { values: { score: m.score } })}
+        title={$t('mood.scoreLabel', { values: { score: m.score } })}
+      >
+        <span class="mood-emoji">{m.emoji}</span>
+      </button>
+    {/each}
+  </div>
+
+  <!-- Optional note -->
+  <div class="mood-note-wrap">
+    <input
+      type="text"
+      class="mood-note-input"
+      bind:value={noteText}
+      placeholder={$t('mood.notePlaceholder')}
+      aria-label={$t('mood.notePlaceholder')}
+    />
+    <button
+      class="mood-note-save"
+      onclick={handleSaveNote}
+      disabled={saving || selectedScore === null}
+      aria-label={$t('common.save')}
+    >
+      {$t('common.save')}
+    </button>
+  </div>
+
+  <!-- 7-day history bar -->
+  <div class="mood-history">
+    <span class="mood-history-label">{$t('mood.history')}</span>
+    <div class="mood-bars">
+      {#each recentHistory as entry}
+        <div class="mood-bar-col" title={`${entry.entry_date}: ${entry.score}/5`}>
+          <div class="mood-bar-track">
+            <div class="mood-bar-fill" style="height: {barHeight(entry.score)};"></div>
+          </div>
+        </div>
+      {/each}
+      {#if recentHistory.length === 0}
+        <span class="mood-empty">{$t('mood.noHistory')}</span>
+      {/if}
+    </div>
+  </div>
+
+  <!-- Stats row -->
+  <div class="mood-stats-row">
+    <div class="mood-stat">
+      <span class="mood-stat-value mono">{$moodStats.average.toFixed(1)}</span>
+      <span class="mood-stat-label">{$t('mood.avg')}</span>
+    </div>
+    <div class="mood-stat-divider"></div>
+    <div class="mood-stat">
+      <span class="mood-stat-value mono">{$moodStats.streak}</span>
+      <span class="mood-stat-label">{$t('mood.streak')}</span>
+    </div>
+  </div>
+</div>
+
+<style>
+  .mood-widget {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 0 10px;
+    width: 100%;
+  }
+
+  .mood-title {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--text-primary);
+    letter-spacing: 0.14em;
+  }
+
+  /* ── Emoji selector ── */
+  .mood-selector {
+    display: flex;
+    gap: 4px;
+  }
+
+  .mood-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    cursor: pointer;
+    transition: all var(--t-fast);
+    padding: 0;
+    opacity: 0.5;
+  }
+
+  .mood-btn:hover {
+    opacity: 1;
+    border-color: var(--text-muted);
+  }
+
+  .mood-btn.selected {
+    opacity: 1;
+    border-color: var(--xp);
+    background: var(--elevated);
+    transform: scale(1.1);
+  }
+
+  .mood-emoji {
+    font-size: 16px;
+    line-height: 1;
+  }
+
+  /* ── Note input ── */
+  .mood-note-wrap {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+    max-width: 220px;
+  }
+
+  .mood-note-input {
+    flex: 1;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 4px 8px;
+    font-size: 11px;
+    font-family: var(--font-sans);
+    color: var(--text-primary);
+    outline: none;
+    transition: border-color var(--t-fast);
+  }
+
+  .mood-note-input::placeholder {
+    color: var(--text-muted);
+  }
+
+  .mood-note-input:focus {
+    border-color: var(--text-muted);
+  }
+
+  .mood-note-save {
+    padding: 4px 10px;
+    font-size: 10px;
+    font-family: var(--font-sans);
+    border: 1px solid var(--xp);
+    border-radius: var(--r);
+    background: var(--xp);
+    color: var(--xp-contrast-text, var(--bg));
+    cursor: pointer;
+    transition: all var(--t-fast);
+    white-space: nowrap;
+  }
+
+  .mood-note-save:hover:not(:disabled) {
+    background: var(--xp-2);
+    border-color: var(--xp-2);
+  }
+
+  .mood-note-save:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  /* ── History bar ── */
+  .mood-history {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+  }
+
+  .mood-history-label {
+    font-size: 9px;
+    color: var(--text-muted);
+    letter-spacing: 0.08em;
+  }
+
+  .mood-bars {
+    display: flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 36px;
+  }
+
+  .mood-bar-col {
+    display: flex;
+    align-items: flex-end;
+  }
+
+  .mood-bar-track {
+    width: 6px;
+    height: 36px;
+    background: var(--border);
+    border-radius: 2px;
+    overflow: hidden;
+    display: flex;
+    align-items: flex-end;
+  }
+
+  .mood-bar-fill {
+    width: 100%;
+    background: var(--xp);
+    border-radius: 2px;
+    transition: height var(--t-normal);
+  }
+
+  .mood-empty {
+    font-size: 9px;
+    color: var(--text-muted);
+  }
+
+  /* ── Stats row ── */
+  .mood-stats-row {
+    display: flex;
+    align-items: center;
+    gap: var(--s4);
+  }
+
+  .mood-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .mood-stat-value {
+    font-size: 16px;
+    font-weight: 300;
+    color: var(--text-primary);
+    line-height: 1;
+  }
+
+  .mood-stat-label {
+    font-size: 9px;
+    color: var(--text-muted);
+  }
+
+  .mood-stat-divider {
+    width: 1px;
+    height: 24px;
+    background: var(--border);
+  }
+</style>

--- a/frontend/src/lib/stores/layout.ts
+++ b/frontend/src/lib/stores/layout.ts
@@ -8,6 +8,7 @@ export type WidgetId =
   | 'time-widget'
   | 'weather-widget'
   | 'pomodoro'
+  | 'mood-tracker'
   | 'recent-notes'
   | 'github-issues';
 
@@ -24,6 +25,7 @@ export const WIDGET_REGISTRY: Record<WidgetId, WidgetMeta> = {
   'time-widget':       { id: 'time-widget',       label: 'Reloj',                  panel: 'left'  },
   'weather-widget': { id: 'weather-widget', label: 'Clima',         panel: 'left'  },
   'pomodoro':       { id: 'pomodoro',        label: 'Pomodoro',     panel: 'left'  },
+  'mood-tracker':   { id: 'mood-tracker',    label: 'Mood',         panel: 'left'  },
   'recent-notes':   { id: 'recent-notes',    label: 'Notas',        panel: 'right' },
   'github-issues':  { id: 'github-issues',   label: 'GitHub',       panel: 'right' },
 };
@@ -35,7 +37,7 @@ export interface DashboardLayout {
 }
 
 const DEFAULT: DashboardLayout = {
-  left:  ['plant-carousel', 'stats-xp', 'activity-progress', 'time-widget', 'pomodoro'],
+  left:  ['plant-carousel', 'stats-xp', 'activity-progress', 'time-widget', 'pomodoro', 'mood-tracker'],
   right: ['recent-notes', 'github-issues'],
 };
 

--- a/frontend/src/lib/stores/mood.ts
+++ b/frontend/src/lib/stores/mood.ts
@@ -1,0 +1,54 @@
+import { writable } from 'svelte/store';
+import { api, type MoodEntry, type MoodStats } from '$lib/api';
+import { logger } from '$lib/utils/logger';
+
+export const todayMood = writable<MoodEntry | null>(null);
+export const moodHistory = writable<MoodEntry[]>([]);
+export const moodStats = writable<MoodStats>({
+  average: 0,
+  streak: 0,
+  total_entries: 0,
+  notes_correlation: 0,
+});
+
+let loadedOnce = false;
+
+/** Load today's mood, recent history, and stats in parallel. */
+export async function loadMood(): Promise<void> {
+  try {
+    const [today, history, stats] = await Promise.all([
+      api.mood.today(),
+      api.mood.history(30),
+      api.mood.stats(),
+    ]);
+    todayMood.set(today);
+    moodHistory.set(history);
+    moodStats.set(stats);
+    loadedOnce = true;
+  } catch (e) {
+    logger.error('Failed to load mood data:', e);
+  }
+}
+
+/** Create or update today's mood, then refresh stats + history. */
+export async function saveMood(score: number, note?: string | null): Promise<MoodEntry | null> {
+  try {
+    const entry = await api.mood.create({ score, note: note ?? null });
+    todayMood.set(entry);
+    // Refresh history + stats so the widget reflects the new entry.
+    const [history, stats] = await Promise.all([api.mood.history(30), api.mood.stats()]);
+    moodHistory.set(history);
+    moodStats.set(stats);
+    return entry;
+  } catch (e) {
+    logger.error('Failed to save mood:', e);
+    return null;
+  }
+}
+
+/** Ensure mood data is loaded at least once per session. */
+export async function ensureMoodLoaded(): Promise<void> {
+  if (!loadedOnce) {
+    await loadMood();
+  }
+}

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -81,5 +81,16 @@
     "timeFormat": "Time format",
     "language": "Language",
     "languageHint": "The interface language"
+  },
+  "mood": {
+    "title": "MOOD",
+    "scoreLabel": "Mood {score} of 5",
+    "notePlaceholder": "Note (optional)",
+    "history": "Last 7 days",
+    "noHistory": "No entries yet",
+    "avg": "average",
+    "streak": "streak",
+    "saved": "Mood saved",
+    "error": "Failed to save mood"
   }
 }

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -81,5 +81,16 @@
     "timeFormat": "Formato de hora",
     "language": "Idioma",
     "languageHint": "El idioma de la interfaz"
+  },
+  "mood": {
+    "title": "ÁNIMO",
+    "scoreLabel": "Ánimo {score} de 5",
+    "notePlaceholder": "Nota (opcional)",
+    "history": "Últimos 7 días",
+    "noHistory": "Sin registros aún",
+    "avg": "promedio",
+    "streak": "racha",
+    "saved": "Ánimo guardado",
+    "error": "Error al guardar el ánimo"
   }
 }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -12,6 +12,7 @@
   import XPBar          from '$lib/components/XPBar.svelte';
   import NoteCard       from '$lib/components/NoteCard.svelte';
   import PomodoroWidget from '$lib/components/PomodoroWidget.svelte';
+  import MoodWidget from '$lib/components/MoodWidget.svelte';
   import { Target } from 'lucide-svelte';
   import { startFocusMode } from '$lib/stores/focusMode';
   import TimeWidget from '$lib/components/TimeWidget.svelte';
@@ -373,6 +374,8 @@
       <Target size={16} />
       Modo Enfoque
     </button>
+  {:else if wid === 'mood-tracker'}
+    <MoodWidget />
   {:else if wid === 'recent-notes'}
     <div class="section-header">
       <h4 style="color: {$accentColors[0]}">Notas recientes</h4>


### PR DESCRIPTION
## Summary

Implements the **Mood Tracker widget** — a daily mood selector (1-5 scale with emoji) that records mood entries and shows a small 7-day history bar. Part of the productivity widgets initiative (#392) alongside the existing Pomodoro widget and the separately-handled Quick Capture widget.

Closes #392 (mood tracker portion).

## Backend

- **`api/models/mood_entry.py`** — `MoodEntry` SQLAlchemy model: `id`, `user_id`, `score` (1-5), `note` (optional), `entry_date`, `created_at`, `updated_at`. Unique constraint on `(user_id, entry_date)` ensures one entry per user per day.
- **`api/services/mood_service.py`** — Service layer with:
  - `create_or_update_mood()` — upsert for today's mood
  - `get_today_mood()` — fetch today's entry
  - `get_mood_history()` — last N days of entries (oldest → newest)
  - `get_mood_stats()` — average score, current streak, total entries, notes correlation
- **`api/routers/mood.py`** — REST API:
  - `POST /mood` — create/update today's mood (score 1-5, optional note)
  - `GET /mood/today` — get today's mood
  - `GET /mood/history?days=30` — get mood history
  - `GET /mood/stats` — get mood statistics
  - All endpoints require auth via `get_current_user`
- **`api/alembic/versions/f6a7b8c9d0e1_add_mood_entries.py`** — Alembic migration for the `mood_entries` table
- **`api/tests/test_mood_service.py`** — 15 unit tests covering upsert, get today, history (range/clamping), and stats (average, streak, notes correlation)

## Frontend

- **`frontend/src/lib/components/MoodWidget.svelte`** — Widget component with:
  - 5 emoji buttons (😞 😟 😐 🙂 😄) mapping to scores 1-5
  - Today's selected mood highlighted
  - Optional note input with save button
  - 7-day history bar chart
  - Stats row (average + streak)
  - Uses Svelte 5 runes (`$state`, `$derived`, `$effect`)
  - i18n via `$t()` from svelte-i18n
  - Design tokens (CSS variables from app.css)
- **`frontend/src/lib/stores/mood.ts`** — Svelte store: `todayMood`, `moodHistory`, `moodStats` writables + `loadMood()` and `saveMood()` functions
- **`frontend/src/lib/api.ts`** — API client: `api.mood.create()`, `api.mood.today()`, `api.mood.history()`, `api.mood.stats()` + `MoodEntry`/`MoodStats` types
- **`frontend/src/lib/stores/layout.ts`** — Registered `mood-tracker` in `WidgetId`, `WIDGET_REGISTRY`, and `DEFAULT.left`
- **`frontend/src/routes/+page.svelte`** — Added `MoodWidget` import and render case in `renderWidget` snippet
- **`frontend/src/locales/{es,en}/common.json`** — Added `mood.*` i18n strings

## Test Plan

- [x] `python -m py_compile` passes on all new Python files
- [x] `pytest tests/test_mood_service.py` — 15/15 tests pass
- [x] `npm run check` — 0 errors (119 pre-existing warnings)
- [x] `ruff format` applied to new Python files
- [x] `prettier` applied to new frontend files
- [ ] Manual: select a mood emoji → entry saved → history bar updates
- [ ] Manual: add a note → save → stats refresh
- [ ] Manual: switch language (es/en) → all mood labels translate
- [ ] Manual: `make migrate` applies the new migration cleanly

Generated with [Devin](https://devin.ai)