### PR TITLE
test(backend): critical router test coverage — ai, export, folders, vault, websocket (#13)

### DIFF
--- a/api/tests/test_export.py
+++ b/api/tests/test_export.py
@@ -37,6 +37,28 @@ def test_export_notes_zip(client, db_session):
     resp = client.get("/export/notes/zip")
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/zip"
+    assert resp.headers["content-disposition"].startswith("attachment; filename=")
+    # The body must be a valid ZIP archive containing the note file.
+    import io
+    import zipfile
+
+    zf = zipfile.ZipFile(io.BytesIO(resp.content))
+    names = zf.namelist()
+    assert len(names) >= 1
+    assert any(name.endswith(".md") for name in names)
+    body = zf.read(names[0]).decode("utf-8")
+    assert "# Hello" in body
+    assert "World" in body
+
+
+def test_export_notes_html_empty(client):
+    resp = client.get("/export/notes/html")
+    assert resp.status_code == 404
+
+
+def test_export_notes_zip_empty(client):
+    resp = client.get("/export/notes/zip")
+    assert resp.status_code == 404
 
 
 def test_export_notes_markdown_empty(client):

--- a/api/tests/test_folders.py
+++ b/api/tests/test_folders.py
@@ -31,4 +31,52 @@ def test_create_folder_success(client, monkeypatch, tmp_path):
 
     resp = client.post("/folders/", json={"path": "notes/daily"})
     assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "path": "notes/daily"}
     assert os.path.isdir(os.path.join(vault, "notes", "daily"))
+
+
+def test_create_folder_already_exists(client, monkeypatch, tmp_path):
+    vault = str(tmp_path / "vault")
+    os.makedirs(vault, exist_ok=True)
+    monkeypatch.setattr(settings, "obsidian_vault_path", vault)
+
+    # Pre-create the folder so the endpoint sees it as existing.
+    os.makedirs(os.path.join(vault, "existing-folder"), exist_ok=True)
+
+    resp = client.post("/folders/", json={"path": "existing-folder"})
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Folder already exists"
+
+
+def test_create_folder_no_vault_path(client, monkeypatch):
+    """When OBSIDIAN_VAULT_PATH is not set, folder creation returns 400."""
+    monkeypatch.setattr(settings, "obsidian_vault_path", "")
+
+    resp = client.post("/folders/", json={"path": "some-folder"})
+    assert resp.status_code == 400
+    assert "OBSIDIAN_VAULT_PATH" in resp.json()["detail"]
+
+
+def test_delete_folder_success(client, monkeypatch, tmp_path):
+    vault = str(tmp_path / "vault")
+    os.makedirs(vault, exist_ok=True)
+    monkeypatch.setattr(settings, "obsidian_vault_path", vault)
+
+    # Create a folder to delete.
+    folder = os.path.join(vault, "to-delete")
+    os.makedirs(folder, exist_ok=True)
+
+    resp = client.delete("/folders/to-delete")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+    assert not os.path.exists(folder)
+
+
+def test_delete_folder_not_found(client, monkeypatch, tmp_path):
+    vault = str(tmp_path / "vault")
+    os.makedirs(vault, exist_ok=True)
+    monkeypatch.setattr(settings, "obsidian_vault_path", vault)
+
+    resp = client.delete("/folders/nonexistent-folder")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Folder not found"

--- a/api/tests/test_routers_ai.py
+++ b/api/tests/test_routers_ai.py
@@ -1,0 +1,217 @@
+"""Tests for /ai router endpoints (#13).
+
+The AI service runs in a separate container, so all outbound ``httpx`` calls
+are mocked. These tests cover the chat, classify, usage, and daily-recap
+endpoints, including graceful degradation when the AI service is unreachable.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+
+def _mock_httpx(response_json: dict) -> tuple[MagicMock, MagicMock]:
+    """Build a mocked ``httpx.AsyncClient`` async-context-manager.
+
+    Returns the class-level mock (to be asserted on) and the instance mock so
+    callers can inspect which method was called.
+    """
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = response_json
+    mock_resp.raise_for_status = MagicMock()
+
+    mock_instance = MagicMock()
+    mock_instance.get = AsyncMock(return_value=mock_resp)
+    mock_instance.post = AsyncMock(return_value=mock_resp)
+    mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+    mock_instance.__aexit__ = AsyncMock(return_value=None)
+
+    mock_cls = MagicMock(return_value=mock_instance)
+    return mock_cls, mock_instance
+
+
+# --- GET /ai/usage -----------------------------------------------------------
+
+
+@patch("routers.ai.httpx.AsyncClient")
+def test_ai_usage_returns_data(mock_client_cls, client: TestClient):
+    mock_cls, mock_instance = _mock_httpx({"ai_enabled": True, "estimated_cost_usd": 1.23, "tokens": 5000})
+    mock_client_cls.side_effect = mock_cls
+
+    resp = client.get("/ai/usage")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ai_enabled"] is True
+    assert data["estimated_cost_usd"] == 1.23
+    mock_instance.get.assert_awaited_once()
+
+
+@patch("routers.ai.httpx.AsyncClient")
+def test_ai_usage_unreachable_returns_fallback(mock_client_cls, client: TestClient):
+    """When the AI service is down the endpoint returns a safe fallback (#13)."""
+    import httpx
+
+    mock_instance = MagicMock()
+    mock_instance.get = AsyncMock(side_effect=httpx.HTTPError("connection refused"))
+    mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+    mock_instance.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_instance
+
+    resp = client.get("/ai/usage")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ai_enabled"] is False
+    assert data["estimated_cost_usd"] == 0
+    assert "error" in data
+
+
+# --- POST /ai/chat -----------------------------------------------------------
+
+
+@patch("routers.ai.httpx.AsyncClient")
+def test_ai_chat_with_valid_message(mock_client_cls, client: TestClient):
+    mock_cls, mock_instance = _mock_httpx({"response": "Hello! How can I help?", "suggestions": ["Tell me more"]})
+    mock_client_cls.side_effect = mock_cls
+
+    resp = client.post(
+        "/ai/chat",
+        json={"messages": [{"role": "user", "content": "Hi there"}]},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["response"] == "Hello! How can I help?"
+    assert "Tell me more" in data["suggestions"]
+    mock_instance.post.assert_awaited_once()
+
+
+def test_ai_chat_with_empty_messages_validation(client: TestClient):
+    """A request missing the required ``messages`` field fails validation."""
+    resp = client.post("/ai/chat", json={})
+    assert resp.status_code == 422
+
+
+def test_ai_chat_with_malformed_message_validation(client: TestClient):
+    """A message missing the ``content`` field fails validation."""
+    resp = client.post("/ai/chat", json={"messages": [{"role": "user"}]})
+    assert resp.status_code == 422
+
+
+@patch("routers.ai.httpx.AsyncClient")
+def test_ai_chat_service_unavailable(mock_client_cls, client: TestClient):
+    """When the AI service is unreachable, chat returns a graceful fallback."""
+    import httpx
+
+    mock_instance = MagicMock()
+    mock_instance.post = AsyncMock(side_effect=httpx.HTTPError("timeout"))
+    mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+    mock_instance.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_instance
+
+    resp = client.post(
+        "/ai/chat",
+        json={"messages": [{"role": "user", "content": "Hi"}]},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "unavailable"
+    assert "response" in data
+
+
+# --- POST /ai/classify -------------------------------------------------------
+
+
+@patch("routers.ai.httpx.AsyncClient")
+def test_ai_classify_returns_suggestions(mock_client_cls, client: TestClient):
+    mock_cls, mock_instance = _mock_httpx({"note_id": 1, "suggestions": ["work", "urgent"]})
+    mock_client_cls.side_effect = mock_cls
+
+    resp = client.post(
+        "/ai/classify",
+        json={"note_id": 1, "content": "Meeting about project deadline", "existing_tags": []},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["note_id"] == 1
+    assert "work" in data["suggestions"]
+    mock_instance.post.assert_awaited_once()
+
+
+@patch("routers.ai.httpx.AsyncClient")
+def test_ai_classify_service_unavailable(mock_client_cls, client: TestClient):
+    """Classify degrades gracefully when the AI service is down."""
+    import httpx
+
+    mock_instance = MagicMock()
+    mock_instance.post = AsyncMock(side_effect=httpx.HTTPError("refused"))
+    mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+    mock_instance.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_instance
+
+    resp = client.post(
+        "/ai/classify",
+        json={"note_id": 2, "content": "Some content"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "unavailable"
+    assert data["suggestions"] == []
+
+
+# --- POST /ai/daily-recap ----------------------------------------------------
+
+
+@patch("routers.ai.httpx.AsyncClient")
+def test_ai_daily_recap_returns_summary(mock_client_cls, client: TestClient):
+    mock_cls, mock_instance = _mock_httpx({"recap": "You created 3 notes today.", "suggestions": ["Review your goals"]})
+    mock_client_cls.side_effect = mock_cls
+
+    resp = client.post("/ai/daily-recap")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "recap" in data
+    mock_instance.post.assert_awaited_once()
+
+
+@patch("routers.ai.httpx.AsyncClient")
+def test_ai_daily_recap_with_explicit_date(mock_client_cls, client: TestClient):
+    mock_cls, mock_instance = _mock_httpx({"recap": "Summary for the day.", "suggestions": []})
+    mock_client_cls.side_effect = mock_cls
+
+    resp = client.post("/ai/daily-recap?target_date=2024-06-15")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["recap"] == "Summary for the day."
+
+
+def test_ai_daily_recap_invalid_date(client: TestClient):
+    """An invalid date format returns 400."""
+    resp = client.post("/ai/daily-recap?target_date=not-a-date")
+    assert resp.status_code == 400
+    assert "Invalid date format" in resp.json()["detail"]
+
+
+@patch("routers.ai.httpx.AsyncClient")
+def test_ai_daily_recap_service_unavailable(mock_client_cls, client: TestClient):
+    """Daily recap degrades gracefully when the AI service is down."""
+    import httpx
+
+    mock_instance = MagicMock()
+    mock_instance.post = AsyncMock(side_effect=httpx.HTTPError("down"))
+    mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+    mock_instance.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_instance
+
+    resp = client.post("/ai/daily-recap")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "unavailable"
+    assert "recap" in data

--- a/api/tests/test_routers_vault.py
+++ b/api/tests/test_routers_vault.py
@@ -1,0 +1,88 @@
+"""Tests for /vault router endpoints (#13).
+
+The vault writer service touches the filesystem (Obsidian vault), so the
+service functions are mocked to test the router layer in isolation. This
+covers the write-daily, write-objectives, write-skills, and restore-goals
+endpoints for both success and no-vault paths.
+"""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+@patch("routers.vault.write_daily", return_value=True)
+def test_vault_write_daily_ok(mock_write, client: TestClient):
+    resp = client.post("/vault/write-daily")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["file"].startswith("_joidy/daily/")
+    assert data["file"].endswith(".md")
+    mock_write.assert_called_once()
+
+
+@patch("routers.vault.write_daily", return_value=False)
+def test_vault_write_daily_no_vault(mock_write, client: TestClient):
+    resp = client.post("/vault/write-daily")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "no_vault"
+    mock_write.assert_called_once()
+
+
+@patch("routers.vault.write_objectives", return_value=True)
+def test_vault_write_objectives_ok(mock_write, client: TestClient):
+    resp = client.post("/vault/write-objectives")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    mock_write.assert_called_once()
+
+
+@patch("routers.vault.write_objectives", return_value=False)
+def test_vault_write_objectives_no_vault(mock_write, client: TestClient):
+    resp = client.post("/vault/write-objectives")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "no_vault"
+    mock_write.assert_called_once()
+
+
+@patch("routers.vault.write_skills", return_value=True)
+def test_vault_write_skills_ok(mock_write, client: TestClient):
+    resp = client.post("/vault/write-skills")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    mock_write.assert_called_once()
+
+
+@patch("routers.vault.write_skills", return_value=False)
+def test_vault_write_skills_no_vault(mock_write, client: TestClient):
+    resp = client.post("/vault/write-skills")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "no_vault"
+    mock_write.assert_called_once()
+
+
+@patch(
+    "routers.vault.restore_goals_from_vault",
+    return_value={"status": "ok", "restored": 2, "skipped": 1},
+)
+def test_vault_restore_goals(mock_restore, client: TestClient):
+    resp = client.post("/vault/restore-goals")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["restored"] == 2
+    assert data["skipped"] == 1
+    mock_restore.assert_called_once()
+
+
+@patch(
+    "routers.vault.restore_goals_from_vault",
+    return_value={"status": "no_vault", "restored": 0, "skipped": 0},
+)
+def test_vault_restore_goals_no_vault(mock_restore, client: TestClient):
+    resp = client.post("/vault/restore-goals")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "no_vault"
+    assert data["restored"] == 0

--- a/api/tests/test_routers_websocket.py
+++ b/api/tests/test_routers_websocket.py
@@ -1,0 +1,163 @@
+"""Tests for the /ws WebSocket endpoint and ConnectionManager (#13).
+
+Covers:
+- WebSocket connection in development mode (auth bypassed).
+- WebSocket connection with a valid JWT token when auth is configured.
+- WebSocket rejection when no token is provided and auth is configured.
+- Ping/pong message handling.
+- ConnectionManager.broadcast delivering messages to connected clients.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from config import settings
+from fastapi.testclient import TestClient
+from routers.websocket import ConnectionManager
+from services.auth_service import create_access_token
+from starlette.websockets import WebSocketDisconnect
+
+# --- Connection (dev mode, auth bypassed) ------------------------------------
+
+
+def test_ws_connect_dev_mode(client: TestClient, monkeypatch):
+    """In development without AUTH_PASSWORD, the /ws endpoint accepts connections."""
+    monkeypatch.setattr(settings, "auth_password", "")
+    monkeypatch.setattr(settings, "app_env", "development")
+
+    with client.websocket_connect("/ws") as websocket:
+        websocket.send_text(json.dumps({"type": "ping"}))
+        data = websocket.receive_json()
+        assert data == {"type": "pong"}
+
+
+def test_ws_ping_pong(client: TestClient, monkeypatch):
+    monkeypatch.setattr(settings, "auth_password", "")
+    monkeypatch.setattr(settings, "app_env", "development")
+
+    with client.websocket_connect("/ws") as websocket:
+        websocket.send_text(json.dumps({"type": "ping"}))
+        assert websocket.receive_json() == {"type": "pong"}
+
+
+def test_ws_ignores_non_json(client: TestClient, monkeypatch):
+    """Malformed (non-JSON) messages are silently ignored, not crashing the socket."""
+    monkeypatch.setattr(settings, "auth_password", "")
+    monkeypatch.setattr(settings, "app_env", "development")
+
+    with client.websocket_connect("/ws") as websocket:
+        websocket.send_text("not-json-at-all")
+        # A subsequent valid ping should still work.
+        websocket.send_text(json.dumps({"type": "ping"}))
+        assert websocket.receive_json() == {"type": "pong"}
+
+
+# --- Authentication ----------------------------------------------------------
+
+
+def test_ws_rejected_without_token(client: TestClient, monkeypatch):
+    """When AUTH_PASSWORD is set, connecting without a token is rejected (4001)."""
+    monkeypatch.setattr(settings, "auth_password", "test-secret")
+    monkeypatch.setattr(settings, "app_env", "development")
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/ws"):
+            pass
+
+    assert exc_info.value.code == 4001
+
+
+def test_ws_rejected_with_invalid_token(client: TestClient, monkeypatch):
+    """An invalid token is rejected with 4001."""
+    monkeypatch.setattr(settings, "auth_password", "test-secret")
+    monkeypatch.setattr(settings, "secret_key", "test-secret-key")
+    monkeypatch.setattr(settings, "app_env", "development")
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/ws?token=invalid-token"):
+            pass
+
+    assert exc_info.value.code == 4001
+
+
+def test_ws_connect_with_valid_token(client: TestClient, monkeypatch):
+    """A valid JWT token allows the connection and ping/pong works."""
+    monkeypatch.setattr(settings, "auth_password", "test-secret")
+    monkeypatch.setattr(settings, "secret_key", "test-secret-key-32bytes-long-aaaa")
+    monkeypatch.setattr(settings, "app_env", "development")
+
+    token = create_access_token(user_id=1)
+    with client.websocket_connect(f"/ws?token={token}") as websocket:
+        websocket.send_text(json.dumps({"type": "ping"}))
+        assert websocket.receive_json() == {"type": "pong"}
+
+
+# --- ConnectionManager.broadcast ---------------------------------------------
+
+
+def test_manager_broadcast_delivers_to_all():
+    """broadcast() sends the message to every active connection."""
+
+    async def _run():
+        manager = ConnectionManager()
+        ws_a = MagicMock()
+        ws_a.send_json = AsyncMock()
+        ws_b = MagicMock()
+        ws_b.send_json = AsyncMock()
+        manager.active_connections = {ws_a, ws_b}
+
+        await manager.broadcast({"type": "note_created", "note_id": 1, "title": "Hi"})
+
+        ws_a.send_json.assert_awaited_once_with({"type": "note_created", "note_id": 1, "title": "Hi"})
+        ws_b.send_json.assert_awaited_once_with({"type": "note_created", "note_id": 1, "title": "Hi"})
+
+    asyncio.run(_run())
+
+
+def test_manager_broadcast_no_connections_is_noop():
+    """broadcast() with no active connections does nothing."""
+
+    async def _run():
+        manager = ConnectionManager()
+        await manager.broadcast({"type": "test"})  # must not raise
+
+    asyncio.run(_run())
+
+
+def test_manager_broadcast_removes_failed_connections():
+    """A connection that raises on send is removed from the active set."""
+
+    async def _run():
+        manager = ConnectionManager()
+        good_ws = MagicMock()
+        good_ws.send_json = AsyncMock()
+        bad_ws = MagicMock()
+        bad_ws.send_json = AsyncMock(side_effect=RuntimeError("disconnected"))
+        manager.active_connections = {good_ws, bad_ws}
+
+        await manager.broadcast({"type": "test"})
+
+        assert good_ws in manager.active_connections
+        assert bad_ws not in manager.active_connections
+
+    asyncio.run(_run())
+
+
+def test_manager_connect_and_disconnect():
+    """connect() adds and accept()s; disconnect() removes from the active set."""
+
+    async def _run():
+        manager = ConnectionManager()
+        ws = MagicMock()
+        ws.accept = AsyncMock()
+
+        await manager.connect(ws)
+        assert ws in manager.active_connections
+        ws.accept.assert_awaited_once()
+
+        manager.disconnect(ws)
+        assert ws not in manager.active_connections
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary

Adds test coverage for the 5 most critical untested routers identified in #13. These routers handle core functionality (AI chat, note export, folder management, vault writes, real-time WebSocket) but had no dedicated router-level tests.

### Changes

**`api/tests/test_routers_ai.py`** (new — 12 tests)
- `GET /ai/usage` — returns usage data; graceful fallback when AI service unreachable
- `POST /ai/chat` — valid message (mocked AI service); empty/malformed message validation (422); service-unavailable fallback
- `POST /ai/classify` — returns tag suggestions; service-unavailable fallback
- `POST /ai/daily-recap` — returns summary; explicit date param; invalid date (400); service-unavailable fallback

All outbound `httpx` calls to the ai-service container are mocked via `unittest.mock.patch("routers.ai.httpx.AsyncClient")`.

**`api/tests/test_routers_vault.py`** (new — 8 tests)
- `POST /vault/write-daily` — ok + no_vault paths
- `POST /vault/write-objectives` — ok + no_vault paths
- `POST /vault/write-skills` — ok + no_vault paths
- `POST /vault/restore-goals` — ok + no_vault paths

Vault writer service functions (`write_daily`, `write_objectives`, `write_skills`, `restore_goals_from_vault`) are mocked to isolate the router layer from filesystem access.

**`api/tests/test_routers_websocket.py`** (new — 10 tests)
- WebSocket connection in dev mode (auth bypassed) with ping/pong
- Malformed non-JSON message handling (silently ignored)
- Connection rejected without token (4001) when auth configured
- Connection rejected with invalid token (4001)
- Connection accepted with valid JWT token
- `ConnectionManager.broadcast` delivers to all connections, noop with no connections, removes failed connections
- `ConnectionManager.connect`/`disconnect` lifecycle

**`api/tests/test_folders.py`** (extended — +5 tests)
- Folder creation already-exists (400)
- Folder creation with no vault path configured (400)
- Folder delete success
- Folder delete not-found (404)
- *(path traversal already covered by existing create test)*

**`api/tests/test_export.py`** (extended — +3 tests)
- ZIP export validates binary content is a real ZIP archive with note markdown inside
- HTML export empty (404)
- ZIP export empty (404)

### Test plan

- [x] `python -m py_compile` passes on all modified/new test files
- [x] All 48 tests pass locally (websocket ConnectionManager + client-based tests validated with temporary conftest SQLAlchemy compat fix for Python 3.14; CI runs on Python 3.12 Docker target)
- [x] `ruff format` + `ruff check --fix` applied to all modified files
- [x] No changes to `conftest.py` or production code — test-only PR

Closes #13.

---

Generated with [Devin](https://devin.ai)