### PR TITLE
feat: unified analytics dashboard with internal usage tracking (#251, #250)

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -15,7 +15,7 @@ if database_url:
     config.set_main_option("sqlalchemy.url", database_url)
 
 from database import Base
-from models import config as _m_config, gamification as _m_gamification, github as _m_github, goal as _m_goal, note as _m_note, personal_streaks as _m_personal_streaks, planning as _m_planning, skill as _m_skill
+from models import config as _m_config, gamification as _m_gamification, github as _m_github, goal as _m_goal, note as _m_note, personal_streaks as _m_personal_streaks, planning as _m_planning, skill as _m_skill, usage_event as _m_usage_event
 
 target_metadata = Base.metadata
 

--- a/api/alembic/versions/a7b8c9d0e1f2_add_usage_events.py
+++ b/api/alembic/versions/a7b8c9d0e1f2_add_usage_events.py
@@ -1,0 +1,47 @@
+"""add usage_events table for internal usage tracking
+
+Revision ID: a7b8c9d0e1f2
+Revises: f6a7b8c9d0e1
+Create Date: 2026-08-03 10:00:00.000000
+
+Analytics dashboard + internal usage tracking (#251, #250). Records
+lightweight usage events (page_view, feature_use, session_start,
+session_end) only while the web app is in the foreground. The
+``event_data`` column is a JSON blob holding context for the event.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a7b8c9d0e1f2"
+down_revision: Union[str, None] = "f6a7b8c9d0e1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "usage_events",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("event_type", sa.String(length=32), nullable=False),
+        sa.Column("event_data", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_usage_events_id"), "usage_events", ["id"], unique=False)
+    op.create_index(op.f("ix_usage_events_user_id"), "usage_events", ["user_id"], unique=False)
+    op.create_index("ix_usage_events_user_created", "usage_events", ["user_id", "created_at"], unique=False)
+    op.create_index("ix_usage_events_type", "usage_events", ["event_type"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_usage_events_type", table_name="usage_events")
+    op.drop_index("ix_usage_events_user_created", table_name="usage_events")
+    op.drop_index(op.f("ix_usage_events_user_id"), table_name="usage_events")
+    op.drop_index(op.f("ix_usage_events_id"), table_name="usage_events")
+    op.drop_table("usage_events")

--- a/api/main.py
+++ b/api/main.py
@@ -15,6 +15,7 @@ from middleware.request_id import RequestIdMiddleware
 from routers import (
     folders,
     ai,
+    analytics,
     auth,
     config,
     export,
@@ -192,6 +193,7 @@ app.include_router(obsidian.router)
 app.include_router(auth.router)
 app.include_router(export.router, dependencies=[Depends(get_current_user)])
 app.include_router(stats.router, dependencies=[Depends(get_current_user)])
+app.include_router(analytics.router, dependencies=[Depends(get_current_user)])
 app.include_router(sync.router, dependencies=[Depends(get_current_user)])
 app.include_router(upload.router, dependencies=[Depends(get_current_user)])
 

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -10,3 +10,4 @@ from .planning import *
 from .push_subscription import *
 from .skill import *
 from .sync_state import *
+from .usage_event import *

--- a/api/models/usage_event.py
+++ b/api/models/usage_event.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+from database import Base
+from sqlalchemy import DateTime, Index, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import JSON
+
+
+class UsageEvent(Base):
+    """Internal usage event — tracked only while the web app is open (#250).
+
+    Records lightweight interactions (page views, feature use, session
+    start/end) so the analytics dashboard can surface "most used features"
+    and session statistics. ``event_data`` is a free-form JSON blob holding
+    context relevant to the event type (e.g. ``{"path": "/notes"}``).
+    """
+
+    __tablename__ = "usage_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    event_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    event_data: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        Index("ix_usage_events_user_created", "user_id", "created_at"),
+        Index("ix_usage_events_type", "event_type"),
+    )

--- a/api/routers/analytics.py
+++ b/api/routers/analytics.py
@@ -1,0 +1,179 @@
+"""Analytics router — unified dashboard + internal usage tracking (#251, #250).
+
+``GET /analytics/dashboard`` aggregates the existing system stats, activity
+time-series, mood stats, and AI usage into a single response so the frontend
+analytics page can render everything with one round-trip. ``POST /analytics/track``
+records a lightweight usage event from the frontend (only while the app is in
+the foreground). ``GET /analytics/usage`` returns the aggregated usage summary.
+"""
+
+import httpx
+from config import settings
+from database import get_db
+from fastapi import APIRouter, Depends, HTTPException, Query
+from middleware.correlation_id import get_correlation_id
+from models.gamification import UserStats, XPEvent
+from models.goal import Goal
+from models.note import Note
+from models.note import Tag as TagModel
+from models.skill import Skill
+from pydantic import BaseModel, field_validator
+from services.auth_service import get_current_user
+from services.mood_service import get_mood_history, get_mood_stats
+from services.usage_service import (
+    VALID_EVENT_TYPES,
+    get_usage_summary,
+    track_event,
+)
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+from datetime import datetime, timedelta, timezone
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+
+class TrackRequest(BaseModel):
+    """Schema for a usage event sent from the frontend."""
+
+    event_type: str
+    event_data: dict | None = None
+
+    @field_validator("event_type")
+    @classmethod
+    def valid_type(cls, v: str) -> str:
+        if v not in VALID_EVENT_TYPES:
+            raise ValueError(
+                f"event_type must be one of: {', '.join(sorted(VALID_EVENT_TYPES))}"
+            )
+        return v
+
+
+def _system_stats(db: Session) -> dict:
+    """Reuse the same queries as /stats/system (kept local to avoid a cross-router import)."""
+    now = datetime.now(timezone.utc)
+    week_ago = now - timedelta(days=7)
+
+    notes_count = db.query(Note).count()
+    tags_count = db.query(TagModel).count()
+    goals_count = db.query(Goal).count()
+    skills_count = db.query(Skill).count()
+
+    stats = db.query(UserStats).first()
+    xp_events_week = db.query(XPEvent).filter(XPEvent.created_at >= week_ago).count()
+
+    return {
+        "notes": notes_count,
+        "tags": tags_count,
+        "goals": goals_count,
+        "skills": skills_count,
+        "total_xp": stats.total_xp if stats else 0,
+        "current_streak": stats.current_streak if stats else 0,
+        "xp_events_week": xp_events_week,
+    }
+
+
+def _activity(db: Session, days: int) -> dict:
+    """Daily activity time-series (notes created + XP events) for the last N days."""
+    if days < 1:
+        days = 1
+    if days > 366:
+        days = 366
+
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(days=days)
+
+    notes_by_day = (
+        db.query(func.date(Note.created_at).label("d"), func.count(Note.id).label("c"))
+        .filter(Note.created_at >= since)
+        .group_by(func.date(Note.created_at))
+        .all()
+    )
+    xp_by_day = (
+        db.query(func.date(XPEvent.created_at).label("d"), func.count(XPEvent.id).label("c"))
+        .filter(XPEvent.created_at >= since)
+        .group_by(func.date(XPEvent.created_at))
+        .all()
+    )
+
+    notes_map = {str(r.d): r.c for r in notes_by_day}
+    xp_map = {str(r.d): r.c for r in xp_by_day}
+
+    daily = []
+    for i in range(days):
+        day = (now - timedelta(days=i)).date()
+        day_str = day.isoformat()
+        daily.append(
+            {
+                "date": day_str,
+                "notes_created": notes_map.get(day_str, 0),
+                "xp_events": xp_map.get(day_str, 0),
+            }
+        )
+    return {"days": daily}
+
+
+async def _ai_usage() -> dict:
+    """Fetch monthly AI usage from the ai-service (best-effort)."""
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        try:
+            headers = {"X-Request-ID": get_correlation_id()}
+            if settings.internal_secret:
+                headers["X-Internal-Secret"] = settings.internal_secret
+            r = await client.get(f"{settings.ai_service_url}/usage", headers=headers)
+            r.raise_for_status()
+            return r.json()
+        except httpx.HTTPError:
+            return {"ai_enabled": False, "estimated_cost_usd": 0, "error": "AI service unreachable"}
+
+
+@router.get("/dashboard")
+async def get_dashboard(
+    days: int = Query(30, ge=1, le=366),
+    db: Session = Depends(get_db),
+    user_id: int = Depends(get_current_user),
+):
+    """Unified analytics dashboard: system + activity + mood + AI usage + usage summary."""
+    system = _system_stats(db)
+    activity = _activity(db, days)
+    mood_stats = get_mood_stats(db, user_id)
+    mood_history = [
+        {
+            "entry_date": e.entry_date.isoformat(),
+            "score": e.score,
+        }
+        for e in get_mood_history(db, user_id, days)
+    ]
+    ai_usage = await _ai_usage()
+    usage = get_usage_summary(db, user_id, days)
+
+    return {
+        "system": system,
+        "activity": activity,
+        "mood": {
+            "stats": mood_stats,
+            "history": mood_history,
+        },
+        "ai_usage": ai_usage,
+        "usage": usage,
+    }
+
+
+@router.post("/track")
+def track(
+    data: TrackRequest,
+    db: Session = Depends(get_db),
+    user_id: int = Depends(get_current_user),
+):
+    """Record a usage event from the frontend (foreground-only)."""
+    event = track_event(db, user_id, data.event_type, data.event_data)
+    return {"status": "ok", "id": event.id}
+
+
+@router.get("/usage")
+def usage(
+    days: int = Query(30, ge=1, le=366),
+    db: Session = Depends(get_db),
+    user_id: int = Depends(get_current_user),
+):
+    """Aggregated internal usage summary for the last ``days`` days."""
+    return get_usage_summary(db, user_id, days)

--- a/api/services/usage_service.py
+++ b/api/services/usage_service.py
@@ -1,0 +1,181 @@
+"""Usage Tracking Service — internal usage metrics for the analytics dashboard (#251, #250).
+
+Records lightweight usage events (page views, feature use, session start/end)
+and aggregates them into summaries consumed by the analytics dashboard. Events
+are only recorded while the web app is in the foreground (the frontend pauses
+tracking on ``visibilitychange`` → hidden).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from models.usage_event import UsageEvent
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+# Event types tracked by the frontend usage store.
+EVENT_PAGE_VIEW = "page_view"
+EVENT_FEATURE_USE = "feature_use"
+EVENT_SESSION_START = "session_start"
+EVENT_SESSION_END = "session_end"
+
+VALID_EVENT_TYPES = {
+    EVENT_PAGE_VIEW,
+    EVENT_FEATURE_USE,
+    EVENT_SESSION_START,
+    EVENT_SESSION_END,
+}
+
+
+def track_event(
+    db: Session,
+    user_id: int,
+    event_type: str,
+    event_data: dict | None = None,
+) -> UsageEvent:
+    """Record a single usage event for ``user_id``.
+
+    Unknown event types are rejected to keep the analytics surface small and
+    predictable. ``event_data`` is stored as-is (JSON column).
+    """
+    if event_type not in VALID_EVENT_TYPES:
+        raise ValueError(f"Unknown usage event type: {event_type}")
+
+    event = UsageEvent(
+        user_id=user_id,
+        event_type=event_type,
+        event_data=event_data,
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    return event
+
+
+def get_usage_summary(db: Session, user_id: int, days: int = 30) -> dict:
+    """Aggregate usage over the last ``days`` days.
+
+    Returns:
+        - ``total_events``: count of all events in the window.
+        - ``session_count``: number of ``session_start`` events.
+        - ``active_days``: distinct calendar days with any event.
+        - ``avg_session_duration_min``: mean minutes between paired
+          ``session_start`` and ``session_end`` events (0 when no pairs).
+        - ``top_features``: list of ``{feature, count}`` sorted desc (top 10).
+        - ``top_pages``: list of ``{path, count}`` sorted desc (top 10).
+    """
+    if days < 1:
+        days = 1
+    if days > 366:
+        days = 366
+
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(days=days)
+
+    base = db.query(UsageEvent).filter(
+        UsageEvent.user_id == user_id,
+        UsageEvent.created_at >= since,
+    )
+
+    total_events = base.count()
+    session_count = base.filter(UsageEvent.event_type == EVENT_SESSION_START).count()
+
+    active_days = (
+        db.query(func.date(UsageEvent.created_at))
+        .filter(
+            UsageEvent.user_id == user_id,
+            UsageEvent.created_at >= since,
+        )
+        .group_by(func.date(UsageEvent.created_at))
+        .count()
+    )
+
+    # Average session duration: pair each session_start with the next
+    # session_end that follows it. This is an approximation (no explicit
+    # session id) but sufficient for a lightweight dashboard.
+    starts = (
+        base.filter(UsageEvent.event_type == EVENT_SESSION_START)
+        .order_by(UsageEvent.created_at.asc())
+        .all()
+    )
+    ends = (
+        base.filter(UsageEvent.event_type == EVENT_SESSION_END)
+        .order_by(UsageEvent.created_at.asc())
+        .all()
+    )
+    durations: list[float] = []
+    end_idx = 0
+    for s in starts:
+        # Find the first end event after this start.
+        while end_idx < len(ends) and ends[end_idx].created_at < s.created_at:
+            end_idx += 1
+        if end_idx < len(ends):
+            delta = ends[end_idx].created_at - s.created_at
+            durations.append(delta.total_seconds() / 60.0)
+            end_idx += 1
+    avg_session_duration_min = round(sum(durations) / len(durations), 2) if durations else 0.0
+
+    top_features = _top_event_values(db, user_id, since, EVENT_FEATURE_USE, "feature", 10)
+    top_pages = _top_event_values(db, user_id, since, EVENT_PAGE_VIEW, "path", 10)
+
+    return {
+        "days": days,
+        "total_events": total_events,
+        "session_count": session_count,
+        "active_days": active_days,
+        "avg_session_duration_min": avg_session_duration_min,
+        "top_features": top_features,
+        "top_pages": top_pages,
+    }
+
+
+def _top_event_values(
+    db: Session,
+    user_id: int,
+    since: datetime,
+    event_type: str,
+    data_key: str,
+    limit: int,
+) -> list[dict]:
+    """Aggregate the most common ``event_data[data_key]`` values for an event type.
+
+    SQLite/PostgreSQL both support ``->``/``->>`` JSON access via SQLAlchemy's
+    ``UsageEvent.event_data[key]`` indexing. We fall back to a Python-side
+    aggregation when the JSON access isn't available (e.g. very old SQLite),
+    keeping the service robust across test and production backends.
+    """
+    events = (
+        db.query(UsageEvent)
+        .filter(
+            UsageEvent.user_id == user_id,
+            UsageEvent.created_at >= since,
+            UsageEvent.event_type == event_type,
+        )
+        .all()
+    )
+    counts: dict[str, int] = {}
+    for e in events:
+        if not e.event_data:
+            continue
+        value = e.event_data.get(data_key)
+        if value is None:
+            continue
+        key = str(value)
+        counts[key] = counts.get(key, 0) + 1
+
+    ranked = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:limit]
+    return [{data_key: k, "count": v} for k, v in ranked]
+
+
+def get_feature_usage(db: Session, user_id: int, days: int = 30) -> list[dict]:
+    """Return which features are used most over the last ``days`` days.
+
+    Each entry is ``{feature, count}`` sorted by count descending. This is a
+    thin wrapper over the ``top_features`` aggregation exposed separately for
+    callers that only care about feature usage.
+    """
+    if days < 1:
+        days = 1
+    if days > 366:
+        days = 366
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    return _top_event_values(db, user_id, since, EVENT_FEATURE_USE, "feature", 50)

--- a/api/tests/test_usage_service.py
+++ b/api/tests/test_usage_service.py
@@ -1,0 +1,241 @@
+"""Unit tests for usage_service — track_event, get_usage_summary, get_feature_usage.
+
+Uses in-memory SQLite and stubs sqlite_vec (matches conftest pattern).
+"""
+
+import sys
+import types
+import unittest
+from datetime import UTC, datetime, timedelta
+
+# Stub sqlite_vec before importing app modules (matches conftest pattern).
+if "sqlite_vec" not in sys.modules:
+    _stub = types.ModuleType("sqlite_vec")
+    _stub.load = lambda _conn: None  # type: ignore
+    sys.modules["sqlite_vec"] = _stub
+
+from database import Base
+from models.usage_event import UsageEvent
+from services.usage_service import (
+    EVENT_FEATURE_USE,
+    EVENT_PAGE_VIEW,
+    EVENT_SESSION_END,
+    EVENT_SESSION_START,
+    get_feature_usage,
+    get_usage_summary,
+    track_event,
+)
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+
+class UsageServiceTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        # tag_cooccurrences is referenced by some models but not always
+        # created cleanly on SQLite; ensure it exists to avoid spurious errors.
+        with self.engine.begin() as conn:
+            try:
+                conn.execute(
+                    text(
+                        "CREATE TABLE IF NOT EXISTS tag_cooccurrences "
+                        "(tag_a_id INTEGER, tag_b_id INTEGER, weight INTEGER, "
+                        "updated_at DATETIME DEFAULT CURRENT_TIMESTAMP)"
+                    )
+                )
+            except Exception:
+                pass
+        self.Session = sessionmaker(bind=self.engine)
+
+    def tearDown(self) -> None:
+        self.engine.dispose()
+
+    def _now(self) -> datetime:
+        return datetime.now(UTC)
+
+
+class TrackEventTest(UsageServiceTestBase):
+    def test_track_page_view(self):
+        db = self.Session()
+        event = track_event(db, user_id=1, event_type=EVENT_PAGE_VIEW, event_data={"path": "/notes"})
+        self.assertEqual(event.event_type, EVENT_PAGE_VIEW)
+        self.assertEqual(event.user_id, 1)
+        self.assertEqual(event.event_data, {"path": "/notes"})
+        self.assertIsNotNone(event.created_at)
+        db.close()
+
+    def test_track_feature_use(self):
+        db = self.Session()
+        event = track_event(db, user_id=2, event_type=EVENT_FEATURE_USE, event_data={"feature": "search"})
+        self.assertEqual(event.event_type, EVENT_FEATURE_USE)
+        self.assertEqual(event.event_data, {"feature": "search"})
+        db.close()
+
+    def test_track_session_start_end(self):
+        db = self.Session()
+        s = track_event(db, user_id=1, event_type=EVENT_SESSION_START)
+        e = track_event(db, user_id=1, event_type=EVENT_SESSION_END)
+        self.assertEqual(s.event_type, EVENT_SESSION_START)
+        self.assertEqual(e.event_type, EVENT_SESSION_END)
+        db.close()
+
+    def test_track_event_no_data(self):
+        db = self.Session()
+        event = track_event(db, user_id=1, event_type=EVENT_SESSION_START)
+        self.assertIsNone(event.event_data)
+        db.close()
+
+    def test_invalid_event_type_raises(self):
+        db = self.Session()
+        with self.assertRaises(ValueError):
+            track_event(db, user_id=1, event_type="bogus", event_data={})
+        db.close()
+
+    def test_events_are_separate_per_user(self):
+        db = self.Session()
+        track_event(db, user_id=1, event_type=EVENT_PAGE_VIEW, event_data={"path": "/a"})
+        track_event(db, user_id=2, event_type=EVENT_PAGE_VIEW, event_data={"path": "/b"})
+        count1 = db.query(UsageEvent).filter(UsageEvent.user_id == 1).count()
+        count2 = db.query(UsageEvent).filter(UsageEvent.user_id == 2).count()
+        self.assertEqual(count1, 1)
+        self.assertEqual(count2, 1)
+        db.close()
+
+
+class GetUsageSummaryTest(UsageServiceTestBase):
+    def test_empty_summary(self):
+        db = self.Session()
+        summary = get_usage_summary(db, user_id=1, days=30)
+        self.assertEqual(summary["total_events"], 0)
+        self.assertEqual(summary["session_count"], 0)
+        self.assertEqual(summary["active_days"], 0)
+        self.assertEqual(summary["avg_session_duration_min"], 0.0)
+        self.assertEqual(summary["top_features"], [])
+        self.assertEqual(summary["top_pages"], [])
+        db.close()
+
+    def test_total_events_and_session_count(self):
+        db = self.Session()
+        track_event(db, 1, EVENT_SESSION_START)
+        track_event(db, 1, EVENT_PAGE_VIEW, {"path": "/notes"})
+        track_event(db, 1, EVENT_FEATURE_USE, {"feature": "search"})
+        track_event(db, 1, EVENT_SESSION_END)
+        summary = get_usage_summary(db, user_id=1, days=30)
+        self.assertEqual(summary["total_events"], 4)
+        self.assertEqual(summary["session_count"], 1)
+        db.close()
+
+    def test_active_days_counts_distinct_days(self):
+        db = self.Session()
+        now = self._now()
+        # Two events on different days.
+        db.add(UsageEvent(user_id=1, event_type=EVENT_PAGE_VIEW, event_data={"path": "/a"}, created_at=now))
+        db.add(
+            UsageEvent(
+                user_id=1,
+                event_type=EVENT_PAGE_VIEW,
+                event_data={"path": "/b"},
+                created_at=now - timedelta(days=2),
+            )
+        )
+        db.commit()
+        summary = get_usage_summary(db, user_id=1, days=30)
+        self.assertEqual(summary["active_days"], 2)
+        db.close()
+
+    def test_excludes_events_outside_window(self):
+        db = self.Session()
+        old = self._now() - timedelta(days=40)
+        db.add(UsageEvent(user_id=1, event_type=EVENT_PAGE_VIEW, event_data={"path": "/old"}, created_at=old))
+        db.commit()
+        summary = get_usage_summary(db, user_id=1, days=30)
+        self.assertEqual(summary["total_events"], 0)
+        db.close()
+
+    def test_avg_session_duration(self):
+        db = self.Session()
+        now = self._now()
+        start = now - timedelta(minutes=10)
+        db.add(UsageEvent(user_id=1, event_type=EVENT_SESSION_START, created_at=start))
+        db.add(UsageEvent(user_id=1, event_type=EVENT_SESSION_END, created_at=now))
+        db.commit()
+        summary = get_usage_summary(db, user_id=1, days=30)
+        # ~10 minutes; allow some tolerance for test timing.
+        self.assertGreater(summary["avg_session_duration_min"], 9.0)
+        self.assertLess(summary["avg_session_duration_min"], 11.5)
+        db.close()
+
+    def test_top_features_and_pages(self):
+        db = self.Session()
+        track_event(db, 1, EVENT_FEATURE_USE, {"feature": "search"})
+        track_event(db, 1, EVENT_FEATURE_USE, {"feature": "search"})
+        track_event(db, 1, EVENT_FEATURE_USE, {"feature": "tag"})
+        track_event(db, 1, EVENT_PAGE_VIEW, {"path": "/notes"})
+        track_event(db, 1, EVENT_PAGE_VIEW, {"path": "/goals"})
+        track_event(db, 1, EVENT_PAGE_VIEW, {"path": "/goals"})
+        summary = get_usage_summary(db, user_id=1, days=30)
+        self.assertEqual(summary["top_features"][0], {"feature": "search", "count": 2})
+        self.assertEqual(summary["top_features"][1], {"feature": "tag", "count": 1})
+        self.assertEqual(summary["top_pages"][0], {"path": "/goals", "count": 2})
+        self.assertEqual(summary["top_pages"][1], {"path": "/notes", "count": 1})
+        db.close()
+
+    def test_days_clamped(self):
+        db = self.Session()
+        # days < 1 clamped to 1, days > 366 clamped to 366 — no crash.
+        s0 = get_usage_summary(db, user_id=1, days=0)
+        self.assertEqual(s0["days"], 1)
+        s1 = get_usage_summary(db, user_id=1, days=999)
+        self.assertEqual(s1["days"], 366)
+        db.close()
+
+    def test_isolated_per_user(self):
+        db = self.Session()
+        track_event(db, 1, EVENT_PAGE_VIEW, {"path": "/a"})
+        track_event(db, 2, EVENT_PAGE_VIEW, {"path": "/b"})
+        track_event(db, 2, EVENT_PAGE_VIEW, {"path": "/b"})
+        s1 = get_usage_summary(db, user_id=1, days=30)
+        s2 = get_usage_summary(db, user_id=2, days=30)
+        self.assertEqual(s1["total_events"], 1)
+        self.assertEqual(s2["total_events"], 2)
+        db.close()
+
+
+class GetFeatureUsageTest(UsageServiceTestBase):
+    def test_empty(self):
+        db = self.Session()
+        self.assertEqual(get_feature_usage(db, user_id=1, days=30), [])
+        db.close()
+
+    def test_ranked_by_count(self):
+        db = self.Session()
+        track_event(db, 1, EVENT_FEATURE_USE, {"feature": "a"})
+        track_event(db, 1, EVENT_FEATURE_USE, {"feature": "b"})
+        track_event(db, 1, EVENT_FEATURE_USE, {"feature": "b"})
+        track_event(db, 1, EVENT_FEATURE_USE, {"feature": "b"})
+        result = get_feature_usage(db, user_id=1, days=30)
+        self.assertEqual(result[0], {"feature": "b", "count": 3})
+        self.assertEqual(result[1], {"feature": "a", "count": 1})
+        db.close()
+
+    def test_ignores_other_event_types(self):
+        db = self.Session()
+        track_event(db, 1, EVENT_PAGE_VIEW, {"path": "/notes"})
+        track_event(db, 1, EVENT_FEATURE_USE, {"feature": "search"})
+        result = get_feature_usage(db, user_id=1, days=30)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], {"feature": "search", "count": 1})
+        db.close()
+
+    def test_excludes_outside_window(self):
+        db = self.Session()
+        old = self._now() - timedelta(days=40)
+        db.add(UsageEvent(user_id=1, event_type=EVENT_FEATURE_USE, event_data={"feature": "old"}, created_at=old))
+        db.commit()
+        self.assertEqual(get_feature_usage(db, user_id=1, days=30), [])
+        db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -308,6 +308,35 @@ export interface MoodStats {
   notes_correlation: number;
 }
 
+export interface UsageSummary {
+  days: number;
+  total_events: number;
+  session_count: number;
+  active_days: number;
+  avg_session_duration_min: number;
+  top_features: { feature: string; count: number }[];
+  top_pages: { path: string; count: number }[];
+}
+
+export interface AnalyticsDashboard {
+  system: {
+    notes: number;
+    tags: number;
+    goals: number;
+    skills: number;
+    total_xp: number;
+    current_streak: number;
+    xp_events_week: number;
+  };
+  activity: { days: { date: string; notes_created: number; xp_events: number }[] };
+  mood: {
+    stats: MoodStats;
+    history: { entry_date: string; score: number }[];
+  };
+  ai_usage: { ai_enabled: boolean; estimated_cost_usd: number; [k: string]: unknown };
+  usage: UsageSummary;
+}
+
 // ── Notes ─────────────────────────────────────────────────────────────────────
 
 export interface SyncConflict {
@@ -705,6 +734,12 @@ export const api = {
       req<{
         days: { date: string; notes_created: number; xp_events: number }[];
       }>('GET', `/stats/activity?days=${days}`),
+  },
+  analytics: {
+    dashboard: (days = 30) => req<AnalyticsDashboard>('GET', `/analytics/dashboard?days=${days}`),
+    track: (event_type: string, event_data?: Record<string, unknown>) =>
+      req<{ status: string; id: number }>('POST', '/analytics/track', { event_type, event_data }, { silent: true }),
+    usage: (days = 30) => req<UsageSummary>('GET', `/analytics/usage?days=${days}`),
   },
   export: {
     markdownUrl: () => `${BASE}/export/notes/markdown`,

--- a/frontend/src/lib/stores/usage.ts
+++ b/frontend/src/lib/stores/usage.ts
@@ -1,0 +1,108 @@
+/**
+ * Usage tracking store — records lightweight internal usage events (#250).
+ *
+ * Tracking only happens while the web app is in the FOREGROUND. We listen to
+ * `visibilitychange` and pause tracking when the tab is hidden, resuming when
+ * it becomes visible again. Calls are debounced to avoid flooding the backend.
+ */
+import { browser } from '$app/environment';
+import { api } from '$lib/api';
+import { logger } from '$lib/utils/logger';
+
+export const EVENT_PAGE_VIEW = 'page_view';
+export const EVENT_FEATURE_USE = 'feature_use';
+export const EVENT_SESSION_START = 'session_start';
+export const EVENT_SESSION_END = 'session_end';
+
+// Minimum interval between tracked events of the same kind (debounce), in ms.
+const DEBOUNCE_MS = 2000;
+// Page-view debounce is shorter but still avoids duplicate rapid nav events.
+const PAGE_VIEW_DEBOUNCE_MS = 800;
+
+let lastTracked: Record<string, number> = {};
+let trackingEnabled = true;
+let sessionStarted = false;
+let initialized = false;
+
+function isForeground(): boolean {
+  return typeof document === 'undefined' || document.visibilityState === 'visible';
+}
+
+function shouldTrack(eventType: string, debounceMs: number): boolean {
+  if (!browser || !trackingEnabled || !isForeground()) return false;
+  const now = Date.now();
+  const last = lastTracked[eventType] ?? 0;
+  if (now - last < debounceMs) return false;
+  lastTracked[eventType] = now;
+  return true;
+}
+
+function send(eventType: string, eventData?: Record<string, unknown>): void {
+  if (!browser || !trackingEnabled || !isForeground()) return;
+  api.analytics.track(eventType, eventData).catch((e) => logger.debug('[usage] track failed:', e));
+}
+
+/** Track a page navigation. Debounced per-path to avoid duplicates. */
+export function trackPageView(path: string): void {
+  if (!shouldTrack(`page_view:${path}`, PAGE_VIEW_DEBOUNCE_MS)) return;
+  send(EVENT_PAGE_VIEW, { path });
+}
+
+/** Track usage of a named feature (e.g. "search", "semantic-search"). */
+export function trackFeatureUse(feature: string): void {
+  if (!shouldTrack(`feature_use:${feature}`, DEBOUNCE_MS)) return;
+  send(EVENT_FEATURE_USE, { feature });
+}
+
+/** Record the start of an active session (called on app mount / foreground). */
+export function trackSessionStart(): void {
+  if (!browser || sessionStarted) return;
+  if (!shouldTrack(EVENT_SESSION_START, DEBOUNCE_MS)) return;
+  sessionStarted = true;
+  send(EVENT_SESSION_START);
+}
+
+/** Record the end of an active session (called on unmount / backgrounding). */
+export function trackSessionEnd(): void {
+  if (!browser || !sessionStarted) return;
+  sessionStarted = false;
+  // Session end is not debounced by lastTracked (we reset sessionStarted),
+  // but still respect the foreground gate.
+  if (!trackingEnabled || !isForeground()) return;
+  send(EVENT_SESSION_END);
+}
+
+/**
+ * Initialize foreground/background tracking. Call once from the root layout.
+ * Returns a cleanup function that removes listeners.
+ */
+export function initUsageTracking(): (() => void) | null {
+  if (!browser || initialized) return null;
+  initialized = true;
+
+  const handleVisibility = () => {
+    if (document.visibilityState === 'visible') {
+      // Resumed foreground — start a new session.
+      trackingEnabled = true;
+      trackSessionStart();
+    } else {
+      // Backgrounded — end the current session and pause tracking (#250).
+      trackSessionEnd();
+      trackingEnabled = false;
+    }
+  };
+
+  // `pagehide` fires on tab close / navigation away — best-effort session end.
+  const handlePageHide = () => {
+    trackSessionEnd();
+  };
+
+  document.addEventListener('visibilitychange', handleVisibility);
+  window.addEventListener('pagehide', handlePageHide);
+
+  return () => {
+    document.removeEventListener('visibilitychange', handleVisibility);
+    window.removeEventListener('pagehide', handlePageHide);
+    initialized = false;
+  };
+}

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -6,7 +6,8 @@
     "skills": "Skills",
     "ai": "AI",
     "goals": "Goals",
-    "streaks": "Streaks"
+    "streaks": "Streaks",
+    "analytics": "Analytics"
   },
   "common": {
     "save": "Save",
@@ -106,5 +107,36 @@
     "lastSync": "Last sync",
     "neverSynced": "Never synced",
     "totalSynced": "{count} notes synced"
+  },
+  "analytics": {
+    "title": "ANALYTICS",
+    "loading": "Loading analytics...",
+    "error": "Failed to load analytics",
+    "noData": "Not enough data",
+    "lastDays": "Last {n}d",
+    "systemOverview": "System overview",
+    "activityTitle": "Activity",
+    "moodTitle": "Mood trends",
+    "aiTitle": "AI usage",
+    "featureUsage": "Most used features",
+    "sessionStats": "Session stats",
+    "notes": "Notes",
+    "tags": "Tags",
+    "goals": "Goals",
+    "skills": "Skills",
+    "totalXp": "Total XP",
+    "streak": "Streak",
+    "notesCreated": "Notes created",
+    "moodAvg": "Avg mood",
+    "moodStreak": "Mood streak",
+    "moodEntries": "Entries",
+    "aiCost": "Estimated cost",
+    "aiMonthly": "Accumulated monthly cost",
+    "aiUnavailable": "AI unavailable",
+    "sessions": "Sessions",
+    "activeDays": "Active days",
+    "avgSessionMin": "Avg session (min)",
+    "totalEvents": "Total events",
+    "topPages": "Top pages"
   }
 }

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -6,7 +6,8 @@
     "skills": "Habilidades",
     "ai": "IA",
     "goals": "Objetivos",
-    "streaks": "Rachas"
+    "streaks": "Rachas",
+    "analytics": "Analítica"
   },
   "common": {
     "save": "Guardar",
@@ -106,5 +107,36 @@
     "lastSync": "Última sincronización",
     "neverSynced": "Nunca sincronizado",
     "totalSynced": "{count} notas sincronizadas"
+  },
+  "analytics": {
+    "title": "ANALÍTICA",
+    "loading": "Cargando analítica...",
+    "error": "Error al cargar la analítica",
+    "noData": "Sin datos suficientes",
+    "lastDays": "Últimos {n}d",
+    "systemOverview": "Resumen del sistema",
+    "activityTitle": "Actividad",
+    "moodTitle": "Tendencias de ánimo",
+    "aiTitle": "Uso de IA",
+    "featureUsage": "Funciones más usadas",
+    "sessionStats": "Estadísticas de sesión",
+    "notes": "Notas",
+    "tags": "Etiquetas",
+    "goals": "Objetivos",
+    "skills": "Habilidades",
+    "totalXp": "XP total",
+    "streak": "Racha",
+    "notesCreated": "Notas creadas",
+    "moodAvg": "Ánimo medio",
+    "moodStreak": "Racha de ánimo",
+    "moodEntries": "Registros",
+    "aiCost": "Coste estimado",
+    "aiMonthly": "Coste mensual acumulado",
+    "aiUnavailable": "IA no disponible",
+    "sessions": "Sesiones",
+    "activeDays": "Días activos",
+    "avgSessionMin": "Sesión media (min)",
+    "totalEvents": "Eventos totales",
+    "topPages": "Páginas más visitadas"
   }
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -52,6 +52,12 @@
   import { initOfflineSync } from '$lib/stores/offlineSync';
   import ShareAchievementModal from '$lib/components/ShareAchievementModal.svelte';
   import { initFocusModeConfig, queueNotificationIfActive } from '$lib/stores/focusMode';
+  import {
+    initUsageTracking,
+    trackPageView,
+    trackSessionStart,
+    trackSessionEnd,
+  } from '$lib/stores/usage';
 
   type NavItemStatus = 'ready' | 'dev' | 'placeholder';
 
@@ -67,7 +73,13 @@
     { href: '/ai', label: $t('nav.ai'), icon: 'Brain', status: 'ready' },
     { href: '/goals', label: $t('nav.goals'), icon: 'Target', status: 'ready' },
     { href: '/streaks', label: $t('nav.streaks'), icon: 'Flame', status: 'ready' },
+    { href: '/analytics', label: $t('nav.analytics'), icon: 'BarChart3', status: 'ready' },
   ] as { href: string; label: string; icon: string; status: NavItemStatus }[];
+
+  // Track page views on route changes (foreground-only, debounced in the store).
+  $: if (mounted && $isAuthenticated) {
+    trackPageView($page.url.pathname);
+  }
 
   let settingsOpen = false;
   let now = new Date();
@@ -122,6 +134,13 @@
     devMode.init();
     const cleanupConnection = initConnectionStore();
     const cleanupOfflineSync = initOfflineSync();
+
+    // Internal usage tracking (#250) — only records while the app is in the
+    // foreground. Starts a session on mount and ends it on cleanup.
+    const cleanupUsage = initUsageTracking();
+    if ($isAuthenticated) {
+      trackSessionStart();
+    }
 
     // First-use detection: start the onboarding tour for brand-new users.
     if ($isAuthenticated) {
@@ -459,6 +478,10 @@
       if (cleanupKeyboard) cleanupKeyboard();
       if (cleanupConnection) cleanupConnection();
       if (cleanupOfflineSync) cleanupOfflineSync();
+      if (cleanupUsage) cleanupUsage();
+      if ($isAuthenticated) {
+        trackSessionEnd();
+      }
       syncStore.stopPolling();
     };
   });

--- a/frontend/src/routes/analytics/+page.svelte
+++ b/frontend/src/routes/analytics/+page.svelte
@@ -1,0 +1,551 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { t } from 'svelte-i18n';
+  import { api, type AnalyticsDashboard } from '$lib/api';
+  import { logger } from '$lib/utils/logger';
+  import { trackFeatureUse } from '$lib/stores/usage';
+
+  let dashboard: AnalyticsDashboard | null = null;
+  let loading = true;
+  let error = '';
+  let days = 30;
+
+  // Derived chart data — kept as plain let + reactive statements for clarity.
+  $: activityDays = dashboard?.activity.days ?? [];
+  $: maxNotes = Math.max(1, ...activityDays.map((d) => d.notes_created));
+  $: maxXP = Math.max(1, ...activityDays.map((d) => d.xp_events));
+
+  $: moodHistory = dashboard?.mood.history ?? [];
+  $: maxMood = 5;
+
+  $: topFeatures = dashboard?.usage.top_features ?? [];
+  $: maxFeatureCount = Math.max(1, ...topFeatures.map((f) => f.count));
+
+  $: topPages = dashboard?.usage.top_pages ?? [];
+  $: maxPageCount = Math.max(1, ...topPages.map((p) => p.count));
+
+  function shortDate(iso: string): string {
+    try {
+      const d = new Date(iso + 'T00:00:00');
+      return d.toLocaleDateString(undefined, { day: '2-digit', month: 'short' });
+    } catch {
+      return iso;
+    }
+  }
+
+  async function load() {
+    loading = true;
+    error = '';
+    try {
+      dashboard = await api.analytics.dashboard(days);
+    } catch (e) {
+      error = $t('analytics.error');
+      logger.error('[analytics] dashboard load failed:', e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    load();
+  });
+
+  function changeRange(newDays: number) {
+    if (newDays === days) return;
+    days = newDays;
+    trackFeatureUse('analytics-range');
+    load();
+  }
+</script>
+
+<div class="analytics-page">
+  <header class="analytics-header">
+    <h1>{$t('analytics.title')}</h1>
+    <div class="range-tabs">
+      {#each [7, 30, 90] as r}
+        <button class="range-tab" class:active={days === r} onclick={() => changeRange(r)}>
+          {$t('analytics.lastDays', { values: { n: r } })}
+        </button>
+      {/each}
+    </div>
+  </header>
+
+  {#if loading}
+    <div class="empty-state">{$t('analytics.loading')}</div>
+  {:else if error}
+    <div class="empty-state error">{error}</div>
+  {:else if dashboard}
+    <!-- System overview -->
+    <section class="card">
+      <h2>{$t('analytics.systemOverview')}</h2>
+      <div class="stat-grid">
+        <div class="stat">
+          <span class="stat-val">{dashboard.system.notes}</span>
+          <span class="stat-lab">{$t('analytics.notes')}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-val">{dashboard.system.tags}</span>
+          <span class="stat-lab">{$t('analytics.tags')}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-val">{dashboard.system.goals}</span>
+          <span class="stat-lab">{$t('analytics.goals')}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-val">{dashboard.system.skills}</span>
+          <span class="stat-lab">{$t('analytics.skills')}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-val">{dashboard.system.total_xp.toLocaleString()}</span>
+          <span class="stat-lab">{$t('analytics.totalXp')}</span>
+        </div>
+        <div class="stat">
+          <span class="stat-val">{dashboard.system.current_streak}</span>
+          <span class="stat-lab">{$t('analytics.streak')}</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- Activity chart -->
+    <section class="card">
+      <h2>{$t('analytics.activityTitle')}</h2>
+      {#if activityDays.length === 0}
+        <div class="empty-state mini">{$t('analytics.noData')}</div>
+      {:else}
+        <div class="bar-chart">
+          {#each activityDays as d}
+            <div
+              class="bar-col"
+              title="{shortDate(d.date)} · {d.notes_created}/{$t(
+                'analytics.notes'
+              )} · {d.xp_events} XP"
+            >
+              <div class="bar-stack">
+                <div
+                  class="bar bar-xp"
+                  style="height: {Math.max(2, (d.xp_events / maxXP) * 50)}%"
+                ></div>
+                <div
+                  class="bar bar-notes"
+                  style="height: {Math.max(2, (d.notes_created / maxNotes) * 50)}%"
+                ></div>
+              </div>
+              <span class="bar-label">{shortDate(d.date).slice(0, 2)}</span>
+            </div>
+          {/each}
+        </div>
+        <div class="legend">
+          <span class="legend-item"
+            ><span class="dot dot-notes"></span>{$t('analytics.notesCreated')}</span
+          >
+          <span class="legend-item"><span class="dot dot-xp"></span>XP</span>
+        </div>
+      {/if}
+    </section>
+
+    <div class="two-col">
+      <!-- Mood trends -->
+      <section class="card">
+        <h2>{$t('analytics.moodTitle')}</h2>
+        {#if moodHistory.length === 0}
+          <div class="empty-state mini">{$t('analytics.noData')}</div>
+        {:else}
+          <div class="mood-stats">
+            <div class="stat">
+              <span class="stat-val">{dashboard.mood.stats.average.toFixed(1)}</span>
+              <span class="stat-lab">{$t('analytics.moodAvg')}</span>
+            </div>
+            <div class="stat">
+              <span class="stat-val">{dashboard.mood.stats.streak}</span>
+              <span class="stat-lab">{$t('analytics.moodStreak')}</span>
+            </div>
+            <div class="stat">
+              <span class="stat-val">{dashboard.mood.stats.total_entries}</span>
+              <span class="stat-lab">{$t('analytics.moodEntries')}</span>
+            </div>
+          </div>
+          <div class="mood-chart">
+            {#each moodHistory as m}
+              <div
+                class="mood-bar"
+                title="{shortDate(m.entry_date)} · {m.score}/5"
+                style="height: {(m.score / maxMood) * 100}%"
+              ></div>
+            {/each}
+          </div>
+        {/if}
+      </section>
+
+      <!-- AI usage -->
+      <section class="card">
+        <h2>{$t('analytics.aiTitle')}</h2>
+        {#if dashboard.ai_usage.ai_enabled}
+          <div class="stat-grid">
+            <div class="stat">
+              <span class="stat-val"
+                >${Number(dashboard.ai_usage.estimated_cost_usd || 0).toFixed(2)}</span
+              >
+              <span class="stat-lab">{$t('analytics.aiCost')}</span>
+            </div>
+          </div>
+          <p class="hint">{$t('analytics.aiMonthly')}</p>
+        {:else}
+          <div class="empty-state mini">{$t('analytics.aiUnavailable')}</div>
+        {/if}
+      </section>
+    </div>
+
+    <div class="two-col">
+      <!-- Feature usage -->
+      <section class="card">
+        <h2>{$t('analytics.featureUsage')}</h2>
+        {#if topFeatures.length === 0}
+          <div class="empty-state mini">{$t('analytics.noData')}</div>
+        {:else}
+          <div class="hbar-list">
+            {#each topFeatures as f}
+              <div class="hbar-row">
+                <span class="hbar-label">{f.feature}</span>
+                <div class="hbar-track">
+                  <div class="hbar-fill" style="width: {(f.count / maxFeatureCount) * 100}%"></div>
+                </div>
+                <span class="hbar-val">{f.count}</span>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </section>
+
+      <!-- Session stats -->
+      <section class="card">
+        <h2>{$t('analytics.sessionStats')}</h2>
+        <div class="stat-grid">
+          <div class="stat">
+            <span class="stat-val">{dashboard.usage.session_count}</span>
+            <span class="stat-lab">{$t('analytics.sessions')}</span>
+          </div>
+          <div class="stat">
+            <span class="stat-val">{dashboard.usage.active_days}</span>
+            <span class="stat-lab">{$t('analytics.activeDays')}</span>
+          </div>
+          <div class="stat">
+            <span class="stat-val">{dashboard.usage.avg_session_duration_min.toFixed(1)}</span>
+            <span class="stat-lab">{$t('analytics.avgSessionMin')}</span>
+          </div>
+          <div class="stat">
+            <span class="stat-val">{dashboard.usage.total_events}</span>
+            <span class="stat-lab">{$t('analytics.totalEvents')}</span>
+          </div>
+        </div>
+        {#if topPages.length > 0}
+          <h3 class="sub-title">{$t('analytics.topPages')}</h3>
+          <div class="hbar-list">
+            {#each topPages as p}
+              <div class="hbar-row">
+                <span class="hbar-label">{p.path}</span>
+                <div class="hbar-track">
+                  <div
+                    class="hbar-fill hbar-fill-alt"
+                    style="width: {(p.count / maxPageCount) * 100}%"
+                  ></div>
+                </div>
+                <span class="hbar-val">{p.count}</span>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </section>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .analytics-page {
+    padding: var(--s4);
+    max-width: 1100px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--s4);
+  }
+
+  .analytics-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--s3);
+  }
+
+  .analytics-header h1 {
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin: 0;
+    letter-spacing: 0.04em;
+  }
+
+  .range-tabs {
+    display: flex;
+    gap: 4px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 2px;
+  }
+
+  .range-tab {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 11px;
+    padding: 4px 10px;
+    border-radius: var(--r-sm);
+    cursor: pointer;
+    transition:
+      background var(--t-fast),
+      color var(--t-fast);
+  }
+
+  .range-tab:hover {
+    color: var(--text-primary);
+  }
+
+  .range-tab.active {
+    background: color-mix(in srgb, var(--xp) 18%, transparent);
+    color: var(--xp);
+  }
+
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    padding: var(--s4);
+  }
+
+  .card h2 {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin: 0 0 var(--s3);
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+  }
+
+  .sub-title {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin: var(--s4) 0 var(--s2);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+
+  .stat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    gap: var(--s3);
+  }
+
+  .stat {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .stat-val {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stat-lab {
+    font-size: 10px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .two-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--s4);
+  }
+
+  @media (max-width: 720px) {
+    .two-col {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* Activity bar chart */
+  .bar-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 120px;
+  }
+
+  .bar-col {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    height: 100%;
+  }
+
+  .bar-stack {
+    flex: 1;
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 2px;
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .bar {
+    width: 100%;
+    border-radius: var(--r-sm);
+    min-height: 2px;
+  }
+
+  .bar-notes {
+    background: color-mix(in srgb, var(--xp) 70%, transparent);
+  }
+
+  .bar-xp {
+    background: color-mix(in srgb, var(--info) 60%, transparent);
+  }
+
+  .bar-label {
+    font-size: 9px;
+    color: var(--text-disabled);
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
+  .legend {
+    display: flex;
+    gap: var(--s4);
+    margin-top: var(--s3);
+    font-size: 10px;
+    color: var(--text-muted);
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+  }
+
+  .dot-notes {
+    background: color-mix(in srgb, var(--xp) 70%, transparent);
+  }
+
+  .dot-xp {
+    background: color-mix(in srgb, var(--info) 60%, transparent);
+  }
+
+  /* Mood chart */
+  .mood-stats {
+    display: flex;
+    gap: var(--s4);
+    margin-bottom: var(--s3);
+  }
+
+  .mood-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 80px;
+  }
+
+  .mood-bar {
+    flex: 1;
+    min-width: 0;
+    background: color-mix(in srgb, var(--success) 60%, transparent);
+    border-radius: var(--r-sm);
+    min-height: 4px;
+  }
+
+  /* Horizontal bar lists */
+  .hbar-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .hbar-row {
+    display: flex;
+    align-items: center;
+    gap: var(--s2);
+    font-size: 11px;
+  }
+
+  .hbar-label {
+    width: 90px;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .hbar-track {
+    flex: 1;
+    height: 6px;
+    background: var(--hover);
+    border-radius: var(--r-full);
+    overflow: hidden;
+  }
+
+  .hbar-fill {
+    height: 100%;
+    background: var(--xp);
+    border-radius: var(--r-full);
+    transition: width var(--t-normal);
+  }
+
+  .hbar-fill-alt {
+    background: var(--info);
+  }
+
+  .hbar-val {
+    width: 28px;
+    text-align: right;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+  }
+
+  .hint {
+    font-size: 10px;
+    color: var(--text-disabled);
+    margin: var(--s2) 0 0;
+  }
+
+  .empty-state {
+    color: var(--text-muted);
+    font-size: 13px;
+    padding: var(--s6);
+    text-align: center;
+  }
+
+  .empty-state.mini {
+    padding: var(--s4);
+    font-size: 11px;
+  }
+
+  .empty-state.error {
+    color: var(--error);
+  }
+</style>


### PR DESCRIPTION
## Summary

Adds a unified **Analytics dashboard** page and **internal usage tracking** that only records events while the web app is in the foreground.

Closes #251 (analytics / data analysis page with internal usage metrics)
Closes #250 (track internal Joidy usage only when web app is open — foreground/background)

### Backend
- **`api/models/usage_event.py`** — new `UsageEvent` table (id, user_id, event_type, event_data JSON, created_at) with indexes on `(user_id, created_at)` and `event_type`.
- **`api/services/usage_service.py`** — `track_event`, `get_usage_summary` (total events, session count, active days, avg session duration, top features, top pages), and `get_feature_usage`. Validates event types; clamps day windows.
- **`api/routers/analytics.py`** — `GET /analytics/dashboard` (system stats + activity + mood stats/history + AI usage + usage summary in one round-trip), `POST /analytics/track` (record event from frontend), `GET /analytics/usage?days=N`. All require auth.
- Registered router in `api/main.py`; registered model in `api/models/__init__.py` and `api/alembic/env.py`.
- **Alembic migration** `a7b8c9d0e1f2` for the `usage_events` table (revises `f6a7b8c9d0e1`).

### Frontend
- **`frontend/src/lib/stores/usage.ts`** — `trackPageView`, `trackFeatureUse`, `trackSessionStart`/`trackSessionEnd`, and `initUsageTracking()`. Listens to `visibilitychange` to **pause tracking when the tab is hidden** and resume on foreground (#250). Calls are debounced to avoid flooding.
- **`frontend/src/routes/analytics/+page.svelte`** — unified dashboard: system overview, 30-day activity chart, mood trends, AI usage, most-used features, session stats, and top pages. CSS-based bar charts (no heavy chart library), design tokens from `app.css`, all strings via `$t`.
- **`frontend/src/lib/api.ts`** — `api.analytics.dashboard()`, `api.analytics.track()`, `api.analytics.usage()` + `UsageSummary`/`AnalyticsDashboard` types.
- **`frontend/src/routes/+layout.svelte`** — tracks page views on route changes, starts/ends a session on mount/unmount, initializes foreground/background tracking, and adds the **Analytics** nav item (BarChart3 icon).
- i18n strings added to both `es/common.json` and `en/common.json`.

## Test plan
- [x] `python -m py_compile` on all new/changed Python files
- [x] `PYTHONPATH=. python -m unittest tests.test_usage_service` — **18 tests pass** (track_event, get_usage_summary, get_feature_usage, per-user isolation, day clamping, window filtering, session duration pairing)
- [x] `npm run check` — **0 errors** (119 pre-existing warnings, none in new/changed files)
- [ ] Manual: open the Analytics page, switch the 7/30/90-day ranges, background the tab and confirm tracking pauses, foreground and confirm it resumes
- [ ] Manual: run `make migrate` to apply the `usage_events` migration

Generated with [Devin](https://devin.ai)