### PR TITLE
feat: real-time vault sync via WebSocket broadcast (#73)

### DIFF
--- a/api/routers/sync.py
+++ b/api/routers/sync.py
@@ -5,12 +5,16 @@ Provides endpoints to list and resolve sync conflicts between
 Joidy and external sources (e.g. Obsidian).
 """
 
+from datetime import datetime, timezone
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, field_validator
 from services.sync_service import list_conflicts, resolve_conflict
 from sqlalchemy.orm import Session
 
 from database import get_db
+from models.note import Note
+from models.sync_state import SyncState
 
 router = APIRouter(prefix="/sync", tags=["sync"])
 
@@ -64,3 +68,36 @@ def resolve_note_conflict(
         raise HTTPException(status_code=400, detail=result["message"])
 
     return result
+
+
+@router.get("/status")
+def get_sync_status(db: Session = Depends(get_db)):
+    """Return the current vault sync status (#73).
+
+    Provides the last sync time, the number of pending conflicts, and the
+    total number of notes synced from Obsidian. The frontend polls this on
+    load to display a sync status indicator.
+    """
+    # Most recent successful sync across all notes.
+    last_sync_row = (
+        db.query(SyncState.last_synced_at)
+        .filter(SyncState.last_synced_at.isnot(None))
+        .order_by(SyncState.last_synced_at.desc())
+        .first()
+    )
+    last_sync_time = None
+    if last_sync_row and last_sync_row[0] is not None:
+        last_sync_time = last_sync_row[0].isoformat() + "Z"
+
+    # Pending (unresolved) conflicts.
+    pending_conflicts = db.query(SyncState).filter(SyncState.conflict.is_(True)).count()
+
+    # Total notes synced from Obsidian.
+    total_synced = db.query(Note).filter(Note.source == "obsidian").count()
+
+    return {
+        "last_sync_time": last_sync_time,
+        "pending_conflicts": pending_conflicts,
+        "total_synced": total_synced,
+        "server_time": datetime.now(timezone.utc).isoformat() + "Z",
+    }

--- a/api/routers/websocket.py
+++ b/api/routers/websocket.py
@@ -91,37 +91,76 @@ async def websocket_endpoint(
 
 async def notify_note_created(note_id: int, title: str):
     """Broadcast note creation to all clients."""
-    await manager.broadcast({
-        "type": "note_created",
-        "note_id": note_id,
-        "title": title,
-    })
+    await manager.broadcast(
+        {
+            "type": "note_created",
+            "note_id": note_id,
+            "title": title,
+        }
+    )
 
 
 async def notify_note_updated(note_id: int, title: str):
     """Broadcast note update to all clients."""
-    await manager.broadcast({
-        "type": "note_updated",
-        "note_id": note_id,
-        "title": title,
-    })
+    await manager.broadcast(
+        {
+            "type": "note_updated",
+            "note_id": note_id,
+            "title": title,
+        }
+    )
 
 
 async def notify_xp_gained(xp: int, total_xp: int):
     """Broadcast XP gain to all clients."""
-    await manager.broadcast({
-        "type": "xp_gained",
-        "xp": xp,
-        "total_xp": total_xp,
-    })
+    await manager.broadcast(
+        {
+            "type": "xp_gained",
+            "xp": xp,
+            "total_xp": total_xp,
+        }
+    )
 
 
 async def notify_streak_updated(streak: int):
     """Broadcast streak update to all clients."""
-    await manager.broadcast({
-        "type": "streak_updated",
-        "streak": streak,
-    })
+    await manager.broadcast(
+        {
+            "type": "streak_updated",
+            "streak": streak,
+        }
+    )
+
+
+async def notify_vault_synced(note_id: int, title: str, source_path: str | None = None):
+    """Broadcast a vault-synced note to all clients (#73).
+
+    Sent when a note is created or updated from the Obsidian vault so the
+    frontend can distinguish vault syncs from manual edits.
+    """
+    await manager.broadcast(
+        {
+            "type": "vault_synced",
+            "note_id": note_id,
+            "title": title,
+            "source_path": source_path,
+        }
+    )
+
+
+async def notify_vault_sync_started():
+    """Broadcast that a vault sync cycle has started (#73)."""
+    await manager.broadcast({"type": "vault_sync_started"})
+
+
+async def notify_vault_sync_complete(total_synced: int = 0):
+    """Broadcast that a vault sync cycle has completed (#73)."""
+    await manager.broadcast(
+        {
+            "type": "vault_sync_complete",
+            "total_synced": total_synced,
+        }
+    )
 
 
 def broadcast_note_created(note_id: int, title: str):
@@ -160,5 +199,35 @@ def broadcast_streak_updated(streak: int):
         loop = asyncio.get_running_loop()
         if loop.is_running():
             loop.create_task(notify_streak_updated(streak))
+    except RuntimeError:
+        pass
+
+
+def broadcast_vault_synced(note_id: int, title: str, source_path: str | None = None):
+    """Synchronous trigger to broadcast a vault-synced note (#73)."""
+    try:
+        loop = asyncio.get_running_loop()
+        if loop.is_running():
+            loop.create_task(notify_vault_synced(note_id, title, source_path))
+    except RuntimeError:
+        pass
+
+
+def broadcast_vault_sync_started():
+    """Synchronous trigger to broadcast vault sync start (#73)."""
+    try:
+        loop = asyncio.get_running_loop()
+        if loop.is_running():
+            loop.create_task(notify_vault_sync_started())
+    except RuntimeError:
+        pass
+
+
+def broadcast_vault_sync_complete(total_synced: int = 0):
+    """Synchronous trigger to broadcast vault sync completion (#73)."""
+    try:
+        loop = asyncio.get_running_loop()
+        if loop.is_running():
+            loop.create_task(notify_vault_sync_complete(total_synced))
     except RuntimeError:
         pass

--- a/api/services/note_service.py
+++ b/api/services/note_service.py
@@ -90,6 +90,7 @@ def sync_note_links(db: Session, source_note_id: int, content: str) -> None:
     # Batch-load all target notes in a single query instead of one per link.
     # Use OR of ilike conditions to avoid N+1 queries.
     from sqlalchemy import or_
+
     conditions = [Note.title.ilike(t) for t in unique_titles]
     targets = db.query(Note).filter(or_(*conditions)).all()
     for target in targets:
@@ -138,15 +139,27 @@ def create_note(
     if source_path and not from_vault:
         write_to_vault(note)
         from services.sync_service import update_local_mtime
+
         update_local_mtime(db, note.id)
         db.commit()
     clear_api_caches()
 
     try:
         from routers.websocket import broadcast_note_created
+
         broadcast_note_created(note.id, note.title)
     except Exception:
         pass
+
+    # Broadcast a vault_synced event when the note came from Obsidian so the
+    # frontend can distinguish vault syncs from manual creations (#73).
+    if source == "obsidian":
+        try:
+            from routers.websocket import broadcast_vault_synced
+
+            broadcast_vault_synced(note.id, note.title, note.source_path)
+        except Exception:
+            pass
 
     return note, gami
 
@@ -183,7 +196,7 @@ def update_note(
         if abs(len(content) - old_len) > 50:
             gami = process_event(db, "note_edited", {"note_id": note.id})
     if tags is not None:
-        touched_tag_ids = {tag_id for tag_id, in db.query(NoteTag.tag_id).filter(NoteTag.note_id == note_id).all()}
+        touched_tag_ids = {tag_id for (tag_id,) in db.query(NoteTag.tag_id).filter(NoteTag.note_id == note_id).all()}
         db.query(NoteTag).filter(NoteTag.note_id == note_id).delete()
         db.flush()
         for tag_name in tags:
@@ -211,15 +224,27 @@ def update_note(
     if content is not None and not from_vault:
         write_to_vault(note)
         from services.sync_service import update_local_mtime
+
         update_local_mtime(db, note.id)
         db.commit()
     clear_api_caches()
 
     try:
         from routers.websocket import broadcast_note_updated
+
         broadcast_note_updated(note.id, note.title)
     except Exception:
         pass
+
+    # Broadcast a vault_synced event when the update came from Obsidian so the
+    # frontend can distinguish vault syncs from manual edits (#73).
+    if from_vault or note.source == "obsidian":
+        try:
+            from routers.websocket import broadcast_vault_synced
+
+            broadcast_vault_synced(note.id, note.title, note.source_path)
+        except Exception:
+            pass
 
     return note, gami
 
@@ -233,6 +258,7 @@ def delete_note(db: Session, note_id: int) -> bool:
 
     # Revert XP awarded for note creation to prevent XP farming
     from models.gamification import UserStats, XPEvent
+
     stats = db.query(UserStats).filter(UserStats.id == 1).first()
     if stats:
         xp_to_revert = xp_for("note_created", db, 10)

--- a/api/tests/test_vault_sync_websocket.py
+++ b/api/tests/test_vault_sync_websocket.py
@@ -1,0 +1,283 @@
+"""Tests for real-time vault sync broadcasting via WebSocket (#73).
+
+Covers:
+- Creating a note with source="obsidian" triggers a `vault_synced` broadcast.
+- Updating a note from the vault triggers a `vault_synced` broadcast.
+- Creating a note with a non-obsidian source does NOT trigger `vault_synced`.
+- The ``GET /sync/status`` endpoint returns last_sync_time, pending_conflicts,
+  and total_synced.
+"""
+
+import sys
+import types
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+if "sqlite_vec" not in sys.modules:
+    _stub = types.ModuleType("sqlite_vec")
+    _stub.load = lambda _conn: None  # type: ignore
+    sys.modules["sqlite_vec"] = _stub
+
+from database import Base, get_db
+import main as main_module
+from main import app
+from middleware.rate_limit import _default_limiter
+from models.note import Note
+from models.sync_state import SyncState
+from services.auth_service import get_current_user
+
+# Prevent lifespan migrations during tests.
+main_module.init_db = lambda: None
+
+
+def _build_client(db_session):
+    """Build a TestClient wired to an isolated DB session."""
+
+    def override_get_db():
+        yield db_session
+
+    def override_get_current_user():
+        return 1
+
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    client = TestClient(app)
+    client._original_overrides = original_overrides  # type: ignore[attr-defined]
+    return client
+
+
+def _teardown_client(client):
+    app.dependency_overrides.clear()
+    app.dependency_overrides.update(client._original_overrides)  # type: ignore[attr-defined]
+
+
+class VaultSyncBroadcastTestBase(unittest.TestCase):
+    """Base class with in-memory SQLite + write_to_vault patched out."""
+
+    def setUp(self) -> None:
+        self.engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(self.engine)
+        with self.engine.begin() as conn:
+            try:
+                conn.execute(
+                    text(
+                        "CREATE TABLE IF NOT EXISTS tag_cooccurrences "
+                        "(tag_a_id INTEGER, tag_b_id INTEGER, weight INTEGER, "
+                        "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP)"
+                    )
+                )
+            except Exception:
+                pass
+        self.Session = sessionmaker(bind=self.engine)
+
+        self._vault_patcher = patch("services.note_service.write_to_vault", return_value=False)
+        self._vault_patcher.start()
+        # Disable rate limits for tests.
+        _default_limiter.requests_per_minute = 10_000
+        _default_limiter.auth_requests_per_minute = 10_000
+
+    def tearDown(self) -> None:
+        self._vault_patcher.stop()
+        self.engine.dispose()
+
+
+class TestVaultSyncedBroadcast(VaultSyncBroadcastTestBase):
+    """Creating/updating notes from Obsidian should broadcast vault_synced."""
+
+    def test_create_obsidian_note_broadcasts_vault_synced(self) -> None:
+        with self.Session() as db:
+            client = _build_client(db)
+            try:
+                with (
+                    patch("routers.websocket.broadcast_vault_synced") as mock_broadcast,
+                    patch("routers.websocket.broadcast_note_created"),
+                ):
+                    response = client.post(
+                        "/notes/",
+                        json={
+                            "title": "Vault Note",
+                            "content": "From Obsidian",
+                            "tags": ["vault"],
+                            "source": "obsidian",
+                            "source_path": "/vault/note.md",
+                        },
+                        headers={"X-From-Vault": "1"},
+                    )
+                    self.assertEqual(response.status_code, 201)
+                    mock_broadcast.assert_called_once()
+                    call_args = mock_broadcast.call_args
+                    self.assertEqual(call_args.args[1], "Vault Note")
+            finally:
+                _teardown_client(client)
+
+    def test_create_non_obsidian_note_does_not_broadcast_vault_synced(self) -> None:
+        with self.Session() as db:
+            client = _build_client(db)
+            try:
+                with (
+                    patch("routers.websocket.broadcast_vault_synced") as mock_broadcast,
+                    patch("routers.websocket.broadcast_note_created"),
+                ):
+                    response = client.post(
+                        "/notes/",
+                        json={
+                            "title": "Manual Note",
+                            "content": "Typed by hand",
+                            "tags": [],
+                            "source": "joidy",
+                        },
+                    )
+                    self.assertEqual(response.status_code, 201)
+                    mock_broadcast.assert_not_called()
+            finally:
+                _teardown_client(client)
+
+    def test_update_obsidian_note_broadcasts_vault_synced(self) -> None:
+        with self.Session() as db:
+            client = _build_client(db)
+            try:
+                # Create an obsidian note first.
+                create_res = client.post(
+                    "/notes/",
+                    json={
+                        "title": "Original Vault",
+                        "content": "v1",
+                        "tags": [],
+                        "source": "obsidian",
+                        "source_path": "/vault/update.md",
+                    },
+                    headers={"X-From-Vault": "1"},
+                )
+                note_id = create_res.json()["id"]
+
+                with (
+                    patch("routers.websocket.broadcast_vault_synced") as mock_broadcast,
+                    patch("routers.websocket.broadcast_note_updated"),
+                ):
+                    update_res = client.put(
+                        f"/notes/{note_id}",
+                        json={
+                            "title": "Updated Vault",
+                            "content": "v2 with more text to trigger edit event",
+                            "source": "obsidian",
+                            "source_path": "/vault/update.md",
+                        },
+                        headers={"X-From-Vault": "1"},
+                    )
+                    self.assertEqual(update_res.status_code, 200)
+                    mock_broadcast.assert_called_once()
+                    self.assertEqual(mock_broadcast.call_args.args[1], "Updated Vault")
+            finally:
+                _teardown_client(client)
+
+
+class TestSyncStatusEndpoint(VaultSyncBroadcastTestBase):
+    """GET /sync/status returns last_sync_time, pending_conflicts, total_synced."""
+
+    def test_status_empty_database(self) -> None:
+        with self.Session() as db:
+            client = _build_client(db)
+            try:
+                response = client.get("/sync/status")
+                self.assertEqual(response.status_code, 200)
+                data = response.json()
+                self.assertIsNone(data["last_sync_time"])
+                self.assertEqual(data["pending_conflicts"], 0)
+                self.assertEqual(data["total_synced"], 0)
+                self.assertIsNotNone(data["server_time"])
+            finally:
+                _teardown_client(client)
+
+    def test_status_counts_obsidian_notes(self) -> None:
+        with self.Session() as db:
+            db.add(Note(title="A", content="c", source="obsidian", source_path="/v/a.md"))
+            db.add(Note(title="B", content="c", source="obsidian", source_path="/v/b.md"))
+            db.add(Note(title="C", content="c", source="joidy"))
+            db.commit()
+
+            client = _build_client(db)
+            try:
+                response = client.get("/sync/status")
+                self.assertEqual(response.status_code, 200)
+                data = response.json()
+                self.assertEqual(data["total_synced"], 2)
+            finally:
+                _teardown_client(client)
+
+    def test_status_reports_pending_conflicts(self) -> None:
+        with self.Session() as db:
+            note = Note(title="Conflicted", content="c", source="obsidian", source_path="/v/c.md")
+            db.add(note)
+            db.flush()
+            db.add(
+                SyncState(
+                    note_id=note.id,
+                    conflict=True,
+                    local_mtime=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    remote_mtime=datetime(2024, 1, 2, tzinfo=timezone.utc),
+                )
+            )
+            db.commit()
+
+            client = _build_client(db)
+            try:
+                response = client.get("/sync/status")
+                self.assertEqual(response.status_code, 200)
+                data = response.json()
+                self.assertEqual(data["pending_conflicts"], 1)
+            finally:
+                _teardown_client(client)
+
+    def test_status_reports_last_sync_time(self) -> None:
+        with self.Session() as db:
+            note = Note(title="Synced", content="c", source="obsidian", source_path="/v/s.md")
+            db.add(note)
+            db.flush()
+            sync_time = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+            db.add(SyncState(note_id=note.id, conflict=False, last_synced_at=sync_time))
+            db.commit()
+
+            client = _build_client(db)
+            try:
+                response = client.get("/sync/status")
+                self.assertEqual(response.status_code, 200)
+                data = response.json()
+                self.assertIsNotNone(data["last_sync_time"])
+                self.assertIn("2024-06-15", data["last_sync_time"])
+            finally:
+                _teardown_client(client)
+
+
+class TestWebSocketBroadcastFunctions(unittest.TestCase):
+    """The broadcast_* helper functions schedule tasks on the running loop."""
+
+    def test_broadcast_vault_synced_no_running_loop_is_noop(self) -> None:
+        # Outside an event loop, broadcast_vault_synced should not raise.
+        from routers.websocket import broadcast_vault_synced
+
+        broadcast_vault_synced(1, "Test", "/vault/test.md")  # should not raise
+
+    def test_broadcast_vault_sync_started_no_running_loop_is_noop(self) -> None:
+        from routers.websocket import broadcast_vault_sync_started
+
+        broadcast_vault_sync_started()  # should not raise
+
+    def test_broadcast_vault_sync_complete_no_running_loop_is_noop(self) -> None:
+        from routers.websocket import broadcast_vault_sync_complete
+
+        broadcast_vault_sync_complete(5)  # should not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,9 +6,9 @@ import { showNotification } from './stores/notifications';
 import { session, getToken } from './stores/session';
 
 const BASE = browser
-  ? (import.meta.env.VITE_API_URL as string ||
-    `${window.location.protocol}//${window.location.hostname}:8000`)
-  : (import.meta.env.VITE_INTERNAL_API_URL as string || 'http://api:8000');
+  ? (import.meta.env.VITE_API_URL as string) ||
+    `${window.location.protocol}//${window.location.hostname}:8000`
+  : (import.meta.env.VITE_INTERNAL_API_URL as string) || 'http://api:8000';
 
 let isHandlingLogout = false;
 
@@ -21,7 +21,12 @@ export interface RequestOptions {
   signal?: AbortSignal;
 }
 
-async function req<T>(method: string, path: string, body?: unknown, opts?: RequestOptions): Promise<T> {
+async function req<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  opts?: RequestOptions
+): Promise<T> {
   const silent = opts?.silent ?? false;
   const signal = opts?.signal;
 
@@ -64,7 +69,9 @@ async function req<T>(method: string, path: string, body?: unknown, opts?: Reque
         try {
           const parsed = JSON.parse(raw);
           userMsg = parsed.detail || parsed.message || parsed.error || raw;
-        } catch { /* not JSON, use raw text */ }
+        } catch {
+          /* not JSON, use raw text */
+        }
 
         // Map non-actionable server errors to friendlier messages
         if (res.status === 502 || res.status === 503) {
@@ -83,7 +90,12 @@ async function req<T>(method: string, path: string, body?: unknown, opts?: Reque
       // AbortError is expected when a component unmounts mid-request — don't
       // show a network error notification for it (#350).
       if (error.name === 'AbortError') throw error;
-      if (!silent && (error.name === 'TypeError' || error.message.includes('Failed to fetch') || error.message.includes('fetch failed'))) {
+      if (
+        !silent &&
+        (error.name === 'TypeError' ||
+          error.message.includes('Failed to fetch') ||
+          error.message.includes('fetch failed'))
+      ) {
         showNotification('Error de red. No se pudo conectar con el servidor.', 'error');
       }
       throw error;
@@ -156,9 +168,21 @@ export interface Skill {
   first_unlocked_at: string | null;
 }
 
-export interface SkillNode { id: number; name: string; level: string; note_count: number; xp: number; }
-export interface SkillEdge { source: number; target: number; }
-export interface SkillTree { nodes: SkillNode[]; edges: SkillEdge[]; }
+export interface SkillNode {
+  id: number;
+  name: string;
+  level: string;
+  note_count: number;
+  xp: number;
+}
+export interface SkillEdge {
+  source: number;
+  target: number;
+}
+export interface SkillTree {
+  nodes: SkillNode[];
+  edges: SkillEdge[];
+}
 
 export interface Goal {
   id: number;
@@ -197,10 +221,22 @@ export interface GraphNode {
   tags?: string[];
   group: string;
 }
-export interface GraphEdge { source: number | string; target: number | string; type: 'hierarchy' | 'cooccurrence' | 'linked' | 'tagged'; weight?: number; }
-export interface GraphData { nodes: GraphNode[]; edges: GraphEdge[]; }
+export interface GraphEdge {
+  source: number | string;
+  target: number | string;
+  type: 'hierarchy' | 'cooccurrence' | 'linked' | 'tagged';
+  weight?: number;
+}
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
 
-export interface AISuggestion { tag: string; confidence: number; is_new: boolean; }
+export interface AISuggestion {
+  tag: string;
+  confidence: number;
+  is_new: boolean;
+}
 
 export interface StreakDay {
   date: string;
@@ -272,6 +308,41 @@ export interface MoodStats {
   notes_correlation: number;
 }
 
+export interface UsageEventValue {
+  feature?: string;
+  path?: string;
+  count: number;
+}
+
+export interface UsageSummary {
+  days: number;
+  total_events: number;
+  session_count: number;
+  active_days: number;
+  avg_session_duration_min: number;
+  top_features: { feature: string; count: number }[];
+  top_pages: { path: string; count: number }[];
+}
+
+export interface AnalyticsDashboard {
+  system: {
+    notes: number;
+    tags: number;
+    goals: number;
+    skills: number;
+    total_xp: number;
+    current_streak: number;
+    xp_events_week: number;
+  };
+  activity: { days: { date: string; notes_created: number; xp_events: number }[] };
+  mood: {
+    stats: MoodStats;
+    history: { entry_date: string; score: number }[];
+  };
+  ai_usage: { ai_enabled: boolean; estimated_cost_usd: number; [k: string]: unknown };
+  usage: UsageSummary;
+}
+
 // ── Notes ─────────────────────────────────────────────────────────────────────
 
 export interface SyncConflict {
@@ -285,42 +356,74 @@ export interface SyncConflict {
 
 export const api = {
   auth: {
-    login: (password: string, username = 'user') => 
-      req<{ access_token: string; token_type: string }>('POST', `/auth/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`),
-    status: () => 
-      req<{ enabled: boolean; has_password: boolean }>('GET', '/auth/status')
+    login: (password: string, username = 'user') =>
+      req<{ access_token: string; token_type: string }>(
+        'POST',
+        `/auth/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`
+      ),
+    status: () => req<{ enabled: boolean; has_password: boolean }>('GET', '/auth/status'),
   },
-  
+
   notes: {
-    list:   (tag?: string, limit = 1000) => req<Note[]>('GET', `/notes/?limit=${limit}${tag ? `&tag=${encodeURIComponent(tag)}` : ''}`),
-    get:    (id: number)   => req<Note>('GET', `/notes/${id}`),
-    create: (data: { title: string; content: string; tags: string[]; source_path?: string | null; source?: string }) =>
-      req<Note & { gamification: GamificationResult }>('POST', '/notes/', data),
-    update: (id: number, data: Partial<{ title: string; content: string; tags: string[]; source_path: string | null }>) =>
-      req<Note & { gamification: GamificationResult }>('PUT', `/notes/${id}`, data),
-    delete: (id: number)   => req<void>('DELETE', `/notes/${id}`),
-    bulkDelete: (ids: number[]) => req<{ deleted: number; total: number }>('POST', '/notes/bulk-delete', { ids }),
-    bulkTag: (ids: number[], tags: string[]) => req<{ added: number; notes: number; tags: string[] }>('POST', '/notes/bulk-tag', { ids, tags }),
-    bulkUntag: (ids: number[], tags: string[]) => req<{ removed: number; notes: number; tags: string[] }>('POST', '/notes/bulk-untag', { ids, tags }),
+    list: (tag?: string, limit = 1000) =>
+      req<Note[]>('GET', `/notes/?limit=${limit}${tag ? `&tag=${encodeURIComponent(tag)}` : ''}`),
+    get: (id: number) => req<Note>('GET', `/notes/${id}`),
+    create: (data: {
+      title: string;
+      content: string;
+      tags: string[];
+      source_path?: string | null;
+      source?: string;
+    }) => req<Note & { gamification: GamificationResult }>('POST', '/notes/', data),
+    update: (
+      id: number,
+      data: Partial<{ title: string; content: string; tags: string[]; source_path: string | null }>
+    ) => req<Note & { gamification: GamificationResult }>('PUT', `/notes/${id}`, data),
+    delete: (id: number) => req<void>('DELETE', `/notes/${id}`),
+    bulkDelete: (ids: number[]) =>
+      req<{ deleted: number; total: number }>('POST', '/notes/bulk-delete', { ids }),
+    bulkTag: (ids: number[], tags: string[]) =>
+      req<{ added: number; notes: number; tags: string[] }>('POST', '/notes/bulk-tag', {
+        ids,
+        tags,
+      }),
+    bulkUntag: (ids: number[], tags: string[]) =>
+      req<{ removed: number; notes: number; tags: string[] }>('POST', '/notes/bulk-untag', {
+        ids,
+        tags,
+      }),
     acceptTag: (noteId: number, tag: string) =>
-      req<{ tag: string; gamification: GamificationResult }>('POST', `/notes/${noteId}/accept-tag?tag_name=${encodeURIComponent(tag)}`),
+      req<{ tag: string; gamification: GamificationResult }>(
+        'POST',
+        `/notes/${noteId}/accept-tag?tag_name=${encodeURIComponent(tag)}`
+      ),
     backlinks: (id: number) => req<Note[]>('GET', `/notes/${id}/backlinks`),
-    similar: (id: number, limit = 5) => req<{ note: Note; score: number }[]>('GET', `/notes/${id}/similar?limit=${limit}`),
+    similar: (id: number, limit = 5) =>
+      req<{ note: Note; score: number }[]>('GET', `/notes/${id}/similar?limit=${limit}`),
     semanticSearch: (query: string, limit = 10, threshold = 0.3) =>
-      req<{ results: { note: Note; score: number }[] }>('POST', '/notes/search/semantic', { query, limit, threshold }),
+      req<{ results: { note: Note; score: number }[] }>('POST', '/notes/search/semantic', {
+        query,
+        limit,
+        threshold,
+      }),
   },
 
   tags: {
-    list:  ()           => req<Tag[]>('GET', '/tags/'),
-    graph: ()           => req<GraphData>('GET', '/tags/graph'),
+    list: () => req<Tag[]>('GET', '/tags/'),
+    graph: () => req<GraphData>('GET', '/tags/graph'),
     create: (name: string, parent_id?: number) => req<Tag>('POST', '/tags/', { name, parent_id }),
   },
 
   gamification: {
-    stats:   ()          => req<GamificationStats>('GET', '/gamification/stats'),
-    ping:    ()          => req<GamificationResult>('POST', '/gamification/ping'),
-    history: (days = 30) => req<{ date: string; xp: number }[]>('GET', `/gamification/streak-history?days=${days}`),
-    events:  (limit = 20)=> req<{ type: string; xp: number; at: string }[]>('GET', `/gamification/recent-events?limit=${limit}`),
+    stats: () => req<GamificationStats>('GET', '/gamification/stats'),
+    ping: () => req<GamificationResult>('POST', '/gamification/ping'),
+    history: (days = 30) =>
+      req<{ date: string; xp: number }[]>('GET', `/gamification/streak-history?days=${days}`),
+    events: (limit = 20) =>
+      req<{ type: string; xp: number; at: string }[]>(
+        'GET',
+        `/gamification/recent-events?limit=${limit}`
+      ),
   },
 
   skills: {
@@ -330,25 +433,78 @@ export const api = {
   },
 
   goals: {
-    list:     (skip?: number, limit?: number) => req<Goal[]>('GET', `/goals/${skip !== undefined || limit !== undefined ? `?${skip !== undefined ? `skip=${skip}&` : ''}${limit !== undefined ? `limit=${limit}` : ''}` : ''}`),
-    get:      (id: number)        => req<Goal>('GET', `/goals/${id}`),
-    create:   (data: { title: string; description?: string; temporality?: string; measurement_type?: string; target_value?: number; fail_config?: string; fail_emoji?: string; color?: string; theme?: string; tag_id?: number | null; note_id?: number | null; parent_id?: number | null; max_assignment_days?: number | null }) =>
-      req<Goal>('POST', '/goals/', data),
-    update:   (id: number, data: Partial<Goal>) => req<Goal>('PUT', `/goals/${id}`, data),
+    list: (skip?: number, limit?: number) =>
+      req<Goal[]>(
+        'GET',
+        `/goals/${skip !== undefined || limit !== undefined ? `?${skip !== undefined ? `skip=${skip}&` : ''}${limit !== undefined ? `limit=${limit}` : ''}` : ''}`
+      ),
+    get: (id: number) => req<Goal>('GET', `/goals/${id}`),
+    create: (data: {
+      title: string;
+      description?: string;
+      temporality?: string;
+      measurement_type?: string;
+      target_value?: number;
+      fail_config?: string;
+      fail_emoji?: string;
+      color?: string;
+      theme?: string;
+      tag_id?: number | null;
+      note_id?: number | null;
+      parent_id?: number | null;
+      max_assignment_days?: number | null;
+    }) => req<Goal>('POST', '/goals/', data),
+    update: (id: number, data: Partial<Goal>) => req<Goal>('PUT', `/goals/${id}`, data),
     complete: (id: number) =>
       req<{ goal: Goal; gamification: GamificationResult }>('POST', `/goals/${id}/complete`),
-    delete:   (id: number) => req<void>('DELETE', `/goals/${id}`),
-    streak:   () => req<{ current_streak: number; best_streak: number }>('GET', '/goals/streak'),
+    delete: (id: number) => req<void>('DELETE', `/goals/${id}`),
+    streak: () => req<{ current_streak: number; best_streak: number }>('GET', '/goals/streak'),
     resolveRemoval: (id: number, action: 'delete' | 'manual' | 'cancel') =>
       req<Goal | { status: string }>('POST', `/goals/${id}/resolve-removal`, { action }),
-    getContent:  (id: number) => req<{ title: string; content: string; temporality?: string; measurement_type?: string; state?: string; fail_config?: string; fail_emoji?: string; color?: string }>('GET', `/goals/${id}/content`),
-    saveContent: (id: number, data: { title: string; content: string; temporality?: string; measurement_type?: string; target_value?: number; state?: string; fail_config?: string; fail_emoji?: string; color?: string; theme?: string; note_id?: number | null; tag_id?: number | null; parent_id?: number | null; max_assignment_days?: number | null; description?: string }) =>
-      req<Goal>('POST', `/goals/${id}/content`, data),
+    getContent: (id: number) =>
+      req<{
+        title: string;
+        content: string;
+        temporality?: string;
+        measurement_type?: string;
+        state?: string;
+        fail_config?: string;
+        fail_emoji?: string;
+        color?: string;
+      }>('GET', `/goals/${id}/content`),
+    saveContent: (
+      id: number,
+      data: {
+        title: string;
+        content: string;
+        temporality?: string;
+        measurement_type?: string;
+        target_value?: number;
+        state?: string;
+        fail_config?: string;
+        fail_emoji?: string;
+        color?: string;
+        theme?: string;
+        note_id?: number | null;
+        tag_id?: number | null;
+        parent_id?: number | null;
+        max_assignment_days?: number | null;
+        description?: string;
+      }
+    ) => req<Goal>('POST', `/goals/${id}/content`, data),
   },
 
   planning: {
-    getAssignments: (date: string) => req<{ date: string; goal_ids: number[] }>('GET', `/planning/assignments?date=${encodeURIComponent(date)}`),
-    setAssignments: (date: string, goal_ids: number[]) => req<{ date: string; goal_ids: number[] }>('POST', '/planning/assignments', { date, goal_ids }),
+    getAssignments: (date: string) =>
+      req<{ date: string; goal_ids: number[] }>(
+        'GET',
+        `/planning/assignments?date=${encodeURIComponent(date)}`
+      ),
+    setAssignments: (date: string, goal_ids: number[]) =>
+      req<{ date: string; goal_ids: number[] }>('POST', '/planning/assignments', {
+        date,
+        goal_ids,
+      }),
   },
 
   personalStreaks: {
@@ -360,82 +516,193 @@ export const api = {
       return req<PersonalStreak[]>('GET', `/personal-streaks/${qs ? '?' + qs : ''}`);
     },
     create: (data: {
-      name: string; emoji?: string; icon?: string; description?: string;
-      color?: string; theme?: string; category?: string;
-      start_date?: string | null; target_date?: string | null;
-      offset?: number; frequency?: string; frequency_days?: number;
+      name: string;
+      emoji?: string;
+      icon?: string;
+      description?: string;
+      color?: string;
+      theme?: string;
+      category?: string;
+      start_date?: string | null;
+      target_date?: string | null;
+      offset?: number;
+      frequency?: string;
+      frequency_days?: number;
       freeze_count?: number;
     }) => req<PersonalStreak>('POST', '/personal-streaks/', data),
-    update: (id: number, data: {
-      name?: string; emoji?: string; icon?: string; description?: string;
-      color?: string; theme?: string; category?: string;
-      start_date?: string | null; target_date?: string | null;
-      offset?: number; frequency?: string; frequency_days?: number;
-      is_archived?: boolean; freeze_count?: number;
-    }) => req<PersonalStreak>('PUT', `/personal-streaks/${id}`, data),
-    delete:   (id: number)        => req<void>('DELETE', `/personal-streaks/${id}`),
-    checkin:  (id: number, data?: { note?: string; mood?: number; check_date?: string }) =>
+    update: (
+      id: number,
+      data: {
+        name?: string;
+        emoji?: string;
+        icon?: string;
+        description?: string;
+        color?: string;
+        theme?: string;
+        category?: string;
+        start_date?: string | null;
+        target_date?: string | null;
+        offset?: number;
+        frequency?: string;
+        frequency_days?: number;
+        is_archived?: boolean;
+        freeze_count?: number;
+      }
+    ) => req<PersonalStreak>('PUT', `/personal-streaks/${id}`, data),
+    delete: (id: number) => req<void>('DELETE', `/personal-streaks/${id}`),
+    checkin: (id: number, data?: { note?: string; mood?: number; check_date?: string }) =>
       req<PersonalStreak>('POST', `/personal-streaks/${id}/checkin`, data || {}),
-    undo:     (id: number)        => req<PersonalStreak>('DELETE', `/personal-streaks/${id}/checkin`),
-    freeze:   (id: number)        => req<PersonalStreak>('POST', `/personal-streaks/${id}/freeze`),
-    stats:    ()                  => req<StreakStats>('GET', '/personal-streaks/stats'),
-    categories: ()                => req<string[]>('GET', '/personal-streaks/categories'),
-    history:  (id: number, days = 90) => req<{ date: string; note: string; mood: number | null; created_at: string }[]>('GET', `/personal-streaks/${id}/history?days=${days}`),
+    undo: (id: number) => req<PersonalStreak>('DELETE', `/personal-streaks/${id}/checkin`),
+    freeze: (id: number) => req<PersonalStreak>('POST', `/personal-streaks/${id}/freeze`),
+    stats: () => req<StreakStats>('GET', '/personal-streaks/stats'),
+    categories: () => req<string[]>('GET', '/personal-streaks/categories'),
+    history: (id: number, days = 90) =>
+      req<{ date: string; note: string; mood: number | null; created_at: string }[]>(
+        'GET',
+        `/personal-streaks/${id}/history?days=${days}`
+      ),
   },
 
   mood: {
     create: (data: { score: number; note?: string | null }) =>
       req<MoodEntry>('POST', '/mood/', data),
-    today:  () => req<MoodEntry | null>('GET', '/mood/today'),
+    today: () => req<MoodEntry | null>('GET', '/mood/today'),
     history: (days = 30) => req<MoodEntry[]>('GET', `/mood/history?days=${days}`),
-    stats:   () => req<MoodStats>('GET', '/mood/stats'),
+    stats: () => req<MoodStats>('GET', '/mood/stats'),
   },
 
   ai: {
     classify: (noteId: number, content: string, existingTags: string[]) =>
-      req<{ note_id: number; status: string; suggestions: AISuggestion[] }>('POST', '/ai/classify', { note_id: noteId, content, existing_tags: existingTags }, { silent: true }),
+      req<{ note_id: number; status: string; suggestions: AISuggestion[] }>(
+        'POST',
+        '/ai/classify',
+        { note_id: noteId, content, existing_tags: existingTags },
+        { silent: true }
+      ),
     usage: () => req<{ ai_enabled: boolean; estimated_cost_usd: number }>('GET', '/ai/usage'),
     dailyRecap: (date?: string) =>
-      req<{ status: string; recap: string; suggestions: string[]; provider?: string }>('POST', `/ai/daily-recap${date ? `?target_date=${encodeURIComponent(date)}` : ''}`),
+      req<{ status: string; recap: string; suggestions: string[]; provider?: string }>(
+        'POST',
+        `/ai/daily-recap${date ? `?target_date=${encodeURIComponent(date)}` : ''}`
+      ),
     cluster: (eps = 0.3, minSamples = 3, maxNotes = 500) =>
-      req<{ clusters: { cluster_id: number; note_ids: number[]; note_count: number; representative_title: string; titles: string[] }[]; total_notes: number; noise_count: number; error?: string }>('POST', `/ai/cluster?eps=${eps}&min_samples=${minSamples}&max_notes=${maxNotes}`),
+      req<{
+        clusters: {
+          cluster_id: number;
+          note_ids: number[];
+          note_count: number;
+          representative_title: string;
+          titles: string[];
+        }[];
+        total_notes: number;
+        noise_count: number;
+        error?: string;
+      }>('POST', `/ai/cluster?eps=${eps}&min_samples=${minSamples}&max_notes=${maxNotes}`),
     chat: (messages: { role: 'user' | 'assistant'; content: string }[]) =>
-      req<{ status: string; response: string; suggestions?: string[]; provider?: string }>('POST', '/ai/chat', { messages }, { silent: true }),
+      req<{ status: string; response: string; suggestions?: string[]; provider?: string }>(
+        'POST',
+        '/ai/chat',
+        { messages },
+        { silent: true }
+      ),
   },
 
-github: {
-    status: () => req<{ connected: boolean; username: string | null }>('GET', '/integrations/github/status'),
-    issues: (filter: string = 'all') => req<{ issues: { id: number; number: number; title: string; repo: string; url: string; state: string; updated_at: string; author?: string }[]; stats: { total: number; open: number; closed: number }; filter: string }>('GET', `/integrations/github/issues?filter=${filter}`),
-    pulls: (filter: string = 'all') => req<{ pulls: { id: number; number: number; title: string; repo: string; url: string; state: string; draft: boolean; updated_at: string; author?: string }[]; stats: { total: number; open: number; closed: number; draft: number }; filter: string }>('GET', `/integrations/github/pulls?filter=${filter}`),
-    repos: () => req<{ repos: { id: number; name: string; full_name: string; color: string }[] }>('GET', '/integrations/github/repos'),
-    startDeviceAuth: () => req<{ device_code: string; user_code: string; verification_uri: string; verification_uri_secondary?: string; expires_in: number; interval: number }>('GET', '/integrations/github/oauth/device/start'),
-    pollDeviceCode: (device_code: string) => req<{ status: 'authorized'; access_token: string; token_type: string; scope: string } | { status: 'pending' | 'slowdown' | 'expired' | 'denied'; message: string }>('POST', `/integrations/github/oauth/device/polling?device_code=${encodeURIComponent(device_code)}`),
-    startWebFlow: () => req<{ authorize_url: string; redirect_uri: string }>('GET', '/integrations/github/oauth/web/start'),
-    oauthCallback: (code: string, state?: string) => req<{ status: string; access_token: string; token_type: string; scope: string }>('GET', `/integrations/github/oauth/callback?code=${encodeURIComponent(code)}${state ? `&state=${encodeURIComponent(state)}` : ''}`),
+  github: {
+    status: () =>
+      req<{ connected: boolean; username: string | null }>('GET', '/integrations/github/status'),
+    issues: (filter: string = 'all') =>
+      req<{
+        issues: {
+          id: number;
+          number: number;
+          title: string;
+          repo: string;
+          url: string;
+          state: string;
+          updated_at: string;
+          author?: string;
+        }[];
+        stats: { total: number; open: number; closed: number };
+        filter: string;
+      }>('GET', `/integrations/github/issues?filter=${filter}`),
+    pulls: (filter: string = 'all') =>
+      req<{
+        pulls: {
+          id: number;
+          number: number;
+          title: string;
+          repo: string;
+          url: string;
+          state: string;
+          draft: boolean;
+          updated_at: string;
+          author?: string;
+        }[];
+        stats: { total: number; open: number; closed: number; draft: number };
+        filter: string;
+      }>('GET', `/integrations/github/pulls?filter=${filter}`),
+    repos: () =>
+      req<{ repos: { id: number; name: string; full_name: string; color: string }[] }>(
+        'GET',
+        '/integrations/github/repos'
+      ),
+    startDeviceAuth: () =>
+      req<{
+        device_code: string;
+        user_code: string;
+        verification_uri: string;
+        verification_uri_secondary?: string;
+        expires_in: number;
+        interval: number;
+      }>('GET', '/integrations/github/oauth/device/start'),
+    pollDeviceCode: (device_code: string) =>
+      req<
+        | { status: 'authorized'; access_token: string; token_type: string; scope: string }
+        | { status: 'pending' | 'slowdown' | 'expired' | 'denied'; message: string }
+      >(
+        'POST',
+        `/integrations/github/oauth/device/polling?device_code=${encodeURIComponent(device_code)}`
+      ),
+    startWebFlow: () =>
+      req<{ authorize_url: string; redirect_uri: string }>(
+        'GET',
+        '/integrations/github/oauth/web/start'
+      ),
+    oauthCallback: (code: string, state?: string) =>
+      req<{ status: string; access_token: string; token_type: string; scope: string }>(
+        'GET',
+        `/integrations/github/oauth/callback?code=${encodeURIComponent(code)}${state ? `&state=${encodeURIComponent(state)}` : ''}`
+      ),
     revoke: () => req<{ status: string }>('POST', '/integrations/github/oauth/revoke'),
   },
 
   google: {
     authUrl: () => req<{ url: string }>('GET', '/integrations/google/auth'),
     connect: (code: string) =>
-      req<{ status: string; scope: string | null }>('POST', '/integrations/google/connect', { code }),
+      req<{ status: string; scope: string | null }>('POST', '/integrations/google/connect', {
+        code,
+      }),
     status: () => req<{ connected: boolean }>('GET', '/integrations/google/status'),
     disconnect: () => req<{ status: string }>('POST', '/integrations/google/disconnect'),
   },
 
   config: {
     setupStatus: () => req<{ needs_setup: boolean }>('GET', '/config/setup-status'),
-    setup: (auth_password: string, obsidian_vault_path?: string) => 
-      req<{ status: string; message: string }>('POST', '/config/setup', { auth_password, obsidian_vault_path }),
+    setup: (auth_password: string, obsidian_vault_path?: string) =>
+      req<{ status: string; message: string }>('POST', '/config/setup', {
+        auth_password,
+        obsidian_vault_path,
+      }),
 
-    get: () => req<{
-      gemini_api_key: string | null;
-      obsidian_vault_path: string | null;
-      daily_notes_folder: string | null;
-      github_username: string | null;
-      app_env: string | null;
-      configured_keys: string[];
-    }>('GET', '/config/'),
+    get: () =>
+      req<{
+        gemini_api_key: string | null;
+        obsidian_vault_path: string | null;
+        daily_notes_folder: string | null;
+        github_username: string | null;
+        app_env: string | null;
+        configured_keys: string[];
+      }>('GET', '/config/'),
     update: (data: {
       gemini_api_key?: string;
       obsidian_vault_path?: string;
@@ -447,38 +714,58 @@ github: {
       telegram_bot_token?: string;
       telegram_allowed_user_id?: string;
     }) => req<{ status: string; message: string }>('POST', '/config/', data),
-    keys: () => req<{
-      keys: { key: string; env_key: string; public: boolean; description: string }[];
-    }>('GET', '/config/keys'),
-    gamification: () => req<{
-      xp_table: Record<string, number>;
-      plant_stages: { stage: number; name: string; xp_required: number }[];
-      streak_milestones: number[];
-    }>('GET', '/config/gamification'),
+    keys: () =>
+      req<{
+        keys: { key: string; env_key: string; public: boolean; description: string }[];
+      }>('GET', '/config/keys'),
+    gamification: () =>
+      req<{
+        xp_table: Record<string, number>;
+        plant_stages: { stage: number; name: string; xp_required: number }[];
+        streak_milestones: number[];
+      }>('GET', '/config/gamification'),
   },
   stats: {
-    system: () => req<{
-      notes: number;
-      tags: number;
-      goals: number;
-      skills: number;
-      total_xp: number;
-      current_streak: number;
-      xp_events_week: number;
-    }>('GET', '/stats/system'),
-    activity: (days = 30) => req<{
-      days: { date: string; notes_created: number; xp_events: number }[];
-    }>('GET', `/stats/activity?days=${days}`),
+    system: () =>
+      req<{
+        notes: number;
+        tags: number;
+        goals: number;
+        skills: number;
+        total_xp: number;
+        current_streak: number;
+        xp_events_week: number;
+      }>('GET', '/stats/system'),
+    activity: (days = 30) =>
+      req<{
+        days: { date: string; notes_created: number; xp_events: number }[];
+      }>('GET', `/stats/activity?days=${days}`),
+  },
+  analytics: {
+    dashboard: (days = 30) => req<AnalyticsDashboard>('GET', `/analytics/dashboard?days=${days}`),
+    track: (event_type: string, event_data?: Record<string, unknown>) =>
+      req<{ status: string; id: number }>(
+        'POST',
+        '/analytics/track',
+        { event_type, event_data },
+        { silent: true }
+      ),
+    usage: (days = 30) => req<UsageSummary>('GET', `/analytics/usage?days=${days}`),
   },
   export: {
     markdownUrl: () => `${BASE}/export/notes/markdown`,
     htmlUrl: () => `${BASE}/export/notes/html`,
-    zipUrl: () => `${BASE}/export/notes/zip`
+    zipUrl: () => `${BASE}/export/notes/zip`,
   },
-  
+
   embeddings: {
-    deadLetters: (limit = 50) => req<EmbeddingFailure[]>('GET', `/notes/embeddings/dead-letters?limit=${limit}`),
-    resetDeadLetter: (noteId: number) => req<{ status: string; note_id: number }>('POST', `/notes/embeddings/dead-letters/${noteId}/reset`),
+    deadLetters: (limit = 50) =>
+      req<EmbeddingFailure[]>('GET', `/notes/embeddings/dead-letters?limit=${limit}`),
+    resetDeadLetter: (noteId: number) =>
+      req<{ status: string; note_id: number }>(
+        'POST',
+        `/notes/embeddings/dead-letters/${noteId}/reset`
+      ),
     purgeDeadLetters: () => req<{ purged: number }>('DELETE', '/notes/embeddings/dead-letters'),
   },
 
@@ -488,7 +775,7 @@ github: {
     },
     delete: async (path: string) => {
       return req('DELETE', `/folders/${encodeURIComponent(path)}`);
-    }
+    },
   },
 
   upload: {
@@ -503,7 +790,12 @@ github: {
         const err = await res.text().catch(() => res.statusText);
         throw new Error(`Upload failed: ${res.status} ${err}`);
       }
-      const result = await res.json() as { url: string; filename: string; mime: string; size: number };
+      const result = (await res.json()) as {
+        url: string;
+        filename: string;
+        mime: string;
+        size: number;
+      };
       result.url = result.url.startsWith('http') ? result.url : `${BASE}${result.url}`;
       return result;
     },
@@ -518,27 +810,40 @@ github: {
         const err = await res.text().catch(() => res.statusText);
         throw new Error(`Upload failed: ${res.status} ${err}`);
       }
-      const result = await res.json() as { url: string; filename: string; mime: string; size: number };
+      const result = (await res.json()) as {
+        url: string;
+        filename: string;
+        mime: string;
+        size: number;
+      };
       result.url = result.url.startsWith('http') ? result.url : `${BASE}${result.url}`;
       return result;
     },
   },
 
   push: {
-    vapidPublicKey: () =>
-      req<{ publicKey: string }>('GET', '/push/vapid-public-key'),
+    vapidPublicKey: () => req<{ publicKey: string }>('GET', '/push/vapid-public-key'),
     subscribe: (endpoint: string, keys: { p256dh: string; auth: string }) =>
       req<{ status: string }>('POST', '/push/subscribe', { endpoint, keys }),
-    unsubscribe: () =>
-      req<{ status: string }>('POST', '/push/unsubscribe'),
+    unsubscribe: () => req<{ status: string }>('POST', '/push/unsubscribe'),
     test: (title: string, body: string) =>
       req<{ status: string }>('POST', '/push/test', { title, body }),
   },
 
   sync: {
-    conflicts: () =>
-      req<{ conflicts: SyncConflict[]; count: number }>('GET', '/sync/conflicts'),
+    conflicts: () => req<{ conflicts: SyncConflict[]; count: number }>('GET', '/sync/conflicts'),
     resolve: (noteId: number, resolution: string, mergedContent?: string) =>
-      req<{ status: string; note_id: number; resolution: string }>('POST', `/sync/resolve/${noteId}`, { resolution, merged_content: mergedContent ?? null }),
+      req<{ status: string; note_id: number; resolution: string }>(
+        'POST',
+        `/sync/resolve/${noteId}`,
+        { resolution, merged_content: mergedContent ?? null }
+      ),
+    status: () =>
+      req<{
+        last_sync_time: string | null;
+        pending_conflicts: number;
+        total_synced: number;
+        server_time: string;
+      }>('GET', '/sync/status'),
   },
 };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -308,41 +308,6 @@ export interface MoodStats {
   notes_correlation: number;
 }
 
-export interface UsageEventValue {
-  feature?: string;
-  path?: string;
-  count: number;
-}
-
-export interface UsageSummary {
-  days: number;
-  total_events: number;
-  session_count: number;
-  active_days: number;
-  avg_session_duration_min: number;
-  top_features: { feature: string; count: number }[];
-  top_pages: { path: string; count: number }[];
-}
-
-export interface AnalyticsDashboard {
-  system: {
-    notes: number;
-    tags: number;
-    goals: number;
-    skills: number;
-    total_xp: number;
-    current_streak: number;
-    xp_events_week: number;
-  };
-  activity: { days: { date: string; notes_created: number; xp_events: number }[] };
-  mood: {
-    stats: MoodStats;
-    history: { entry_date: string; score: number }[];
-  };
-  ai_usage: { ai_enabled: boolean; estimated_cost_usd: number; [k: string]: unknown };
-  usage: UsageSummary;
-}
-
 // ── Notes ─────────────────────────────────────────────────────────────────────
 
 export interface SyncConflict {
@@ -740,17 +705,6 @@ export const api = {
       req<{
         days: { date: string; notes_created: number; xp_events: number }[];
       }>('GET', `/stats/activity?days=${days}`),
-  },
-  analytics: {
-    dashboard: (days = 30) => req<AnalyticsDashboard>('GET', `/analytics/dashboard?days=${days}`),
-    track: (event_type: string, event_data?: Record<string, unknown>) =>
-      req<{ status: string; id: number }>(
-        'POST',
-        '/analytics/track',
-        { event_type, event_data },
-        { silent: true }
-      ),
-    usage: (days = 30) => req<UsageSummary>('GET', `/analytics/usage?days=${days}`),
   },
   export: {
     markdownUrl: () => `${BASE}/export/notes/markdown`,

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -98,5 +98,13 @@
     "streak": "streak",
     "saved": "Mood saved",
     "error": "Failed to save mood"
+  },
+  "sync": {
+    "syncedFromVault": "Synced from vault: \"{title}\"",
+    "syncingVault": "Syncing vault...",
+    "syncedVault": "Vault synced",
+    "lastSync": "Last sync",
+    "neverSynced": "Never synced",
+    "totalSynced": "{count} notes synced"
   }
 }

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -98,5 +98,13 @@
     "streak": "racha",
     "saved": "Ánimo guardado",
     "error": "Error al guardar el ánimo"
+  },
+  "sync": {
+    "syncedFromVault": "Sincronizado desde la bóveda: \"{title}\"",
+    "syncingVault": "Sincronizando bóveda...",
+    "syncedVault": "Bóveda sincronizada",
+    "lastSync": "Última sincronización",
+    "neverSynced": "Nunca sincronizado",
+    "totalSynced": "{count} notas sincronizadas"
   }
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -52,6 +52,12 @@
   import { initOfflineSync } from '$lib/stores/offlineSync';
   import ShareAchievementModal from '$lib/components/ShareAchievementModal.svelte';
   import { initFocusModeConfig, queueNotificationIfActive } from '$lib/stores/focusMode';
+  import {
+    initUsageTracking,
+    trackPageView,
+    trackSessionStart,
+    trackSessionEnd,
+  } from '$lib/stores/usage';
 
   type NavItemStatus = 'ready' | 'dev' | 'placeholder';
 
@@ -67,7 +73,13 @@
     { href: '/ai', label: $t('nav.ai'), icon: 'Brain', status: 'ready' },
     { href: '/goals', label: $t('nav.goals'), icon: 'Target', status: 'ready' },
     { href: '/streaks', label: $t('nav.streaks'), icon: 'Flame', status: 'ready' },
+    { href: '/analytics', label: $t('nav.analytics'), icon: 'BarChart3', status: 'ready' },
   ] as { href: string; label: string; icon: string; status: NavItemStatus }[];
+
+  // Track page views on route changes (foreground-only, debounced in the store).
+  $: if (mounted && $isAuthenticated) {
+    trackPageView($page.url.pathname);
+  }
 
   let settingsOpen = false;
   let now = new Date();
@@ -122,6 +134,13 @@
     devMode.init();
     const cleanupConnection = initConnectionStore();
     const cleanupOfflineSync = initOfflineSync();
+
+    // Internal usage tracking (#250) — only records while the app is in the
+    // foreground. Starts a session on mount and ends it on cleanup.
+    const cleanupUsage = initUsageTracking();
+    if ($isAuthenticated) {
+      trackSessionStart();
+    }
 
     // First-use detection: start the onboarding tour for brand-new users.
     if ($isAuthenticated) {
@@ -193,6 +212,29 @@
           } else if (msg.type === 'streak_updated') {
             queueNotificationIfActive(`¡Racha de ${msg.streak} días! 🔥`, 'info');
             loadStats().catch(() => {});
+          } else if (msg.type === 'vault_synced') {
+            // A note was synced from the Obsidian vault (#73).
+            queueNotificationIfActive(
+              $t('sync.syncedFromVault', { values: { title: msg.title } }),
+              'info'
+            );
+            loadNotes(undefined, true).catch(() => {});
+            vaultSyncActive = true;
+            if (vaultSyncTimeout) clearTimeout(vaultSyncTimeout);
+            vaultSyncTimeout = setTimeout(() => {
+              vaultSyncActive = false;
+            }, 3000);
+          } else if (msg.type === 'vault_sync_started') {
+            vaultSyncActive = true;
+            if (vaultSyncTimeout) clearTimeout(vaultSyncTimeout);
+          } else if (msg.type === 'vault_sync_complete') {
+            loadNotes(undefined, true).catch(() => {});
+            vaultSyncActive = false;
+            vaultSyncPulse = true;
+            if (vaultSyncTimeout) clearTimeout(vaultSyncTimeout);
+            vaultSyncTimeout = setTimeout(() => {
+              vaultSyncPulse = false;
+            }, 2000);
           }
         } catch (e) {
           logger.error('[layout] Error parsing WebSocket message:', e);
@@ -431,15 +473,25 @@
       }
       if (wsReconnectTimeout) clearTimeout(wsReconnectTimeout);
       if (pillTimeout) clearTimeout(pillTimeout);
+      if (vaultSyncTimeout) clearTimeout(vaultSyncTimeout);
       if (cleanupTheme) cleanupTheme();
       if (cleanupKeyboard) cleanupKeyboard();
       if (cleanupConnection) cleanupConnection();
       if (cleanupOfflineSync) cleanupOfflineSync();
+      if (cleanupUsage) cleanupUsage();
+      if ($isAuthenticated) {
+        trackSessionEnd();
+      }
       syncStore.stopPolling();
     };
   });
   let showConnectedPill = false;
   let pillTimeout: any = null;
+
+  // Vault sync indicator state (#73).
+  let vaultSyncActive = false;
+  let vaultSyncPulse = false;
+  let vaultSyncTimeout: any = null;
 
   $: if ($isOnline && $wasOffline) {
     showConnectedPill = true;
@@ -499,6 +551,21 @@
       {/if}
 
       <div style="flex:1;"></div>
+
+      <!-- Vault sync indicator (#73) -->
+      {#if vaultSyncActive || vaultSyncPulse}
+        <div
+          class="vault-sync-indicator"
+          class:syncing={vaultSyncActive}
+          class:pulse={vaultSyncPulse}
+          transition:fade={{ duration: 150 }}
+          title={$t('sync.syncedFromVault', { values: { title: '' } }).trim() ||
+            $t('sync.syncingVault')}
+        >
+          <DynamicIcon name="RefreshCw" size={12} />
+          <span>{vaultSyncActive ? $t('sync.syncingVault') : $t('sync.syncedVault')}</span>
+        </div>
+      {/if}
 
       <!-- Connectivity Indicator -->
       {#if !$isOnline}
@@ -817,6 +884,38 @@
   .pulse-dot.green {
     background-color: var(--success, #22c55e);
     animation: green-pulse 1.5s infinite;
+  }
+
+  /* Vault sync indicator (#73) */
+  .vault-sync-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    font-weight: 500;
+    padding: 4px 10px;
+    border-radius: 99px;
+    margin-right: 12px;
+    background: color-mix(in srgb, var(--accent, var(--xp)) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent, var(--xp)) 30%, transparent);
+    color: var(--accent, var(--xp));
+    transition: all 0.2s ease-in-out;
+  }
+  .vault-sync-indicator.syncing :global(svg) {
+    animation: vault-spin 1s linear infinite;
+  }
+  .vault-sync-indicator.pulse {
+    background: color-mix(in srgb, var(--success, #22c55e) 10%, transparent);
+    border-color: color-mix(in srgb, var(--success, #22c55e) 30%, transparent);
+    color: var(--success, #22c55e);
+  }
+  @keyframes vault-spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
   }
 
   @keyframes red-pulse {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -52,12 +52,6 @@
   import { initOfflineSync } from '$lib/stores/offlineSync';
   import ShareAchievementModal from '$lib/components/ShareAchievementModal.svelte';
   import { initFocusModeConfig, queueNotificationIfActive } from '$lib/stores/focusMode';
-  import {
-    initUsageTracking,
-    trackPageView,
-    trackSessionStart,
-    trackSessionEnd,
-  } from '$lib/stores/usage';
 
   type NavItemStatus = 'ready' | 'dev' | 'placeholder';
 
@@ -73,13 +67,7 @@
     { href: '/ai', label: $t('nav.ai'), icon: 'Brain', status: 'ready' },
     { href: '/goals', label: $t('nav.goals'), icon: 'Target', status: 'ready' },
     { href: '/streaks', label: $t('nav.streaks'), icon: 'Flame', status: 'ready' },
-    { href: '/analytics', label: $t('nav.analytics'), icon: 'BarChart3', status: 'ready' },
   ] as { href: string; label: string; icon: string; status: NavItemStatus }[];
-
-  // Track page views on route changes (foreground-only, debounced in the store).
-  $: if (mounted && $isAuthenticated) {
-    trackPageView($page.url.pathname);
-  }
 
   let settingsOpen = false;
   let now = new Date();
@@ -134,13 +122,6 @@
     devMode.init();
     const cleanupConnection = initConnectionStore();
     const cleanupOfflineSync = initOfflineSync();
-
-    // Internal usage tracking (#250) — only records while the app is in the
-    // foreground. Starts a session on mount and ends it on cleanup.
-    const cleanupUsage = initUsageTracking();
-    if ($isAuthenticated) {
-      trackSessionStart();
-    }
 
     // First-use detection: start the onboarding tour for brand-new users.
     if ($isAuthenticated) {
@@ -478,10 +459,6 @@
       if (cleanupKeyboard) cleanupKeyboard();
       if (cleanupConnection) cleanupConnection();
       if (cleanupOfflineSync) cleanupOfflineSync();
-      if (cleanupUsage) cleanupUsage();
-      if ($isAuthenticated) {
-        trackSessionEnd();
-      }
       syncStore.stopPolling();
     };
   });


### PR DESCRIPTION
## Summary

Implements real-time bidirectional vault sync broadcasting via WebSocket so the frontend receives instant notifications when notes are synced from the Obsidian vault (#73).

### Backend changes

- **`api/routers/websocket.py`**: Added three new WebSocket message types and their broadcast helper functions:
  - `vault_synced` — broadcast when a note is created/updated from the vault (includes `note_id`, `title`, `source_path`)
  - `vault_sync_started` — broadcast when a sync cycle starts (for UI indicator)
  - `vault_sync_complete` — broadcast when a sync cycle completes (includes `total_synced`)
- **`api/services/note_service.py`**: `create_note()` and `update_note()` now broadcast a `vault_synced` event via WebSocket when the note source is `"obsidian"` or the update came from the vault (`from_vault=True`). This lets the frontend distinguish vault syncs from manual edits.
- **`api/routers/sync.py`**: Added `GET /sync/status` endpoint returning `last_sync_time`, `pending_conflicts`, `total_synced`, and `server_time`. The frontend can poll this on load to display sync status.

### Frontend changes

- **`frontend/src/routes/+layout.svelte`**: WebSocket message handler now processes `vault_synced`, `vault_sync_started`, and `vault_sync_complete` events — refreshes the notes list, shows a notification, and displays a sync indicator badge in the header that flashes when sync happens.
- **`frontend/src/lib/api.ts`**: Added `api.sync.status()` method for the new endpoint.
- **`frontend/src/locales/{en,es}/common.json`**: Added i18n strings for all new sync UI text (`sync.syncedFromVault`, `sync.syncingVault`, `sync.syncedVault`, etc.).

### Tests

- **`api/tests/test_vault_sync_websocket.py`**: 10 new tests covering:
  - Creating a note with `source="obsidian"` triggers a `vault_synced` broadcast
  - Creating a note with a non-obsidian source does NOT trigger `vault_synced`
  - Updating an obsidian note triggers a `vault_synced` broadcast
  - `GET /sync/status` with empty database, with obsidian notes, with pending conflicts, and with last sync time
  - Broadcast helper functions are safe no-ops outside an event loop

Closes #73.

## Test plan

- [x] `python -m py_compile` passes on all modified/new Python files
- [x] `npm run check` passes (0 errors, pre-existing warnings only)
- [x] All 10 new tests pass (`pytest api/tests/test_vault_sync_websocket.py`)
- [x] Existing tests still pass (37 passed; 4 pre-existing conftest errors unrelated to this PR)
- [x] `ruff format` applied to modified Python files
- [x] `prettier --write` applied to modified frontend files
- [ ] Manual: edit a note in Obsidian vault → verify frontend shows "Synced from vault" notification and sync indicator badge
- [ ] Manual: verify `GET /sync/status` returns correct counts

Generated with [Devin](https://devin.ai)