### PR TITLE
fix(frontend): note editor toolbar responsive at all viewport sizes

### DIFF
--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -1103,6 +1103,7 @@
   /* ── Toolbar ── */
   .toolbar {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
     padding: 6px 20px;
@@ -1185,18 +1186,30 @@
     display: flex;
     align-items: center;
     gap: var(--s2);
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
   }
 
   .toolbar-right {
     display: flex;
     align-items: center;
     gap: var(--s2);
+    flex-shrink: 0;
+    flex-wrap: wrap;
+    justify-content: flex-end;
   }
 
   .format-toolbar {
     display: flex;
     align-items: center;
     gap: 2px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    min-width: 0;
+  }
+  .format-toolbar::-webkit-scrollbar {
+    display: none;
   }
 
   .format-divider {


### PR DESCRIPTION
## Summary
- Note editor toolbar action buttons (Guardar, Exportar, Eliminar, Cerrar) were positioned off-screen at viewports < 1600px
- Fixed toolbar layout to ensure action buttons are always visible and accessible

Fixes #569

#### Test plan
- [ ] Open a note at 1280px viewport — Guardar/Exportar/Eliminar buttons visible
- [ ] Open a note at 1920px viewport — toolbar layout unchanged
- [ ] Open a note at 375px mobile viewport — toolbar adapts
- [ ] Formatting buttons (bold, italic, headings) still functional

Generated with [Devin](https://devin.ai)