### PR TITLE
fix(ai-service): add provider fallback when configured provider is unavailable

### DIFF
--- a/ai-service/clients/factory.py
+++ b/ai-service/clients/factory.py
@@ -12,12 +12,41 @@ from .openrouter import OpenRouterClient
 
 logger = logging.getLogger(__name__)
 
+# Default models per provider when falling back (the configured model name
+# belongs to the original provider and is not valid for the fallback one).
+FALLBACK_LLM_MODELS: dict[str, str] = {
+    "ollama": "llama3",
+    "openai": "gpt-4o-mini",
+    "cohere": "command-r-plus",
+    "anthropic": "claude-3-5-sonnet-20241022",
+    "openrouter": "openai/gpt-4o-mini",
+    "gemini": "gemini-2.0-flash",
+}
+
+FALLBACK_EMBEDDING_MODELS: dict[str, str] = {
+    "ollama": "nomic-embed-text",
+    "openai": "text-embedding-3-small",
+    "cohere": "embed-english-v3.0",
+    "gemini": "models/text-embedding-004",
+}
+
+# Providers that don't offer embeddings — skipped during embedding fallback.
+_NO_EMBEDDING_PROVIDERS = frozenset({"anthropic", "openrouter"})
+
+# Preference order when falling back: local/free providers first.
+_FALLBACK_ORDER = ("ollama", "openai", "cohere", "gemini", "anthropic", "openrouter")
+
 
 class ClientFactory:
     """Factory for creating LLM and embedding clients based on model configuration."""
 
     _llm_client: BaseLLMClient | None = None
     _embedding_client: EmbeddingClient | None = None
+    # Track the actual provider used after fallback so /health can report it.
+    _llm_provider_used: str | None = None
+    _embedding_provider_used: str | None = None
+    _llm_model_used: str | None = None
+    _embedding_model_used: str | None = None
 
     @classmethod
     def parse_model_string(cls, model: str) -> tuple[str, str]:
@@ -28,79 +57,127 @@ class ClientFactory:
         return "gemini", model
 
     @classmethod
+    def _create_llm_client(cls, provider: str, model: str) -> BaseLLMClient:
+        """Instantiate an LLM client for *provider* with *model*."""
+        config = settings.provider_config[provider]
+        if provider == "gemini":
+            return GeminiClient(api_key=config["api_key"], model=model)
+        if provider == "openai":
+            return OpenAIClient(api_key=config["api_key"], model=model)
+        if provider == "anthropic":
+            return AnthropicClient(api_key=config["api_key"], model=model)
+        if provider == "ollama":
+            return OllamaClient(base_url=config["base_url"], model=model)
+        if provider == "openrouter":
+            return OpenRouterClient(api_key=config["api_key"], model=model)
+        if provider == "cohere":
+            return CohereClient(api_key=config["api_key"], model=model)
+        raise ValueError(f"Unknown provider: {provider}")
+
+    @classmethod
+    def _create_embedding_client(cls, provider: str, model: str) -> EmbeddingClient:
+        """Instantiate an embedding client for *provider* with *model*."""
+        config = settings.provider_config[provider]
+        if provider == "gemini":
+            return GeminiClient(api_key=config["api_key"], model=model)
+        if provider == "openai":
+            return OpenAIClient(api_key=config["api_key"], model=model, is_embedding=True)
+        if provider == "cohere":
+            return CohereClient(api_key=config["api_key"], model=model, is_embedding=True)
+        if provider == "ollama":
+            return OllamaClient(base_url=config["base_url"], model=model, is_embedding=True)
+        raise ValueError(f"Provider '{provider}' does not support embeddings")
+
+    @classmethod
+    def _resolve_fallback(cls, kind: str, configured_provider: str, configured_model: str) -> tuple[str, str]:
+        """Find an available fallback provider+model.
+
+        Returns (provider, model). Raises ValueError if none available.
+        """
+        available = settings.available_providers
+        models = FALLBACK_EMBEDDING_MODELS if kind == "embedding" else FALLBACK_LLM_MODELS
+        for candidate in _FALLBACK_ORDER:
+            if candidate == configured_provider:
+                continue
+            if candidate not in available:
+                continue
+            if kind == "embedding" and candidate in _NO_EMBEDDING_PROVIDERS:
+                continue
+            fallback_model = models.get(candidate)
+            if not fallback_model:
+                continue
+            logger.warning(
+                f"Provider '{configured_provider}' not available — falling back to "
+                f"{kind} provider '{candidate}' with model '{fallback_model}'"
+            )
+            return candidate, fallback_model
+        raise ValueError(f"No {kind} provider available for fallback")
+
+    @classmethod
     def get_llm_client(cls) -> BaseLLMClient:
-        """Get the configured LLM client based on settings.llm_model."""
+        """Get the configured LLM client, with fallback if the provider is unavailable (#568)."""
         if cls._llm_client is not None:
             return cls._llm_client
 
         provider, model = cls.parse_model_string(settings.llm_model)
         provider = provider.lower()
-
         available = settings.available_providers
         logger.info(f"Creating LLM client: provider={provider}, model={model}, available={available}")
 
         if provider not in available:
-            raise ValueError(f"Provider '{provider}' not configured. Available: {available}")
+            provider, model = cls._resolve_fallback("llm", provider, model)
 
-        config = settings.provider_config[provider]
-
-        if provider == "gemini":
-            cls._llm_client = GeminiClient(api_key=config["api_key"], model=model)
-        elif provider == "openai":
-            cls._llm_client = OpenAIClient(api_key=config["api_key"], model=model)
-        elif provider == "anthropic":
-            cls._llm_client = AnthropicClient(api_key=config["api_key"], model=model)
-        elif provider == "ollama":
-            cls._llm_client = OllamaClient(base_url=config["base_url"], model=model)
-        elif provider == "openrouter":
-            cls._llm_client = OpenRouterClient(api_key=config["api_key"], model=model)
-        elif provider == "cohere":
-            cls._llm_client = CohereClient(api_key=config["api_key"], model=model)
-        else:
-            raise ValueError(f"Unknown provider: {provider}")
-
+        cls._llm_client = cls._create_llm_client(provider, model)
+        cls._llm_provider_used = provider
+        cls._llm_model_used = model
         return cls._llm_client
 
     @classmethod
     def get_embedding_client(cls) -> EmbeddingClient:
-        """Get the configured embedding client based on settings.embedding_model."""
+        """Get the configured embedding client, with fallback if the provider is unavailable (#568)."""
         if cls._embedding_client is not None:
             return cls._embedding_client
 
         provider, model = cls.parse_model_string(settings.embedding_model)
         provider = provider.lower()
-
         available = settings.available_providers
 
         if provider not in available:
-            raise ValueError(f"Provider '{provider}' not configured. Available: {available}")
+            provider, model = cls._resolve_fallback("embedding", provider, model)
+        elif provider in _NO_EMBEDDING_PROVIDERS:
+            logger.warning(f"Provider {provider} doesn't support embeddings, using fallback")
+            provider, model = cls._resolve_fallback("embedding", provider, model)
 
-        config = settings.provider_config[provider]
-
-        if provider == "gemini":
-            cls._embedding_client = GeminiClient(api_key=config["api_key"], model=model)
-        elif provider == "openai":
-            cls._embedding_client = OpenAIClient(api_key=config["api_key"], model=model, is_embedding=True)
-        elif provider == "cohere":
-            cls._embedding_client = CohereClient(api_key=config["api_key"], model=model, is_embedding=True)
-        elif provider == "ollama":
-            cls._embedding_client = OllamaClient(base_url=config["base_url"], model=model, is_embedding=True)
-        elif provider in ("anthropic", "openrouter"):
-            logger.warning(f"Provider {provider} doesn't have dedicated embedding, using Ollama fallback")
-            if "ollama" in available:
-                cls._embedding_client = OllamaClient(base_url=settings.provider_config["ollama"]["base_url"], model="nomic-embed-text")
-            else:
-                raise ValueError("No embedding provider available")
-        else:
-            raise ValueError(f"Unknown provider: {provider}")
-
+        cls._embedding_client = cls._create_embedding_client(provider, model)
+        cls._embedding_provider_used = provider
+        cls._embedding_model_used = model
         return cls._embedding_client
+
+    @classmethod
+    def get_active_providers(cls) -> dict[str, dict | None]:
+        """Return the actual provider+model used after fallback (for /health)."""
+        return {
+            "llm": (
+                {"provider": cls._llm_provider_used, "model": cls._llm_model_used}
+                if cls._llm_provider_used
+                else None
+            ),
+            "embedding": (
+                {"provider": cls._embedding_provider_used, "model": cls._embedding_model_used}
+                if cls._embedding_provider_used
+                else None
+            ),
+        }
 
     @classmethod
     def reset(cls):
         """Reset cached clients (useful for testing)."""
         cls._llm_client = None
         cls._embedding_client = None
+        cls._llm_provider_used = None
+        cls._embedding_provider_used = None
+        cls._llm_model_used = None
+        cls._embedding_model_used = None
 
 
 def get_llm_client() -> BaseLLMClient:

--- a/ai-service/main.py
+++ b/ai-service/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 
 from circuit_breaker import llm_circuit_breaker, emb_circuit_breaker, CircuitBreakerError
 from clients import get_embedding_client, get_llm_client
+from clients.factory import ClientFactory
 from clients.prompts import CHAT_SYSTEM_PROMPT, CLASSIFY_PROMPT, RAG_PROMPT
 from config import settings
 from cost_tracker import get_monthly_stats, record_usage
@@ -133,21 +134,52 @@ def _get_provider_info():
     available = settings.available_providers
     llm_provider, llm_model = settings.llm_model.split(":", 1) if ":" in settings.llm_model else ("gemini", settings.llm_model)
     emb_provider, emb_model = settings.embedding_model.split(":", 1) if ":" in settings.embedding_model else ("gemini", settings.embedding_model)
+    active = ClientFactory.get_active_providers()
+    llm_active = active.get("llm")
+    emb_active = active.get("embedding")
     return {
-        "llm": {"provider": llm_provider, "model": llm_model, "available": llm_provider in available},
-        "embedding": {"provider": emb_provider, "model": emb_model, "available": emb_provider in available},
+        "llm": {
+            "provider": llm_provider,
+            "model": llm_model,
+            "available": llm_provider in available,
+            "active_provider": llm_active["provider"] if llm_active else None,
+            "active_model": llm_active["model"] if llm_active else None,
+            "fallback": llm_active is not None and llm_active["provider"] != llm_provider,
+        },
+        "embedding": {
+            "provider": emb_provider,
+            "model": emb_model,
+            "available": emb_provider in available,
+            "active_provider": emb_active["provider"] if emb_active else None,
+            "active_model": emb_active["model"] if emb_active else None,
+            "fallback": emb_active is not None and emb_active["provider"] != emb_provider,
+        },
         "available": available,
     }
 
 
 @app.get("/health")
 def health():
+    # Resolve clients eagerly so /health reflects the actual provider after
+    # fallback (clients are cached, so subsequent requests reuse them).
+    if settings.is_ai_enabled:
+        try:
+            get_llm_client()
+        except ValueError:
+            pass
+        try:
+            get_embedding_client()
+        except ValueError:
+            pass
     provider_info = _get_provider_info()
-    # The service is "degraded" if the configured LLM/embedding provider is
-    # not actually available (e.g. GEMINI_API_KEY not set but model is gemini:*).
-    llm_ok = provider_info["llm"]["available"]
-    emb_ok = provider_info["embedding"]["available"]
-    status = "ok" if (llm_ok and emb_ok) else "degraded"
+    # "ok" = configured provider available. "degraded" = using fallback or
+    # no provider could be resolved at all.
+    llm_ok = provider_info["llm"]["available"] or provider_info["llm"]["active_provider"] is not None
+    emb_ok = provider_info["embedding"]["available"] or provider_info["embedding"]["active_provider"] is not None
+    if llm_ok and emb_ok:
+        status = "ok" if not (provider_info["llm"]["fallback"] or provider_info["embedding"]["fallback"]) else "degraded"
+    else:
+        status = "degraded"
     return {
         "status": status,
         "service": "joidy-ai",

--- a/ai-service/tests/test_factory_fallback.py
+++ b/ai-service/tests/test_factory_fallback.py
@@ -1,0 +1,121 @@
+"""Tests for ClientFactory provider fallback logic (#568)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from clients.factory import ClientFactory
+
+
+@pytest.fixture(autouse=True)
+def _reset_factory():
+    """Ensure cached clients don't leak between tests."""
+    ClientFactory.reset()
+    yield
+    ClientFactory.reset()
+
+
+def _mock_settings(available_configs: dict, llm_model="gemini:gemini-2.0-flash", embedding_model="gemini:models/text-embedding-004"):
+    """Build a mock settings object with the given provider configs."""
+    class FakeSettings:
+        def __init__(self):
+            self.llm_model = llm_model
+            self.embedding_model = embedding_model
+
+        @property
+        def provider_config(self):
+            return available_configs
+
+        @property
+        def available_providers(self):
+            return list(available_configs.keys())
+
+        @property
+        def is_ai_enabled(self):
+            return len(available_configs) > 0
+
+    return FakeSettings()
+
+
+def test_fallback_to_ollama_when_gemini_unavailable():
+    """If Gemini is configured but not available, fall back to Ollama (#568)."""
+    fake = _mock_settings({
+        "ollama": {"base_url": "http://localhost:11434"},
+    })
+    with patch("clients.factory.settings", fake):
+        client = ClientFactory.get_llm_client()
+        assert client.provider_name == "ollama"
+        active = ClientFactory.get_active_providers()
+        assert active["llm"]["provider"] == "ollama"
+        assert active["llm"]["model"] == "llama3"
+
+
+def test_fallback_embedding_to_ollama():
+    """Embedding client falls back to Ollama with nomic-embed-text."""
+    fake = _mock_settings({
+        "ollama": {"base_url": "http://localhost:11434"},
+    })
+    with patch("clients.factory.settings", fake):
+        client = ClientFactory.get_embedding_client()
+        assert client.provider_name == "ollama"
+        active = ClientFactory.get_active_providers()
+        assert active["embedding"]["provider"] == "ollama"
+        assert active["embedding"]["model"] == "nomic-embed-text"
+
+
+def test_no_fallback_when_provider_available():
+    """If the configured provider is available, no fallback occurs."""
+    fake = _mock_settings({
+        "gemini": {"api_key": "test-key"},
+    })
+    with patch("clients.factory.settings", fake):
+        client = ClientFactory.get_llm_client()
+        assert client.provider_name == "gemini"
+        active = ClientFactory.get_active_providers()
+        assert active["llm"]["provider"] == "gemini"
+        assert active["llm"]["model"] == "gemini-2.0-flash"
+
+
+def test_no_provider_available_raises():
+    """If no provider is available at all, ValueError is raised."""
+    fake = _mock_settings({})
+    with patch("clients.factory.settings", fake):
+        with pytest.raises(ValueError, match="No llm provider available"):
+            ClientFactory.get_llm_client()
+
+
+def test_fallback_skips_no_embedding_providers():
+    """Anthropic/OpenRouter are skipped for embedding fallback."""
+    fake = _mock_settings({
+        "anthropic": {"api_key": "test-key"},
+    })
+    with patch("clients.factory.settings", fake):
+        with pytest.raises(ValueError, match="No embedding provider available"):
+            ClientFactory.get_embedding_client()
+
+
+def test_embedding_fallback_from_anthropic_configured():
+    """If anthropic is configured for embeddings, fall back to an embedding-capable provider."""
+    fake = _mock_settings(
+        {
+            "anthropic": {"api_key": "test-key"},
+            "ollama": {"base_url": "http://localhost:11434"},
+        },
+        embedding_model="anthropic:claude-3-5-sonnet-20241022",
+    )
+    with patch("clients.factory.settings", fake):
+        client = ClientFactory.get_embedding_client()
+        assert client.provider_name == "ollama"
+        active = ClientFactory.get_active_providers()
+        assert active["embedding"]["provider"] == "ollama"
+
+
+def test_fallback_prefers_ollama_over_openai():
+    """When multiple providers available, Ollama is preferred (local/free)."""
+    fake = _mock_settings({
+        "openai": {"api_key": "test-key"},
+        "ollama": {"base_url": "http://localhost:11434"},
+    })
+    with patch("clients.factory.settings", fake):
+        client = ClientFactory.get_llm_client()
+        assert client.provider_name == "ollama"


### PR DESCRIPTION
## Summary
- When the configured LLM/embedding provider (e.g. Gemini) is not available — missing API key, invalid, or unreachable — the factory now falls back to an available provider instead of raising `ValueError` (which surfaced as 500 on all AI inference endpoints).
- Fallback order: Ollama (local/free) → OpenAI → Cohere → Gemini → Anthropic → OpenRouter, with sensible default models per provider.
- `/health` now eagerly resolves clients and reports both the configured and active provider, plus a `fallback` flag. Status is `"ok"` when configured provider is available, `"degraded"` when using a fallback.
- Added 7 unit tests covering fallback logic (all passing).

## Changes
- `ai-service/clients/factory.py`: Refactored `ClientFactory` with `_create_llm_client`/`_create_embedding_client` helpers, `_resolve_fallback` method, `get_active_providers()` for health reporting, and `FALLBACK_LLM_MODELS`/`FALLBACK_EMBEDDING_MODELS` dicts.
- `ai-service/main.py`: Updated `_get_provider_info()` and `/health` to reflect active provider after fallback.
- `ai-service/tests/test_factory_fallback.py`: New test file with 7 tests.

Closes #568

#### Test plan
- [x] `python -m compileall` passes in ai-service container
- [x] `python -m pytest tests/test_factory_fallback.py` — 7/7 passed
- [ ] Manual: with `GEMINI_API_KEY` unset and `OLLAMA_BASE_URL` set, `/health` reports `degraded` with `fallback: true` and `/embed` returns 200 using Ollama
- [ ] Manual: with `GEMINI_API_KEY` set, `/health` reports `ok` with `fallback: false`

Generated with [Devin](https://devin.ai)