### PR TITLE
fix(ui): graph filters, sync conflict modal, export dropdown (#550, #274)

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -197,6 +197,8 @@ body.zen-mode-active .app-shell {
   padding: var(--s3) 0;
   gap: var(--s2);
   overflow: visible;
+  position: relative;
+  z-index: var(--z-base);
 }
 
 .app-main {

--- a/frontend/src/lib/components/ConflictResolutionModal.svelte
+++ b/frontend/src/lib/components/ConflictResolutionModal.svelte
@@ -7,13 +7,12 @@
   let resolution: ConflictResolution | null = null;
   let mergedContent = '';
   let resolving = false;
-  // Track dismissed conflict IDs so the modal doesn't re-open on every
-  // navigation after the user skips a conflict (#550).
-  let dismissed: Set<number> = new Set();
 
-  // Auto-open modal only for conflicts the user hasn't dismissed this session
+  // Auto-open modal only for conflicts the user hasn't dismissed this session.
+  // The dismissed set lives in the syncStore so it persists across navigations
+  // (component is recreated on each route change, local state would be lost).
   $: {
-    const undismissed = $syncStore.conflicts.filter(c => !dismissed.has(c.note_id));
+    const undismissed = $syncStore.conflicts.filter(c => !$syncStore.dismissed.has(c.note_id));
     if (undismissed.length > 0 && !selectedConflict) {
       selectedConflict = undismissed[0];
       resolution = null;
@@ -23,7 +22,6 @@
 
   $: if ($syncStore.conflicts.length === 0) {
     selectedConflict = null;
-    dismissed = new Set();
   }
 
   async function handleResolve() {
@@ -44,7 +42,7 @@
 
   function handleSkip() {
     if (selectedConflict) {
-      dismissed = new Set([...dismissed, selectedConflict.note_id]);
+      syncStore.dismissConflict(selectedConflict.note_id);
     }
     selectedConflict = null;
     resolution = null;

--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -864,10 +864,11 @@
       {/if}
 
       {#if note}
-        <div style="position: relative; display: inline-block;">
+        <div style="position: relative; display: inline-block; z-index: {showExportMenu ? 'var(--z-overlay)' : 'auto'};">
           <button
             class="toolbar-btn"
             class:active={showExportMenu}
+            style="position: relative; z-index: var(--z-overlay);"
             onclick={() => showExportMenu = !showExportMenu}
             title="Exportar nota"
           >

--- a/frontend/src/lib/stores/sync.ts
+++ b/frontend/src/lib/stores/sync.ts
@@ -17,6 +17,9 @@ interface SyncState {
   conflicts: SyncConflict[];
   loading: boolean;
   lastChecked: number | null;
+  /** Note IDs the user has skipped this session — prevents the modal
+   *  from re-opening on every navigation (#550 regression). */
+  dismissed: Set<number>;
 }
 
 const POLL_INTERVAL = 30_000; // 30 seconds
@@ -26,6 +29,7 @@ function createSyncStore() {
     conflicts: [],
     loading: false,
     lastChecked: null,
+    dismissed: new Set(),
   });
 
   let pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -35,6 +39,7 @@ function createSyncStore() {
     try {
       const data = await api.sync.conflicts();
       update(s => ({
+        ...s,
         conflicts: data.conflicts,
         loading: false,
         lastChecked: Date.now(),
@@ -83,13 +88,23 @@ function createSyncStore() {
     }
   }
 
+  /** Mark a conflict as dismissed so the modal doesn't re-open on
+   *  subsequent navigations within the same session (#550). */
+  function dismissConflict(noteId: number): void {
+    update(s => ({
+      ...s,
+      dismissed: new Set([...s.dismissed, noteId]),
+    }));
+  }
+
   return {
     subscribe,
     checkConflicts,
     resolveConflict,
+    dismissConflict,
     startPolling,
     stopPolling,
-    reset: () => set({ conflicts: [], loading: false, lastChecked: null }),
+    reset: () => set({ conflicts: [], loading: false, lastChecked: null, dismissed: new Set() }),
   };
 }
 

--- a/frontend/src/routes/graph/+page.svelte
+++ b/frontend/src/routes/graph/+page.svelte
@@ -218,7 +218,7 @@
     position: relative;
     min-height: 0;
     background: var(--bg);
-    z-index: var(--z-base); /* Ensure graph content (incl. settings panel) is above the nav sidebar (#274) */
+    z-index: var(--z-sticky); /* Ensure graph content (incl. settings panel) is above the nav sidebar (#274) */
   }
 
   .loading-state {


### PR DESCRIPTION
## Summary

Three bugs found during the systematic UI audit (Playwright) and fixed:

- **Graph filters unclickable (#274):** The `.app-sidebar` had no stacking context (no `position`/`z-index`), so the floating settings panel in the Graph page was intercepted by the nav sidebar. Added `position: relative` + `z-index: var(--z-base)` to `.app-sidebar` and raised `.graph-container` `z-index` from `--z-base` (1) to `--z-sticky` (10).
- **Sync conflict modal re-opened on every navigation (#550):** The `dismissed` set lived in component-local state of `ConflictResolutionModal`, which is recreated on each route change, losing the dismissed IDs. Moved the set to `syncStore` (persists for the whole session) with a new `dismissConflict(noteId)` action.
- **Export dropdown in Notes didn't close on re-click:** The backdrop (`z-index: 100`) was inside the same stacking context as the toggle button (`z-index: auto`), intercepting pointer events on the button. Gave the button's container `z-index: --z-overlay` when open and positioned the button above the backdrop.

## Files changed

- `frontend/src/app.css` — stacking context on `.app-sidebar`
- `frontend/src/routes/graph/+page.svelte` — raise `.graph-container` z-index
- `frontend/src/lib/stores/sync.ts` — `dismissed` set + `dismissConflict()` in store
- `frontend/src/lib/components/ConflictResolutionModal.svelte` — use store instead of local state
- `frontend/src/lib/components/NoteEditor.svelte` — z-index on export button container

#### Test plan

- [x] `npm run check` — 0 errors (119 pre-existing warnings)
- [x] Graph: open settings panel, toggle "Archivos" filter — click registers
- [x] Conflict modal: skip a conflict, navigate to another page, same conflict does not reappear (next undismissed one shows)
- [x] Notes: open export dropdown, re-click "Exportar" — dropdown closes

Generated with [Devin](https://devin.ai)