### PR TITLE
fix(ai-service): implement provider fallback to Ollama + startup health check

### DIFF
--- a/ai-service/clients/__init__.py
+++ b/ai-service/clients/__init__.py
@@ -1,4 +1,13 @@
 from .base import BaseLLMClient, EmbeddingClient
 from .factory import ClientFactory, get_embedding_client, get_llm_client
+from .fallback import FallbackEmbeddingClient, FallbackLLMClient
 
-__all__ = ["get_llm_client", "get_embedding_client", "ClientFactory", "BaseLLMClient", "EmbeddingClient"]
+__all__ = [
+    "get_llm_client",
+    "get_embedding_client",
+    "ClientFactory",
+    "BaseLLMClient",
+    "EmbeddingClient",
+    "FallbackLLMClient",
+    "FallbackEmbeddingClient",
+]

--- a/ai-service/clients/base.py
+++ b/ai-service/clients/base.py
@@ -28,6 +28,14 @@ class BaseLLMClient(ABC):
         """Generate text response."""
         pass
 
+    async def health_check(self) -> bool:
+        """Ping the provider to verify it's reachable. Returns True if healthy."""
+        try:
+            await self.generate("ping", temperature=0.0, max_tokens=1)
+            return True
+        except Exception:
+            return False
+
     async def classify(
         self,
         content: str,
@@ -39,7 +47,7 @@ class BaseLLMClient(ABC):
         """
         prompt = classify_prompt.format(
             content=content[:2000],
-            existing_tags=", ".join(existing_tags) if existing_tags else "ninguno aún"
+            existing_tags=", ".join(existing_tags) if existing_tags else "ninguno aún",
         )
         result = await self.generate(prompt, temperature=0.2, max_tokens=256)
         return parse_classification(result, existing_tags)
@@ -55,11 +63,13 @@ def parse_classification(text: str, existing_tags: list[str]) -> list[dict]:
         result = []
         for s in suggestions:
             if isinstance(s, dict) and "tag" in s and "confidence" in s:
-                result.append({
-                    "tag": str(s["tag"]).lower().strip(),
-                    "confidence": float(s.get("confidence", 0.5)),
-                    "is_new": s.get("is_new", s["tag"] not in existing_tags),
-                })
+                result.append(
+                    {
+                        "tag": str(s["tag"]).lower().strip(),
+                        "confidence": float(s.get("confidence", 0.5)),
+                        "is_new": s.get("is_new", s["tag"] not in existing_tags),
+                    }
+                )
         return result
     except (json.JSONDecodeError, KeyError, ValueError):
         return []
@@ -76,3 +86,11 @@ class EmbeddingClient(ABC):
     @abstractmethod
     async def embed(self, text: str) -> list[float]:
         pass
+
+    async def health_check(self) -> bool:
+        """Ping the provider to verify it's reachable. Returns True if healthy."""
+        try:
+            await self.embed("ping")
+            return True
+        except Exception:
+            return False

--- a/ai-service/clients/factory.py
+++ b/ai-service/clients/factory.py
@@ -5,6 +5,7 @@ from config import settings
 from .anthropic import AnthropicClient
 from .base import BaseLLMClient, EmbeddingClient
 from .cohere import CohereClient
+from .fallback import FallbackEmbeddingClient, FallbackLLMClient
 from .gemini import GeminiClient
 from .ollama import OllamaClient
 from .openai import OpenAIClient
@@ -12,9 +13,19 @@ from .openrouter import OpenRouterClient
 
 logger = logging.getLogger(__name__)
 
+# Default Ollama models used as fallback when the primary provider fails.
+_OLLAMA_LLM_FALLBACK_MODEL = "llama3"
+_OLLAMA_EMB_FALLBACK_MODEL = "nomic-embed-text"
+
 
 class ClientFactory:
-    """Factory for creating LLM and embedding clients based on model configuration."""
+    """Factory for creating LLM and embedding clients based on model configuration.
+
+    When the primary provider is not Ollama but Ollama is available, the
+    factory wraps the primary client in a FallbackLLMClient / FallbackEmbeddingClient
+    so that requests transparently fall back to Ollama if the primary fails
+    (e.g. invalid API key, quota exhausted, network unreachable). See #568.
+    """
 
     _llm_client: BaseLLMClient | None = None
     _embedding_client: EmbeddingClient | None = None
@@ -28,8 +39,64 @@ class ClientFactory:
         return "gemini", model
 
     @classmethod
+    def _create_llm_client(
+        cls, provider: str, model: str, config: dict
+    ) -> BaseLLMClient:
+        """Instantiate a raw LLM client for the given provider."""
+        if provider == "gemini":
+            return GeminiClient(api_key=config["api_key"], model=model)
+        elif provider == "openai":
+            return OpenAIClient(api_key=config["api_key"], model=model)
+        elif provider == "anthropic":
+            return AnthropicClient(api_key=config["api_key"], model=model)
+        elif provider == "ollama":
+            return OllamaClient(base_url=config["base_url"], model=model)
+        elif provider == "openrouter":
+            return OpenRouterClient(api_key=config["api_key"], model=model)
+        elif provider == "cohere":
+            return CohereClient(api_key=config["api_key"], model=model)
+        else:
+            raise ValueError(f"Unknown provider: {provider}")
+
+    @classmethod
+    def _create_embedding_client(
+        cls, provider: str, model: str, config: dict
+    ) -> EmbeddingClient:
+        """Instantiate a raw embedding client for the given provider."""
+        if provider == "gemini":
+            return GeminiClient(api_key=config["api_key"], model=model)
+        elif provider == "openai":
+            return OpenAIClient(
+                api_key=config["api_key"], model=model, is_embedding=True
+            )
+        elif provider == "cohere":
+            return CohereClient(
+                api_key=config["api_key"], model=model, is_embedding=True
+            )
+        elif provider == "ollama":
+            return OllamaClient(
+                base_url=config["base_url"], model=model, is_embedding=True
+            )
+        elif provider in ("anthropic", "openrouter"):
+            logger.warning(
+                f"Provider {provider} doesn't have dedicated embedding, using Ollama fallback"
+            )
+            if "ollama" in settings.available_providers:
+                return OllamaClient(
+                    base_url=settings.provider_config["ollama"]["base_url"],
+                    model=_OLLAMA_EMB_FALLBACK_MODEL,
+                )
+            raise ValueError("No embedding provider available")
+        else:
+            raise ValueError(f"Unknown provider: {provider}")
+
+    @classmethod
     def get_llm_client(cls) -> BaseLLMClient:
-        """Get the configured LLM client based on settings.llm_model."""
+        """Get the configured LLM client based on settings.llm_model.
+
+        If the primary provider is not Ollama but Ollama is available,
+        wraps the client in a FallbackLLMClient for automatic failover (#568).
+        """
         if cls._llm_client is not None:
             return cls._llm_client
 
@@ -37,33 +104,40 @@ class ClientFactory:
         provider = provider.lower()
 
         available = settings.available_providers
-        logger.info(f"Creating LLM client: provider={provider}, model={model}, available={available}")
+        logger.info(
+            f"Creating LLM client: provider={provider}, model={model}, available={available}"
+        )
 
         if provider not in available:
-            raise ValueError(f"Provider '{provider}' not configured. Available: {available}")
+            raise ValueError(
+                f"Provider '{provider}' not configured. Available: {available}"
+            )
 
         config = settings.provider_config[provider]
+        primary = cls._create_llm_client(provider, model, config)
 
-        if provider == "gemini":
-            cls._llm_client = GeminiClient(api_key=config["api_key"], model=model)
-        elif provider == "openai":
-            cls._llm_client = OpenAIClient(api_key=config["api_key"], model=model)
-        elif provider == "anthropic":
-            cls._llm_client = AnthropicClient(api_key=config["api_key"], model=model)
-        elif provider == "ollama":
-            cls._llm_client = OllamaClient(base_url=config["base_url"], model=model)
-        elif provider == "openrouter":
-            cls._llm_client = OpenRouterClient(api_key=config["api_key"], model=model)
-        elif provider == "cohere":
-            cls._llm_client = CohereClient(api_key=config["api_key"], model=model)
+        # Wrap with Ollama fallback if primary is not Ollama and Ollama is available
+        if provider != "ollama" and "ollama" in available:
+            ollama_config = settings.provider_config["ollama"]
+            secondary = OllamaClient(
+                base_url=ollama_config["base_url"], model=_OLLAMA_LLM_FALLBACK_MODEL
+            )
+            cls._llm_client = FallbackLLMClient(primary=primary, secondary=secondary)
+            logger.info(
+                f"LLM client wrapped with Ollama fallback (primary={provider}, secondary=ollama)"
+            )
         else:
-            raise ValueError(f"Unknown provider: {provider}")
+            cls._llm_client = primary
 
         return cls._llm_client
 
     @classmethod
     def get_embedding_client(cls) -> EmbeddingClient:
-        """Get the configured embedding client based on settings.embedding_model."""
+        """Get the configured embedding client based on settings.embedding_model.
+
+        If the primary provider is not Ollama but Ollama is available,
+        wraps the client in a FallbackEmbeddingClient for automatic failover (#568).
+        """
         if cls._embedding_client is not None:
             return cls._embedding_client
 
@@ -73,26 +147,34 @@ class ClientFactory:
         available = settings.available_providers
 
         if provider not in available:
-            raise ValueError(f"Provider '{provider}' not configured. Available: {available}")
+            raise ValueError(
+                f"Provider '{provider}' not configured. Available: {available}"
+            )
 
         config = settings.provider_config[provider]
+        primary = cls._create_embedding_client(provider, model, config)
 
-        if provider == "gemini":
-            cls._embedding_client = GeminiClient(api_key=config["api_key"], model=model)
-        elif provider == "openai":
-            cls._embedding_client = OpenAIClient(api_key=config["api_key"], model=model, is_embedding=True)
-        elif provider == "cohere":
-            cls._embedding_client = CohereClient(api_key=config["api_key"], model=model, is_embedding=True)
-        elif provider == "ollama":
-            cls._embedding_client = OllamaClient(base_url=config["base_url"], model=model, is_embedding=True)
-        elif provider in ("anthropic", "openrouter"):
-            logger.warning(f"Provider {provider} doesn't have dedicated embedding, using Ollama fallback")
-            if "ollama" in available:
-                cls._embedding_client = OllamaClient(base_url=settings.provider_config["ollama"]["base_url"], model="nomic-embed-text")
-            else:
-                raise ValueError("No embedding provider available")
+        # Wrap with Ollama fallback if primary is not Ollama and Ollama is available.
+        # Skip if primary is already Ollama (e.g. anthropic/openrouter embedding fallback).
+        if (
+            provider != "ollama"
+            and "ollama" in available
+            and not isinstance(primary, OllamaClient)
+        ):
+            ollama_config = settings.provider_config["ollama"]
+            secondary = OllamaClient(
+                base_url=ollama_config["base_url"],
+                model=_OLLAMA_EMB_FALLBACK_MODEL,
+                is_embedding=True,
+            )
+            cls._embedding_client = FallbackEmbeddingClient(
+                primary=primary, secondary=secondary
+            )
+            logger.info(
+                f"Embedding client wrapped with Ollama fallback (primary={provider}, secondary=ollama)"
+            )
         else:
-            raise ValueError(f"Unknown provider: {provider}")
+            cls._embedding_client = primary
 
         return cls._embedding_client
 

--- a/ai-service/clients/fallback.py
+++ b/ai-service/clients/fallback.py
@@ -1,0 +1,129 @@
+"""Fallback wrapper clients that try a primary provider and fall back to a secondary on failure.
+
+This addresses #568: when the primary LLM/embedding provider (e.g. Gemini) is
+unavailable — API key invalid, network error, quota exhausted — the wrapper
+transparently retries the operation on a secondary provider (typically Ollama,
+which runs locally and has no external dependencies).
+"""
+
+import logging
+
+from .base import BaseLLMClient, EmbeddingClient
+
+logger = logging.getLogger(__name__)
+
+
+class FallbackLLMClient(BaseLLMClient):
+    """Wraps a primary LLM client and falls back to a secondary on exception."""
+
+    def __init__(self, primary: BaseLLMClient, secondary: BaseLLMClient):
+        self._primary = primary
+        self._secondary = secondary
+        self._using_fallback = False
+
+    @property
+    def provider_name(self) -> str:
+        return (
+            self._secondary.provider_name
+            if self._using_fallback
+            else self._primary.provider_name
+        )
+
+    async def embed_text(self, text: str) -> list[float]:
+        if not hasattr(self._primary, "embed_text"):
+            return await self.embed(text)
+        try:
+            result = await self._primary.embed_text(text)
+            self._using_fallback = False
+            return result
+        except Exception as exc:
+            logger.warning(
+                f"Primary LLM provider '{self._primary.provider_name}' embed_text failed: {exc}. Falling back to '{self._secondary.provider_name}'."
+            )
+            self._using_fallback = True
+            return await self._secondary.embed_text(text)
+
+    async def health_check(self) -> bool:
+        """Healthy if either primary or secondary is reachable."""
+        primary_ok = await self._primary.health_check()
+        if primary_ok:
+            self._using_fallback = False
+            return True
+        secondary_ok = await self._secondary.health_check()
+        if secondary_ok:
+            self._using_fallback = True
+            logger.warning(
+                f"Primary LLM provider '{self._primary.provider_name}' unhealthy. Using fallback '{self._secondary.provider_name}'."
+            )
+        return secondary_ok
+
+    async def generate(
+        self,
+        prompt: str,
+        temperature: float = 0.2,
+        max_tokens: int = 256,
+        system_prompt: str | None = None,
+    ) -> str:
+        try:
+            result = await self._primary.generate(
+                prompt,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                system_prompt=system_prompt,
+            )
+            self._using_fallback = False
+            return result
+        except Exception as exc:
+            logger.warning(
+                f"Primary LLM provider '{self._primary.provider_name}' generate failed: {exc}. Falling back to '{self._secondary.provider_name}'."
+            )
+            self._using_fallback = True
+            return await self._secondary.generate(
+                prompt,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                system_prompt=system_prompt,
+            )
+
+
+class FallbackEmbeddingClient(EmbeddingClient):
+    """Wraps a primary embedding client and falls back to a secondary on exception."""
+
+    def __init__(self, primary: EmbeddingClient, secondary: EmbeddingClient):
+        self._primary = primary
+        self._secondary = secondary
+        self._using_fallback = False
+
+    @property
+    def provider_name(self) -> str:
+        return (
+            self._secondary.provider_name
+            if self._using_fallback
+            else self._primary.provider_name
+        )
+
+    async def embed(self, text: str) -> list[float]:
+        try:
+            result = await self._primary.embed(text)
+            self._using_fallback = False
+            return result
+        except Exception as exc:
+            logger.warning(
+                f"Primary embedding provider '{self._primary.provider_name}' embed failed: {exc}. Falling back to '{self._secondary.provider_name}'."
+            )
+            self._using_fallback = True
+            return await self._secondary.embed(text)
+
+    async def health_check(self) -> bool:
+        """Healthy if either primary or secondary is reachable."""
+        primary_ok = await self._primary.health_check()
+        if primary_ok:
+            self._using_fallback = False
+            return True
+        secondary_ok = await self._secondary.health_check()
+        if secondary_ok:
+            self._using_fallback = True
+            logger.warning(
+                f"Primary embedding provider '{self._primary.provider_name}' unhealthy. Using fallback '{self._secondary.provider_name}'."
+            )
+        return secondary_ok

--- a/ai-service/clients/ollama.py
+++ b/ai-service/clients/ollama.py
@@ -66,3 +66,12 @@ class OllamaClient(BaseLLMClient, EmbeddingClient):
                 raise Exception(f"Ollama generate failed: {await resp.text()}")
             data = await resp.json()
             return data["response"]
+
+    async def health_check(self) -> bool:
+        """Check if Ollama is reachable via GET /api/tags (lightweight, no model load)."""
+        try:
+            session = await self._get_session()
+            async with session.get(f"{self._base_url}/api/tags") as resp:
+                return resp.status == 200
+        except Exception:
+            return False

--- a/ai-service/main.py
+++ b/ai-service/main.py
@@ -31,9 +31,31 @@ ai_rag_errors = Counter('ai_rag_errors_total', 'RAG errors', ['provider'])
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     setup_logging()
-    logging.getLogger(__name__).info("[ai-service] Starting up")
+    logger = logging.getLogger(__name__)
+    logger.info("[ai-service] Starting up")
+
+    # Startup health check: ping configured providers and log availability (#568).
+    # This does NOT block startup — it only logs the result so operators can
+    # see which provider is actually reachable.
+    if settings.is_ai_enabled:
+        try:
+            llm_client = get_llm_client()
+            llm_healthy = await llm_client.health_check()
+            logger.info(f"[ai-service] LLM provider '{llm_client.provider_name}' health: {'OK' if llm_healthy else 'UNREACHABLE'}")
+        except Exception as exc:
+            logger.warning(f"[ai-service] LLM health check failed: {exc}")
+
+        try:
+            emb_client = get_embedding_client()
+            emb_healthy = await emb_client.health_check()
+            logger.info(f"[ai-service] Embedding provider '{emb_client.provider_name}' health: {'OK' if emb_healthy else 'UNREACHABLE'}")
+        except Exception as exc:
+            logger.warning(f"[ai-service] Embedding health check failed: {exc}")
+    else:
+        logger.info("[ai-service] No AI providers configured — AI features disabled")
+
     yield
-    logging.getLogger(__name__).info("[ai-service] Shutting down")
+    logger.info("[ai-service] Shutting down")
 
 
 app = FastAPI(title="Joidy AI Service", version="0.2.0", lifespan=lifespan)
@@ -140,8 +162,16 @@ def _get_provider_info():
     }
 
 
+def _has_fallback() -> bool:
+    """Check if Ollama fallback is available for the configured primary provider."""
+    available = settings.available_providers
+    llm_provider = settings.llm_model.split(":", 1)[0] if ":" in settings.llm_model else "gemini"
+    emb_provider = settings.embedding_model.split(":", 1)[0] if ":" in settings.embedding_model else "gemini"
+    return "ollama" in available and (llm_provider != "ollama" or emb_provider != "ollama")
+
+
 @app.get("/health")
-def health():
+async def health():
     provider_info = _get_provider_info()
     # The service is "degraded" if the configured LLM/embedding provider is
     # not actually available (e.g. GEMINI_API_KEY not set but model is gemini:*).
@@ -153,6 +183,7 @@ def health():
         "service": "joidy-ai",
         "ai_enabled": settings.is_ai_enabled,
         "provider": provider_info,
+        "fallback_enabled": _has_fallback(),
     }
 
 

--- a/ai-service/tests/test_factory_fallback.py
+++ b/ai-service/tests/test_factory_fallback.py
@@ -1,0 +1,267 @@
+"""Tests for AI provider fallback behavior (#568).
+
+Verifies that:
+1. FallbackLLMClient tries primary, falls back to secondary on exception
+2. FallbackEmbeddingClient tries primary, falls back to secondary on exception
+3. ClientFactory wraps primary with Ollama fallback when Ollama is available
+4. ClientFactory does NOT wrap when primary is already Ollama
+5. health_check() returns True if either primary or secondary is healthy
+6. health_check() returns False if both providers are unreachable
+"""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from clients.base import BaseLLMClient, EmbeddingClient
+from clients.factory import ClientFactory
+from clients.fallback import FallbackEmbeddingClient, FallbackLLMClient
+
+
+class FakeLLMClient(BaseLLMClient):
+    """Fake LLM client for testing — configurable to succeed or fail."""
+
+    def __init__(self, name: str, fail: bool = False, embed_fail: bool = False):
+        self._name = name
+        self._fail = fail
+        self._embed_fail = embed_fail or fail
+
+    @property
+    def provider_name(self) -> str:
+        return self._name
+
+    async def embed_text(self, text: str) -> list[float]:
+        if self._embed_fail:
+            raise Exception(f"{self._name} embed_text failed")
+        return [0.1, 0.2, 0.3]
+
+    async def generate(
+        self,
+        prompt: str,
+        temperature: float = 0.2,
+        max_tokens: int = 256,
+        system_prompt: str | None = None,
+    ) -> str:
+        if self._fail:
+            raise Exception(f"{self._name} generate failed")
+        return f"{self._name}:response"
+
+    async def health_check(self) -> bool:
+        return not self._fail
+
+
+class FakeEmbeddingClient(EmbeddingClient):
+    """Fake embedding client for testing."""
+
+    def __init__(self, name: str, fail: bool = False):
+        self._name = name
+        self._fail = fail
+
+    @property
+    def provider_name(self) -> str:
+        return self._name
+
+    async def embed(self, text: str) -> list[float]:
+        if self._fail:
+            raise Exception(f"{self._name} embed failed")
+        return [0.4, 0.5, 0.6]
+
+    async def health_check(self) -> bool:
+        return not self._fail
+
+
+class TestFallbackLLMClient(unittest.IsolatedAsyncioTestCase):
+    """Tests for FallbackLLMClient."""
+
+    async def test_primary_succeeds_no_fallback(self):
+        primary = FakeLLMClient("gemini", fail=False)
+        secondary = FakeLLMClient("ollama", fail=False)
+        client = FallbackLLMClient(primary=primary, secondary=secondary)
+
+        result = await client.generate("test")
+        self.assertEqual(result, "gemini:response")
+        self.assertEqual(client.provider_name, "gemini")
+
+    async def test_primary_fails_fallback_to_secondary(self):
+        primary = FakeLLMClient("gemini", fail=True)
+        secondary = FakeLLMClient("ollama", fail=False)
+        client = FallbackLLMClient(primary=primary, secondary=secondary)
+
+        result = await client.generate("test")
+        self.assertEqual(result, "ollama:response")
+        self.assertEqual(client.provider_name, "ollama")
+
+    async def test_both_fail_raises_exception(self):
+        primary = FakeLLMClient("gemini", fail=True)
+        secondary = FakeLLMClient("ollama", fail=True)
+        client = FallbackLLMClient(primary=primary, secondary=secondary)
+
+        with self.assertRaises(Exception):
+            await client.generate("test")
+
+    async def test_embed_text_primary_succeeds(self):
+        primary = FakeLLMClient("gemini", fail=False)
+        secondary = FakeLLMClient("ollama", fail=False)
+        client = FallbackLLMClient(primary=primary, secondary=secondary)
+
+        result = await client.embed_text("test")
+        self.assertEqual(result, [0.1, 0.2, 0.3])
+
+    async def test_embed_text_falls_back(self):
+        primary = FakeLLMClient("gemini", fail=False, embed_fail=True)
+        secondary = FakeLLMClient("ollama", fail=False)
+        client = FallbackLLMClient(primary=primary, secondary=secondary)
+
+        result = await client.embed_text("test")
+        self.assertEqual(result, [0.1, 0.2, 0.3])
+        self.assertEqual(client.provider_name, "ollama")
+
+    async def test_health_check_primary_healthy(self):
+        primary = FakeLLMClient("gemini", fail=False)
+        secondary = FakeLLMClient("ollama", fail=False)
+        client = FallbackLLMClient(primary=primary, secondary=secondary)
+
+        result = await client.health_check()
+        self.assertTrue(result)
+        self.assertEqual(client.provider_name, "gemini")
+
+    async def test_health_check_primary_down_secondary_healthy(self):
+        primary = FakeLLMClient("gemini", fail=True)
+        secondary = FakeLLMClient("ollama", fail=False)
+        client = FallbackLLMClient(primary=primary, secondary=secondary)
+
+        result = await client.health_check()
+        self.assertTrue(result)
+        self.assertEqual(client.provider_name, "ollama")
+
+    async def test_health_check_both_down(self):
+        primary = FakeLLMClient("gemini", fail=True)
+        secondary = FakeLLMClient("ollama", fail=True)
+        client = FallbackLLMClient(primary=primary, secondary=secondary)
+
+        result = await client.health_check()
+        self.assertFalse(result)
+
+
+class TestFallbackEmbeddingClient(unittest.IsolatedAsyncioTestCase):
+    """Tests for FallbackEmbeddingClient."""
+
+    async def test_primary_succeeds_no_fallback(self):
+        primary = FakeEmbeddingClient("gemini", fail=False)
+        secondary = FakeEmbeddingClient("ollama", fail=False)
+        client = FallbackEmbeddingClient(primary=primary, secondary=secondary)
+
+        result = await client.embed("test")
+        self.assertEqual(result, [0.4, 0.5, 0.6])
+        self.assertEqual(client.provider_name, "gemini")
+
+    async def test_primary_fails_fallback_to_secondary(self):
+        primary = FakeEmbeddingClient("gemini", fail=True)
+        secondary = FakeEmbeddingClient("ollama", fail=False)
+        client = FallbackEmbeddingClient(primary=primary, secondary=secondary)
+
+        result = await client.embed("test")
+        self.assertEqual(result, [0.4, 0.5, 0.6])
+        self.assertEqual(client.provider_name, "ollama")
+
+    async def test_both_fail_raises_exception(self):
+        primary = FakeEmbeddingClient("gemini", fail=True)
+        secondary = FakeEmbeddingClient("ollama", fail=True)
+        client = FallbackEmbeddingClient(primary=primary, secondary=secondary)
+
+        with self.assertRaises(Exception):
+            await client.embed("test")
+
+    async def test_health_check_primary_healthy(self):
+        primary = FakeEmbeddingClient("gemini", fail=False)
+        secondary = FakeEmbeddingClient("ollama", fail=False)
+        client = FallbackEmbeddingClient(primary=primary, secondary=secondary)
+
+        result = await client.health_check()
+        self.assertTrue(result)
+
+    async def test_health_check_both_down(self):
+        primary = FakeEmbeddingClient("gemini", fail=True)
+        secondary = FakeEmbeddingClient("ollama", fail=True)
+        client = FallbackEmbeddingClient(primary=primary, secondary=secondary)
+
+        result = await client.health_check()
+        self.assertFalse(result)
+
+
+class TestClientFactoryFallback(unittest.IsolatedAsyncioTestCase):
+    """Tests for ClientFactory fallback wrapping."""
+
+    def setUp(self):
+        ClientFactory.reset()
+
+    def tearDown(self):
+        ClientFactory.reset()
+
+    @patch("clients.factory.settings")
+    def test_factory_wraps_with_fallback_when_ollama_available(self, mock_settings):
+        """Factory should wrap primary with FallbackLLMClient when Ollama is available."""
+        mock_settings.llm_model = "gemini:gemini-2.0-flash"
+        mock_settings.available_providers = ["gemini", "ollama"]
+        mock_settings.provider_config = {
+            "gemini": {"api_key": "fake-key"},
+            "ollama": {"base_url": "http://localhost:11434"},
+        }
+
+        client = ClientFactory.get_llm_client()
+        self.assertIsInstance(client, FallbackLLMClient)
+
+    @patch("clients.factory.settings")
+    def test_factory_no_fallback_when_ollama_not_available(self, mock_settings):
+        """Factory should NOT wrap when Ollama is not available."""
+        mock_settings.llm_model = "gemini:gemini-2.0-flash"
+        mock_settings.available_providers = ["gemini"]
+        mock_settings.provider_config = {
+            "gemini": {"api_key": "fake-key"},
+        }
+
+        client = ClientFactory.get_llm_client()
+        self.assertNotIsInstance(client, FallbackLLMClient)
+        self.assertEqual(client.provider_name, "gemini")
+
+    @patch("clients.factory.settings")
+    def test_factory_no_fallback_when_primary_is_ollama(self, mock_settings):
+        """Factory should NOT wrap when primary provider is already Ollama."""
+        mock_settings.llm_model = "ollama:llama3"
+        mock_settings.available_providers = ["ollama"]
+        mock_settings.provider_config = {
+            "ollama": {"base_url": "http://localhost:11434"},
+        }
+
+        client = ClientFactory.get_llm_client()
+        self.assertNotIsInstance(client, FallbackLLMClient)
+        self.assertEqual(client.provider_name, "ollama")
+
+    @patch("clients.factory.settings")
+    def test_factory_wraps_embedding_with_fallback(self, mock_settings):
+        """Factory should wrap embedding client with fallback when Ollama is available."""
+        mock_settings.embedding_model = "gemini:models/text-embedding-004"
+        mock_settings.available_providers = ["gemini", "ollama"]
+        mock_settings.provider_config = {
+            "gemini": {"api_key": "fake-key"},
+            "ollama": {"base_url": "http://localhost:11434"},
+        }
+
+        client = ClientFactory.get_embedding_client()
+        self.assertIsInstance(client, FallbackEmbeddingClient)
+
+    @patch("clients.factory.settings")
+    def test_factory_no_embedding_fallback_when_ollama_unavailable(self, mock_settings):
+        """Factory should NOT wrap embedding when Ollama is not available."""
+        mock_settings.embedding_model = "gemini:models/text-embedding-004"
+        mock_settings.available_providers = ["gemini"]
+        mock_settings.provider_config = {
+            "gemini": {"api_key": "fake-key"},
+        }
+
+        client = ClientFactory.get_embedding_client()
+        self.assertNotIsInstance(client, FallbackEmbeddingClient)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
When the primary LLM/embedding provider (e.g. Gemini) fails — invalid API key, quota exhausted, network unreachable — the AI service now transparently falls back to Ollama if configured. This prevents all AI endpoints from returning 500 when only the primary provider is down.

### Changes
- **New `FallbackLLMClient` and `FallbackEmbeddingClient`** wrappers (`clients/fallback.py`) that try the primary provider and fall back to a secondary on exception, logging a warning with both provider names
- **`ClientFactory` refactored**: extracted `_create_llm_client` and `_create_embedding_client` helpers. `get_llm_client`/`get_embedding_client` now wrap the primary client in a `Fallback*Client` when the primary is not Ollama and Ollama is available. Default fallback models: `llama3` (LLM), `nomic-embed-text` (embedding)
- **`health_check()` method** added to `BaseLLMClient`, `EmbeddingClient`, and both fallback wrappers. `OllamaClient` overrides with a lightweight `GET /api/tags` instead of a full generate call
- **Startup lifespan** now pings both LLM and embedding providers and logs their health status (OK/UNREACHABLE). Does not block startup
- **`/health` endpoint** now includes `fallback_enabled` field
- **18 unit tests** covering: primary success, primary fail → fallback, both fail → exception, embed fallback, health check scenarios, factory wrapping logic

Closes #568

#### Test plan
- [x] `python -m compileall` — 0 errors
- [x] `python -m unittest tests.test_factory_fallback` — 18/18 tests pass
- [ ] Manual: With invalid `GEMINI_API_KEY` + `OLLAMA_BASE_URL` set, verify `/embed` and `/classify` fall back to Ollama instead of returning 500
- [ ] Manual: Verify `/health` shows `fallback_enabled: true` when Ollama is configured

Generated with [Devin](https://devin.ai)