### PR TITLE
fix(api): audit fixes — path typo, validation, 404s, request body, health

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -217,7 +217,30 @@ app.mount("/uploads", SafeStaticFiles(directory=settings.upload_dir), name="uplo
 
 @app.get("/health")
 def health():
-    return {"status": "ok", "service": "joidy-api"}
+    """Liveness + basic dependency check.
+
+    Unlike ``/health/ready`` (which performs a full readiness probe including
+    the AI service), this endpoint verifies only the core dependency (database)
+    so it can be used as a liveness probe that still reflects real outages.
+    """
+    from database import engine
+    from sqlalchemy import text
+
+    checks = {"database": "unknown"}
+
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        checks["database"] = "ok"
+    except Exception as e:
+        checks["database"] = f"error: {str(e)[:50]}"
+
+    all_ok = all(v == "ok" for v in checks.values())
+    return {
+        "status": "ok" if all_ok else "degraded",
+        "service": "joidy-api",
+        "checks": checks,
+    }
 
 
 @app.get("/health/ready")

--- a/api/routers/goals.py
+++ b/api/routers/goals.py
@@ -2,7 +2,7 @@ import re
 from datetime import datetime, timezone
 
 from database import get_db
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from models.goal import (
     Goal,
     GoalFailConfig,
@@ -195,16 +195,10 @@ def _serialize_goal(goal: Goal, db: Session, precalculated_progress: float | Non
 
 @router.get("/")
 def list_goals(
-    skip: int = 0,
-    limit: int = 100,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=1000),
     db: Session = Depends(get_db),
 ):
-    if skip < 0:
-        skip = 0
-    if limit < 1:
-        limit = 1
-    if limit > 1000:
-        limit = 1000
     evaluate_active_goals(db)
     goals = (
         db.query(Goal)

--- a/api/routers/integrations/github.py
+++ b/api/routers/integrations/github.py
@@ -46,6 +46,16 @@ class GitHubGoalLink(BaseModel):
     goal_id: int = Field(..., description="Goal ID to link")
 
 
+class CreateIssueRequest(BaseModel):
+    title: str
+    body: str | None = None
+    labels: list[str] = []
+
+
+class CreateCommentRequest(BaseModel):
+    body: str
+
+
 def _headers() -> dict[str, str]:
     if not settings.github_token:
         raise HTTPException(status_code=400, detail="GitHub token not configured")
@@ -426,15 +436,13 @@ async def get_issue(owner: str, repo: str, issue_number: int):
 async def create_issue(
     owner: str,
     repo: str,
-    title: str = Query(..., min_length=1, max_length=500),
-    body: str = Query(""),
-    labels: list[str] = Query(default_factory=list),
+    request: CreateIssueRequest,
 ):
-    data: dict[str, Any] = {"title": title}
-    if body:
-        data["body"] = body
-    if labels:
-        data["labels"] = labels
+    data: dict[str, Any] = {"title": request.title}
+    if request.body:
+        data["body"] = request.body
+    if request.labels:
+        data["labels"] = request.labels
 
     issue = await _post(f"/repos/{owner}/{repo}/issues", data)
     return {
@@ -499,9 +507,14 @@ async def get_comments(owner: str, repo: str, issue_number: int):
 
 @router.post("/repos/{owner}/{repo}/issues/{issue_number}/comments")
 async def add_comment(
-    owner: str, repo: str, issue_number: int, body: str = Query(..., min_length=1)
+    owner: str,
+    repo: str,
+    issue_number: int,
+    request: CreateCommentRequest,
 ):
-    comment = await _post(f"/repos/{owner}/{repo}/issues/{issue_number}/comments", {"body": body})
+    comment = await _post(
+        f"/repos/{owner}/{repo}/issues/{issue_number}/comments", {"body": request.body}
+    )
     return {"id": comment["id"], "body": comment["body"]}
 
 
@@ -973,7 +986,7 @@ async def revoke_token(
     return {"status": "revoked"}
 
 
-@router.get("/oauth/scpies")
+@router.get("/oauth/scopes")
 async def list_oauth_scopes():
     """
     Lista los scopes disponibles para OAuth.

--- a/api/routers/notes.py
+++ b/api/routers/notes.py
@@ -1,6 +1,6 @@
 
 from database import get_db
-from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Query
 from models.note import EmbeddingFailure, Note, NoteTag, Tag
 from pydantic import BaseModel, field_validator
 from services.sanitizer import sanitize_title, sanitize_content
@@ -170,18 +170,12 @@ def _is_truthy_header(value: str | None) -> bool:
 
 @router.get("/")
 def list_notes(
-    skip: int = 0,
-    limit: int = 1000,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(1000, ge=1, le=1000),
     tag: str | None = None,
     source_path: str | None = None,
     db: Session = Depends(get_db),
 ):
-    if skip < 0:
-        skip = 0
-    if limit < 1:
-        limit = 1
-    if limit > 1000:
-        limit = 1000
     query = db.query(Note).options(selectinload(Note.tags).selectinload(NoteTag.tag))
     if tag:
         query = query.join(NoteTag).join(Tag).filter(Tag.name == tag.lower())
@@ -409,16 +403,26 @@ def accept_ai_tag(
 
 @router.get("/{note_id}/backlinks")
 def get_backlinks(note_id: int, db: Session = Depends(get_db)):
+    note = db.query(Note).filter(Note.id == note_id).first()
+    if not note:
+        raise HTTPException(status_code=404, detail="Note not found")
     backlinks = list_backlinks_service(db, note_id)
     return [note_to_response(n) for n in backlinks]
 
 
 @router.get("/{note_id}/similar")
-def get_similar_notes(note_id: int, limit: int = 5, db: Session = Depends(get_db)):
+def get_similar_notes(
+    note_id: int,
+    limit: int = Query(5, ge=1, le=100),
+    db: Session = Depends(get_db),
+):
     """Find semantically similar notes using pgvector cosine similarity (#393).
 
     Uses the note's stored embedding to find the top-K nearest neighbors.
     """
+    note = db.query(Note).filter(Note.id == note_id).first()
+    if not note:
+        raise HTTPException(status_code=404, detail="Note not found")
     from models.note import NoteEmbedding
 
     embedding_row = db.query(NoteEmbedding).filter(NoteEmbedding.note_id == note_id).first()


### PR DESCRIPTION
## Summary
- #566: Fix path typo `/integrations/github/oauth/scpies` → `/scopes`
- #573: Add `ge`/`le` validation on limit/skip params for notes and goals
- #574: Return 404 for non-existent notes on /similar and /backlinks endpoints
- #575: GitHub issue/comment creation uses request body instead of query params
- #576: /health endpoint includes dependency status

#### Test plan
- [ ] `GET /integrations/github/oauth/scopes` returns 200
- [ ] `GET /notes/?limit=0` returns 422
- [ ] `GET /notes/?limit=-1` returns 422
- [ ] `GET /notes/99999999/similar` returns 404
- [ ] `GET /notes/99999999/backlinks` returns 404
- [ ] `POST /integrations/github/repos/{owner}/{repo}/issues` accepts JSON body
- [ ] `GET /health` reflects AI service status
- [ ] Existing API tests pass

Generated with [Devin](https://devin.ai)