### PR TITLE
fix: stability audit — 5 urgent fixes

### DIFF
--- a/api/models/planning.py
+++ b/api/models/planning.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 
 from database import Base
-from sqlalchemy import Date, DateTime, ForeignKey, Integer
+from sqlalchemy import Date, DateTime, ForeignKey, Integer, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 
@@ -11,6 +11,6 @@ class PlanningAssignment(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
     goal_id: Mapped[int] = mapped_column(Integer, ForeignKey("goals.id", ondelete="CASCADE"), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=None)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     goal = relationship("Goal")

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -192,14 +192,19 @@ class SetupRequest(BaseModel):
 def setup_status():
     env_vars = read_env()
     needs_setup = not (env_vars.get("AUTH_PASSWORD") and env_vars.get("SECRET_KEY"))
+    # Only reveal whether setup is needed — no sensitive information
     return {"needs_setup": needs_setup}
 
 @router.post("/setup")
 def perform_setup(req: SetupRequest):
     env_vars = read_env()
 
+    # Reject if setup already completed — prevents re-setup attacks
     if env_vars.get("AUTH_PASSWORD") and env_vars.get("SECRET_KEY"):
-        return {"status": "error", "message": "Setup already completed"}
+        raise HTTPException(
+            status_code=403,
+            detail="Setup already completed. Use the settings page to change configuration.",
+        )
 
     if not req.auth_password or len(req.auth_password) < 4:
         raise HTTPException(

--- a/api/routers/push.py
+++ b/api/routers/push.py
@@ -21,10 +21,10 @@ class PushMessageIn(BaseModel):
 
 
 @router.get("/vapid-public-key")
-def get_vapid_public_key():
-    if not settings.vapid_public_key:
-        raise HTTPException(status_code=503, detail="VAPID not configured")
-    return {"publicKey": settings.vapid_public_key}
+def get_vapid_public_key(user_id: int = Depends(get_current_user)):
+    # Return null instead of 503 when VAPID is not configured —
+    # lets the frontend gracefully disable push notifications (#549)
+    return {"publicKey": settings.vapid_public_key or None}
 
 
 @router.post("/subscribe")

--- a/api/tests/test_push.py
+++ b/api/tests/test_push.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 
 def test_vapid_public_key_unconfigured(client):
     resp = client.get("/push/vapid-public-key")
-    assert resp.status_code == 503
+    assert resp.status_code == 200
+    assert resp.json()["publicKey"] is None
 
 
 def test_subscribe_requires_keys(client):

--- a/api/tests/test_routers_push.py
+++ b/api/tests/test_routers_push.py
@@ -75,5 +75,6 @@ def test_unsubscribe_when_none(client: TestClient):
 
 def test_vapid_public_key_not_configured(client: TestClient):
     response = client.get("/push/vapid-public-key")
-    # VAPID is not configured in tests → 503
-    assert response.status_code == 503
+    # VAPID not configured → returns null instead of 503 (#549)
+    assert response.status_code == 200
+    assert response.json()["publicKey"] is None

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,7 +28,7 @@ services:
       - APP_ENV=development
       - VAULT_PATH=/vault
       - OBSIDIAN_VAULT_PATH=/vault
-    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload --reload-include '*.py'
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload --reload-include '*.py' --reload-exclude '__pycache__/*' --reload-exclude '*.pyc'
 
   ai-service:
     build:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -811,7 +811,7 @@ export const api = {
   },
 
   push: {
-    vapidPublicKey: () => req<{ publicKey: string }>('GET', '/push/vapid-public-key'),
+    vapidPublicKey: () => req<{ publicKey: string | null }>('GET', '/push/vapid-public-key'),
     subscribe: (endpoint: string, keys: { p256dh: string; auth: string }) =>
       req<{ status: string }>('POST', '/push/subscribe', { endpoint, keys }),
     unsubscribe: () => req<{ status: string }>('POST', '/push/unsubscribe'),

--- a/frontend/src/lib/components/ConflictResolutionModal.svelte
+++ b/frontend/src/lib/components/ConflictResolutionModal.svelte
@@ -7,16 +7,23 @@
   let resolution: ConflictResolution | null = null;
   let mergedContent = '';
   let resolving = false;
+  // Track dismissed conflict IDs so the modal doesn't re-open on every
+  // navigation after the user skips a conflict (#550).
+  let dismissed: Set<number> = new Set();
 
-  // Auto-open modal when conflicts exist
-  $: if ($syncStore.conflicts.length > 0 && !selectedConflict) {
-    selectedConflict = $syncStore.conflicts[0];
-    resolution = null;
-    mergedContent = '';
+  // Auto-open modal only for conflicts the user hasn't dismissed this session
+  $: {
+    const undismissed = $syncStore.conflicts.filter(c => !dismissed.has(c.note_id));
+    if (undismissed.length > 0 && !selectedConflict) {
+      selectedConflict = undismissed[0];
+      resolution = null;
+      mergedContent = '';
+    }
   }
 
   $: if ($syncStore.conflicts.length === 0) {
     selectedConflict = null;
+    dismissed = new Set();
   }
 
   async function handleResolve() {
@@ -36,6 +43,9 @@
   }
 
   function handleSkip() {
+    if (selectedConflict) {
+      dismissed = new Set([...dismissed, selectedConflict.note_id]);
+    }
     selectedConflict = null;
     resolution = null;
     mergedContent = '';


### PR DESCRIPTION
## Summary

Exhaustive stability and usability audit of Joidy. 5 urgent fixes:

- **#547**: `PlanningAssignment.created_at` now has `server_default=func.now()` instead of `None` — timestamps auto-populate correctly
- **#548**: `POST /config/setup` returns 403 (not silent error) when setup already completed — prevents re-setup attacks
- **#549**: `GET /push/vapid-public-key` now requires auth and returns `{"publicKey": null}` instead of 503 when VAPID not configured — eliminates console error on every page load
- **#550**: Sync conflict modal tracks dismissed conflicts per-session — no longer re-opens on every page navigation after user skips it
- **#551**: API reloader excludes `__pycache__/*` and `*.pyc` — stops constant restarts that re-run migrations every ~30s

## Files changed

| File | Change |
|------|--------|
| `api/models/planning.py` | `server_default=func.now()` on `created_at` |
| `api/routers/config.py` | 403 on re-setup attempt |
| `api/routers/push.py` | Auth required + null instead of 503 |
| `frontend/src/lib/api.ts` | `publicKey: string \| null` type |
| `frontend/src/lib/components/ConflictResolutionModal.svelte` | Dismissed set per-session |
| `docker-compose.dev.yml` | `--reload-exclude` for pycache |

## Audit findings (issues created)

- #547 — PlanningAssignment.created_at missing server_default
- #548 — /config/setup endpoints missing auth
- #549 — frontend requests /push/vapid-public-key without auth
- #550 — sync conflict modal opens on every navigation
- #551 — API reloader restarts constantly due to __pycache__

## Additional findings (not fixed in this PR — lower priority)

- 17 routers without tests (ai, analytics, export, folders, vault, websocket, etc.)
- 4 integration services without tests (github, google, spotify, strava)
- PersonalStreak model uses old Column style (inconsistent with Mapped style)
- Obsidian webhook auth logic doesn't fall back to JWT as documented
- CORS allows * in development (documented, acceptable)

## Test plan

- [x] `python -m py_compile` on all changed Python files
- [x] `npm run check` — 0 errors, 119 pre-existing warnings
- [ ] `POST /goals/` returns 201 (was 500 due to vault permissions — fixed separately)
- [ ] `GET /push/vapid-public-key` returns `{"publicKey": null}` when VAPID not configured
- [ ] Conflict modal does not re-open after skipping
- [ ] API does not restart every 30s in dev mode

Generated with [Devin](https://devin.ai)