### PR TITLE
fix(infra): audit fixes — worker port, logging perms, vault error handling

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -19,6 +19,10 @@ RUN addgroup --system --gid 1000 app && adduser --system --uid 1000 --ingroup ap
 
 COPY --chown=app:app . .
 
+# Create the file-logging directory with correct ownership so the app user
+# can write /app/data/logs/api.log at runtime (#577).
+RUN mkdir -p /app/data/logs && chown -R app:app /app/data
+
 USER app
 
 CMD ["/bin/sh", "-c", "rm -rf alembic/versions/__pycache__ && exec uvicorn main:app --host 0.0.0.0 --port 8000 --workers ${WEB_CONCURRENCY:-2} --timeout-keep-alive ${UVICORN_TIMEOUT_KEEP_ALIVE:-5} --proxy-headers --forwarded-allow-ips='*'"]

--- a/api/routers/vault.py
+++ b/api/routers/vault.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 
 from database import get_db
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from services.joidy_vault_writer import restore_goals_from_vault, write_daily, write_objectives, write_skills
 from sqlalchemy.orm import Session
 
@@ -31,4 +31,7 @@ def trigger_write_skills(db: Session = Depends(get_db)):
 @router.post("/restore-goals")
 def trigger_restore_goals(db: Session = Depends(get_db)):
     """Restore goals from joidy_managed files in Objetivos/ (#504)."""
-    return restore_goals_from_vault(db)
+    try:
+        return restore_goals_from_vault(db)
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"Vault not ready: {e}")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,7 +28,7 @@ services:
       - APP_ENV=development
       - VAULT_PATH=/vault
       - OBSIDIAN_VAULT_PATH=/vault
-    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload --reload-include '*.py' --reload-exclude '__pycache__/*' --reload-exclude '*.pyc'
+    command: sh -c "mkdir -p /app/data/logs && exec uvicorn main:app --host 0.0.0.0 --port 8000 --reload --reload-include '*.py' --reload-exclude '__pycache__/*' --reload-exclude '*.pyc'"
 
   ai-service:
     build:
@@ -44,6 +44,8 @@ services:
     build:
       context: ./worker
       dockerfile: Dockerfile
+    ports:
+      - "${WORKER_PORT:-8001}:8001"
     volumes:
       - ./worker:/app
       - ./data/db:/data/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,8 @@ services:
 
   worker:
     image: d4mag3/joidy-worker:latest
+    ports:
+      - "${WORKER_PORT:-8001}:8001"
     volumes:
       - ./data/db:/data/db
       - ./.env:/app/.env


### PR DESCRIPTION
## Summary
- #567: Expose worker port 8001 to host for metrics/health access
- #577: Fix API file logging permissions in container
- #578: Add error handling to /vault/restore-goals — return 503 instead of 500

#### Test plan
- [ ] `curl http://localhost:8001/health` returns 200
- [ ] `curl http://localhost:8001/metrics` returns Prometheus metrics
- [ ] API logs appear in `data/logs/api.log` inside container
- [ ] `POST /vault/restore-goals` returns 503 on first call (not 500)
- [ ] `POST /vault/restore-goals` returns 200 on subsequent calls

Generated with [Devin](https://devin.ai)