### PR TITLE
test(backend): router test coverage — 6 untested routers (#13)

### DIFF
--- a/api/tests/test_routers_personal_streaks.py
+++ b/api/tests/test_routers_personal_streaks.py
@@ -1,0 +1,192 @@
+"""Router tests for the personal streaks endpoints (#13)."""
+
+from datetime import date, datetime, timezone
+
+from fastapi.testclient import TestClient
+from models.personal_streaks import PersonalStreak, StreakCheckIn
+
+
+def test_list_categories(client: TestClient):
+    response = client.get("/personal-streaks/categories")
+    assert response.status_code == 200
+    cats = response.json()
+    assert "general" in cats
+    assert "salud" in cats
+    assert "fitness" in cats
+
+
+def test_list_streaks_returns_list(client: TestClient):
+    response = client.get("/personal-streaks/")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+def test_create_streak(client: TestClient):
+    payload = {
+        "name": "Drink Water",
+        "emoji": "💧",
+        "category": "salud",
+    }
+    response = client.post("/personal-streaks/", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Drink Water"
+    assert data["emoji"] == "💧"
+    assert data["category"] == "salud"
+    assert data["current_streak"] == 0
+    assert "id" in data
+
+
+def test_create_streak_with_future_start_date_no_backfill(client: TestClient):
+    future = date(2099, 1, 1)
+    payload = {"name": "Future Streak", "start_date": future.isoformat()}
+    response = client.post("/personal-streaks/", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["start_date"] == future.isoformat()
+    assert data["total_checkins"] == 0
+
+
+def test_list_streaks_includes_created(client: TestClient):
+    client.post("/personal-streaks/", json={"name": "Streak A"})
+    client.post("/personal-streaks/", json={"name": "Streak B"})
+
+    response = client.get("/personal-streaks/")
+    assert response.status_code == 200
+    names = [s["name"] for s in response.json()]
+    assert "Streak A" in names
+    assert "Streak B" in names
+
+
+def test_update_streak(client: TestClient):
+    create = client.post("/personal-streaks/", json={"name": "Original"})
+    streak_id = create.json()["id"]
+
+    response = client.put(f"/personal-streaks/{streak_id}", json={"name": "Updated", "emoji": "✅"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Updated"
+    assert data["emoji"] == "✅"
+
+
+def test_update_streak_not_found(client: TestClient):
+    response = client.put("/personal-streaks/9999", json={"name": "X"})
+    assert response.status_code == 404
+
+
+def test_delete_streak(client: TestClient):
+    create = client.post("/personal-streaks/", json={"name": "To Delete"})
+    streak_id = create.json()["id"]
+
+    response = client.delete(f"/personal-streaks/{streak_id}")
+    assert response.status_code == 204
+
+    get_response = client.get("/personal-streaks/")
+    ids = [s["id"] for s in get_response.json()]
+    assert streak_id not in ids
+
+
+def test_delete_streak_not_found(client: TestClient):
+    response = client.delete("/personal-streaks/9999")
+    assert response.status_code == 404
+
+
+def test_checkin_creates_checkin(client: TestClient):
+    create = client.post("/personal-streaks/", json={"name": "Checkin Streak"})
+    streak_id = create.json()["id"]
+
+    today = date.today().isoformat()
+    response = client.post(f"/personal-streaks/{streak_id}/checkin", json={
+        "note": "Done!",
+        "mood": 4,
+        "check_date": today,
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["today_checked"] is True
+    assert data["total_checkins"] == 1
+
+
+def test_checkin_updates_existing(client: TestClient, db_session):
+    create = client.post("/personal-streaks/", json={"name": "Double Checkin"})
+    streak_id = create.json()["id"]
+
+    today = date.today().isoformat()
+    client.post(f"/personal-streaks/{streak_id}/checkin", json={"note": "First", "check_date": today})
+    response = client.post(f"/personal-streaks/{streak_id}/checkin", json={"note": "Updated", "check_date": today})
+    assert response.status_code == 200
+    # Should not duplicate
+    checkins = db_session.query(StreakCheckIn).filter(StreakCheckIn.streak_id == streak_id).all()
+    assert len(checkins) == 1
+    assert checkins[0].note == "Updated"
+
+
+def test_checkin_not_found(client: TestClient):
+    response = client.post("/personal-streaks/9999/checkin", json={})
+    assert response.status_code == 404
+
+
+def test_undo_checkin(client: TestClient):
+    create = client.post("/personal-streaks/", json={"name": "Undo Streak"})
+    streak_id = create.json()["id"]
+
+    today = date.today().isoformat()
+    client.post(f"/personal-streaks/{streak_id}/checkin", json={"check_date": today})
+    response = client.delete(f"/personal-streaks/{streak_id}/checkin")
+    assert response.status_code == 200
+    assert response.json()["today_checked"] is False
+
+
+def test_global_stats_shape(client: TestClient):
+    response = client.get("/personal-streaks/stats")
+    assert response.status_code == 200
+    data = response.json()
+    for key in ("total_active", "total_archived", "longest_ever", "longest_name",
+                "total_checkins", "checkin_rate", "days_tracked"):
+        assert key in data
+
+
+def test_global_stats_with_streaks(client: TestClient):
+    before = client.get("/personal-streaks/stats").json()
+    client.post("/personal-streaks/", json={"name": "Active Streak Unique"})
+    response = client.get("/personal-streaks/stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_active"] == before["total_active"] + 1
+
+
+def test_freeze_no_freezes_available(client: TestClient):
+    create = client.post("/personal-streaks/", json={"name": "Freeze Streak", "freeze_count": 0})
+    streak_id = create.json()["id"]
+
+    response = client.post(f"/personal-streaks/{streak_id}/freeze")
+    assert response.status_code == 400
+
+
+def test_freeze_used(client: TestClient):
+    create = client.post("/personal-streaks/", json={"name": "Freeze Streak", "freeze_count": 1})
+    streak_id = create.json()["id"]
+
+    response = client.post(f"/personal-streaks/{streak_id}/freeze")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["freeze_used"] == 1
+
+
+def test_get_history(client: TestClient):
+    create = client.post("/personal-streaks/", json={"name": "History Streak"})
+    streak_id = create.json()["id"]
+
+    today = date.today().isoformat()
+    client.post(f"/personal-streaks/{streak_id}/checkin", json={"check_date": today})
+
+    response = client.get(f"/personal-streaks/{streak_id}/history?days=30")
+    assert response.status_code == 200
+    history = response.json()
+    assert len(history) >= 1
+    assert history[0]["date"] == today
+
+
+def test_get_history_not_found(client: TestClient):
+    response = client.get("/personal-streaks/9999/history")
+    assert response.status_code == 404

--- a/api/tests/test_routers_planning.py
+++ b/api/tests/test_routers_planning.py
@@ -1,0 +1,86 @@
+"""Router tests for the planning assignment endpoints (#13)."""
+
+from fastapi.testclient import TestClient
+from models.goal import Goal
+from models.planning import PlanningAssignment
+
+
+def _make_goal(db_session, title="Plan Goal"):
+    goal = Goal(title=title, temporality="DAILY", measurement_type="BOOLEAN")
+    db_session.add(goal)
+    db_session.commit()
+    return goal.id
+
+
+def test_get_assignments_requires_date(client: TestClient):
+    response = client.get("/planning/assignments")
+    assert response.status_code == 400
+    assert "date" in response.json()["detail"].lower()
+
+
+def test_get_assignments_invalid_date(client: TestClient):
+    response = client.get("/planning/assignments?date=not-a-date")
+    assert response.status_code == 400
+
+
+def test_get_assignments_empty(client: TestClient):
+    # Use a far-future date unlikely to have pre-existing data on shared dev DBs.
+    response = client.get("/planning/assignments?date=2099-06-15")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["date"] == "2099-06-15"
+    assert data["goal_ids"] == []
+
+
+def test_set_assignments_creates_rows(client: TestClient, db_session):
+    g1 = _make_goal(db_session, "G1")
+    g2 = _make_goal(db_session, "G2")
+    target_date = "2099-07-20"
+
+    response = client.post("/planning/assignments", json={
+        "date": target_date,
+        "goal_ids": [g1, g2],
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["date"] == target_date
+    assert sorted(data["goal_ids"]) == sorted([g1, g2])
+
+    rows = db_session.query(PlanningAssignment).filter(
+        PlanningAssignment.date == __import__("datetime").date(2099, 7, 20)
+    ).all()
+    assert len(rows) == 2
+
+
+def test_set_assignments_replaces_existing(client: TestClient, db_session):
+    g1 = _make_goal(db_session, "G1")
+    g2 = _make_goal(db_session, "G2")
+    g3 = _make_goal(db_session, "G3")
+    target_date = "2099-08-20"
+
+    client.post("/planning/assignments", json={"date": target_date, "goal_ids": [g1, g2]})
+    client.post("/planning/assignments", json={"date": target_date, "goal_ids": [g3]})
+
+    rows = db_session.query(PlanningAssignment).filter(
+        PlanningAssignment.date == __import__("datetime").date(2099, 8, 20)
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].goal_id == g3
+
+
+def test_set_assignments_invalid_date(client: TestClient):
+    response = client.post("/planning/assignments", json={
+        "date": "01/15/2024",
+        "goal_ids": [],
+    })
+    assert response.status_code == 400
+
+
+def test_set_then_get_assignments(client: TestClient, db_session):
+    g1 = _make_goal(db_session, "G1")
+    target_date = "2099-09-01"
+    client.post("/planning/assignments", json={"date": target_date, "goal_ids": [g1]})
+
+    response = client.get(f"/planning/assignments?date={target_date}")
+    assert response.status_code == 200
+    assert response.json()["goal_ids"] == [g1]

--- a/api/tests/test_routers_push.py
+++ b/api/tests/test_routers_push.py
@@ -1,0 +1,79 @@
+"""Router tests for the push notification endpoints (#13)."""
+
+from fastapi.testclient import TestClient
+from models.push_subscription import PushSubscription
+
+
+def test_subscribe_creates_subscription(client: TestClient, db_session):
+    payload = {
+        "endpoint": "https://fcm.googleapis.com/fcm/send/abc",
+        "keys": {"p256dh": "p256dh-value", "auth": "auth-value"},
+    }
+    response = client.post("/push/subscribe", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+    subs = db_session.query(PushSubscription).all()
+    assert len(subs) == 1
+    assert subs[0].endpoint == payload["endpoint"]
+    assert subs[0].p256dh == "p256dh-value"
+    assert subs[0].auth == "auth-value"
+
+
+def test_subscribe_replaces_existing(client: TestClient, db_session):
+    db_session.add(PushSubscription(
+        user_id=1,
+        endpoint="https://old.example.com/send",
+        p256dh="old-p256dh",
+        auth="old-auth",
+    ))
+    db_session.commit()
+
+    payload = {
+        "endpoint": "https://new.example.com/send",
+        "keys": {"p256dh": "new-p256dh", "auth": "new-auth"},
+    }
+    response = client.post("/push/subscribe", json=payload)
+    assert response.status_code == 200
+
+    subs = db_session.query(PushSubscription).all()
+    assert len(subs) == 1
+    assert subs[0].endpoint == "https://new.example.com/send"
+
+
+def test_subscribe_missing_keys_rejected(client: TestClient):
+    payload = {
+        "endpoint": "https://fcm.googleapis.com/fcm/send/abc",
+        "keys": {"p256dh": "p256dh-value"},
+    }
+    response = client.post("/push/subscribe", json=payload)
+    assert response.status_code == 422
+
+
+def test_unsubscribe_removes_subscription(client: TestClient, db_session):
+    db_session.add(PushSubscription(
+        user_id=1,
+        endpoint="https://example.com/send",
+        p256dh="p",
+        auth="a",
+    ))
+    db_session.commit()
+
+    response = client.post("/push/unsubscribe")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+    subs = db_session.query(PushSubscription).all()
+    assert len(subs) == 0
+
+
+def test_unsubscribe_when_none(client: TestClient):
+    response = client.post("/push/unsubscribe")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_vapid_public_key_not_configured(client: TestClient):
+    response = client.get("/push/vapid-public-key")
+    # VAPID is not configured in tests → 503
+    assert response.status_code == 503

--- a/api/tests/test_routers_stats.py
+++ b/api/tests/test_routers_stats.py
@@ -1,0 +1,93 @@
+"""Router tests for the stats endpoints (#13)."""
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from models.gamification import UserStats, XPEvent
+from models.goal import Goal
+from models.note import Note, Tag as TagModel
+from models.skill import Skill
+
+
+def test_system_stats_shape(client: TestClient):
+    response = client.get("/stats/system")
+    assert response.status_code == 200
+    data = response.json()
+    for key in ("notes", "tags", "goals", "skills", "total_xp", "current_streak", "xp_events_week"):
+        assert key in data
+        assert isinstance(data[key], int)
+
+
+def test_system_stats_with_data(client: TestClient, db_session):
+    before = client.get("/stats/system").json()
+
+    tag = TagModel(name=f"t1-stats-{uuid.uuid4().hex[:8]}")
+    db_session.add(tag)
+    db_session.flush()
+    db_session.add_all([
+        Note(title="Note A stats", content="a"),
+        Note(title="Note B stats", content="b"),
+        Goal(title="G1 stats", temporality="DAILY", measurement_type="BOOLEAN"),
+        Skill(tag_id=tag.id, note_count=5),
+        XPEvent(event_type="note_created", xp=10),
+        XPEvent(event_type="note_created", xp=10),
+    ])
+    # Update or create UserStats (id=1 may already exist on shared dev DB).
+    stats = db_session.query(UserStats).filter(UserStats.id == 1).first()
+    if stats is None:
+        stats = UserStats(id=1)
+        db_session.add(stats)
+    stats.total_xp = 250
+    stats.current_streak = 5
+    db_session.commit()
+
+    response = client.get("/stats/system")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["notes"] == before["notes"] + 2
+    assert data["tags"] == before["tags"] + 1
+    assert data["goals"] == before["goals"] + 1
+    assert data["skills"] == before["skills"] + 1
+    assert data["total_xp"] == 250
+    assert data["current_streak"] == 5
+    assert data["xp_events_week"] == before["xp_events_week"] + 2
+
+
+def test_activity_stats_default_days(client: TestClient):
+    response = client.get("/stats/activity")
+    assert response.status_code == 200
+    data = response.json()
+    assert "days" in data
+    assert len(data["days"]) == 30
+    today_entry = data["days"][0]
+    assert "date" in today_entry
+    assert "notes_created" in today_entry
+    assert "xp_events" in today_entry
+
+
+def test_activity_stats_custom_days(client: TestClient):
+    response = client.get("/stats/activity?days=7")
+    assert response.status_code == 200
+    assert len(response.json()["days"]) == 7
+
+
+def test_activity_stats_days_clamped_to_366(client: TestClient):
+    response = client.get("/stats/activity?days=500")
+    assert response.status_code == 200
+    assert len(response.json()["days"]) == 366
+
+
+def test_activity_stats_invalid_days(client: TestClient):
+    response = client.get("/stats/activity?days=0")
+    assert response.status_code == 400
+
+
+def test_activity_stats_reflects_notes(client: TestClient, db_session):
+    db_session.add(Note(title="Today", content="x"))
+    db_session.commit()
+
+    response = client.get("/stats/activity?days=3")
+    assert response.status_code == 200
+    today_entry = response.json()["days"][0]
+    assert today_entry["notes_created"] >= 1

--- a/api/tests/test_routers_sync.py
+++ b/api/tests/test_routers_sync.py
@@ -1,0 +1,101 @@
+"""Router tests for the sync conflict endpoints (#13)."""
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from models.note import Note
+from models.sync_state import SyncState
+
+
+def _make_conflicted_note(db_session, title="Conflicted Note"):
+    note = Note(title=title, content="local content")
+    db_session.add(note)
+    db_session.flush()
+    sync = SyncState(
+        note_id=note.id,
+        conflict=True,
+        local_mtime=datetime.now(timezone.utc),
+        remote_mtime=datetime.now(timezone.utc),
+    )
+    db_session.add(sync)
+    db_session.commit()
+    return note.id
+
+
+def test_list_conflicts_shape(client: TestClient):
+    response = client.get("/sync/conflicts")
+    assert response.status_code == 200
+    data = response.json()
+    assert "conflicts" in data
+    assert "count" in data
+    assert isinstance(data["conflicts"], list)
+    assert data["count"] == len(data["conflicts"])
+
+
+def test_list_conflicts_shows_conflicted_notes(client: TestClient, db_session):
+    before = client.get("/sync/conflicts").json()["count"]
+    _make_conflicted_note(db_session, "Conflict A Unique")
+
+    response = client.get("/sync/conflicts")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == before + 1
+    titles = [c["title"] for c in data["conflicts"]]
+    assert "Conflict A Unique" in titles
+
+
+def test_resolve_keep_local(client: TestClient, db_session):
+    note_id = _make_conflicted_note(db_session)
+
+    response = client.post(f"/sync/resolve/{note_id}", json={"resolution": "keep_local"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["resolution"] == "keep_local"
+
+    sync = db_session.query(SyncState).filter(SyncState.note_id == note_id).first()
+    assert sync.conflict is False
+
+
+def test_resolve_merge(client: TestClient, db_session):
+    note_id = _make_conflicted_note(db_session)
+
+    response = client.post(f"/sync/resolve/{note_id}", json={
+        "resolution": "merge",
+        "merged_content": "merged content here",
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["resolution"] == "merge"
+
+    note = db_session.query(Note).filter(Note.id == note_id).first()
+    assert "merged content here" in note.content
+
+
+def test_resolve_merge_requires_content(client: TestClient, db_session):
+    note_id = _make_conflicted_note(db_session)
+
+    response = client.post(f"/sync/resolve/{note_id}", json={"resolution": "merge"})
+    assert response.status_code == 400
+    assert "merged_content" in response.json()["detail"]
+
+
+def test_resolve_invalid_resolution(client: TestClient, db_session):
+    note_id = _make_conflicted_note(db_session)
+
+    response = client.post(f"/sync/resolve/{note_id}", json={"resolution": "bogus"})
+    assert response.status_code == 422
+
+
+def test_resolve_nonexistent_note(client: TestClient):
+    response = client.post("/sync/resolve/9999", json={"resolution": "keep_local"})
+    assert response.status_code == 400
+
+
+def test_resolve_keep_remote_without_vault(client: TestClient, db_session):
+    note_id = _make_conflicted_note(db_session)
+
+    response = client.post(f"/sync/resolve/{note_id}", json={"resolution": "keep_remote"})
+    # Without a configured vault path / source_path, the service returns an error
+    assert response.status_code == 400

--- a/api/tests/test_routers_upload.py
+++ b/api/tests/test_routers_upload.py
@@ -1,0 +1,72 @@
+"""Router tests for the file upload endpoints (#13)."""
+
+import io
+
+from fastapi.testclient import TestClient
+
+
+def test_upload_image_succeeds(client: TestClient):
+    response = client.post(
+        "/upload/image",
+        files={"file": ("test.png", io.BytesIO(b"fake-png-data"), "image/png")},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["url"].startswith("/uploads/")
+    assert data["filename"].endswith(".png")
+    assert data["mime"] == "image/png"
+    assert data["size"] == len(b"fake-png-data")
+
+
+def test_upload_image_invalid_type_rejected(client: TestClient):
+    response = client.post(
+        "/upload/image",
+        files={"file": ("test.exe", io.BytesIO(b"binary"), "application/octet-stream")},
+    )
+    assert response.status_code == 400
+
+
+def test_upload_file_succeeds(client: TestClient):
+    content = b"hello world this is a text file"
+    response = client.post(
+        "/upload/file",
+        files={"file": ("notes.txt", io.BytesIO(content), "text/plain")},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["url"].startswith("/uploads/")
+    assert data["mime"] == "text/plain"
+    assert data["size"] == len(content)
+
+
+def test_upload_file_invalid_type_rejected(client: TestClient):
+    response = client.post(
+        "/upload/file",
+        files={"file": ("malware.exe", io.BytesIO(b"bad"), "application/x-msdownload")},
+    )
+    assert response.status_code == 400
+
+
+def test_upload_file_size_limit_enforced(client: TestClient, monkeypatch):
+    # Lower the limit to 10 bytes so we can exceed it trivially.
+    from config import settings
+
+    monkeypatch.setattr(settings, "upload_max_file_bytes", 10)
+
+    response = client.post(
+        "/upload/file",
+        files={"file": ("big.txt", io.BytesIO(b"x" * 100), "text/plain")},
+    )
+    assert response.status_code == 413
+
+
+def test_upload_image_size_limit_enforced(client: TestClient, monkeypatch):
+    from config import settings
+
+    monkeypatch.setattr(settings, "upload_max_image_bytes", 5)
+
+    response = client.post(
+        "/upload/image",
+        files={"file": ("big.png", io.BytesIO(b"x" * 50), "image/png")},
+    )
+    assert response.status_code == 413


### PR DESCRIPTION
## Summary

Adds router tests for 6 previously untested routers, advancing test coverage toward the 70%+ target from issue #13.

Following the patterns established in PRs #537 and #541 (service tests), this PR covers the router layer using the existing `client` fixture from `conftest.py` with pytest function-style tests.

## Routers tested

| Router | File | Tests | Coverage |
|--------|------|-------|----------|
| **stats** | `api/routers/stats.py` | 7 | System stats shape + counts, activity time-series, days clamping (max 366), invalid days |
| **push** | `api/routers/push.py` | 6 | Subscribe, replace-existing, missing-keys rejection, unsubscribe, VAPID key endpoint |
| **planning** | `api/routers/planning.py` | 7 | Get/set assignments, replace behavior, invalid date validation, required-date validation |
| **sync** | `api/routers/sync.py` | 8 | List conflicts shape, keep_local/merge resolution, merge-requires-content, invalid resolution, nonexistent note, keep_remote error |
| **upload** | `api/routers/upload.py` | 6 | Image/file upload success, invalid type rejection, size limit enforcement (image + file) |
| **personal_streaks** | `api/routers/personal_streaks.py` | 19 | Categories, list, create, update, delete, check-in create/update, undo check-in, freeze, history, global stats |

**Total: 53 new tests, all passing.**

## Test plan checklist

- [x] Read `conftest.py` for fixtures (`client`, `db_session`, sqlite_vec stub)
- [x] Read existing `test_routers_goals.py` / `test_routers_notes.py` for patterns
- [x] Used pytest function-style (not `unittest.TestCase`) matching existing router tests
- [x] Used `client` fixture from conftest
- [x] Tests are robust against pre-existing data (before/after counts, unique identifiers, far-future dates)
- [x] `python -m py_compile` passes on all 6 files
- [x] All 53 tests pass via `docker compose run --rm api pytest`

Closes #13 (router portion).

Generated with [Devin](https://devin.ai)