### PR TITLE
fix(api): add pagination metadata headers to list endpoints

### DIFF
--- a/api/routers/notes.py
+++ b/api/routers/notes.py
@@ -1,8 +1,9 @@
 
 from database import get_db
-from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Query, Response
 from models.note import EmbeddingFailure, Note, NoteTag, Tag
 from pydantic import BaseModel, field_validator
+from services.pagination import add_pagination_headers
 from services.sanitizer import sanitize_title, sanitize_content
 from services.embedding_service import (
     get_dead_letter_entries,
@@ -175,13 +176,16 @@ def list_notes(
     tag: str | None = None,
     source_path: str | None = None,
     db: Session = Depends(get_db),
+    response: Response = None,
 ):
     query = db.query(Note).options(selectinload(Note.tags).selectinload(NoteTag.tag))
     if tag:
         query = query.join(NoteTag).join(Tag).filter(Tag.name == tag.lower())
     if source_path:
         query = query.filter(Note.source_path == source_path)
+    total = query.count()
     notes = query.order_by(Note.created_at.desc()).offset(skip).limit(limit).all()
+    add_pagination_headers(response, total=total, limit=limit, offset=skip)
     return [note_to_response(n) for n in notes]
 
 

--- a/api/routers/personal_streaks.py
+++ b/api/routers/personal_streaks.py
@@ -1,9 +1,10 @@
 from datetime import date, datetime, timedelta, timezone
 
 from database import get_db
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from models.personal_streaks import PersonalStreak, StreakCheckIn
 from pydantic import BaseModel
+from services.pagination import add_pagination_headers
 from services.personal_streak_service import (
     backfill_streak_history,
     compute_streak,
@@ -305,13 +306,16 @@ def list_streaks(
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
+    response: Response = None,
 ):
     q = db.query(PersonalStreak).options(selectinload(PersonalStreak.checkins))
     if not include_archived:
         q = q.filter(PersonalStreak.is_archived == False)
     if category and category != "all":
         q = q.filter(PersonalStreak.category == category)
+    total = q.count()
     streaks = q.order_by(PersonalStreak.created_at).offset(offset).limit(limit).all()
+    add_pagination_headers(response, total=total, limit=limit, offset=offset)
     return [
         _streak_to_dict(s, days_history=days_history if include_history else 0)
         for s in streaks

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -1,6 +1,6 @@
 
 from database import get_db
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from models.note import Note, NoteLink, NoteTag, Tag, TagCooccurrence
 from pydantic import BaseModel
 from services.response_cache import clear_api_caches, register_cache_clearer, ttl_cache
@@ -195,5 +195,9 @@ register_cache_clearer(_cached_tag_graph.cache_clear)  # type: ignore[attr-defin
 
 
 @router.get("/graph")
-def get_tag_graph(db: Session = Depends(get_db)):
-    return _cached_tag_graph(db)
+def get_tag_graph(db: Session = Depends(get_db), response: Response = None):
+    data = _cached_tag_graph(db)
+    if response is not None:
+        response.headers["X-Total-Nodes"] = str(len(data.get("nodes", [])))
+        response.headers["X-Total-Edges"] = str(len(data.get("edges", [])))
+    return data

--- a/api/services/pagination.py
+++ b/api/services/pagination.py
@@ -1,0 +1,36 @@
+"""Pagination metadata helpers for list endpoints (#579).
+
+Provides non-breaking pagination metadata via HTTP headers so that:
+- Existing clients that expect a plain JSON array continue to work.
+- New clients can read `X-Total-Count` and `X-Has-More` headers to
+  determine if more data is available without making an extra request.
+
+Header conventions:
+- `X-Total-Count`: total number of items matching the query (before pagination).
+- `X-Has-More`: "true" if there are more items beyond the current page.
+- `X-Page-Size`: the limit applied to this response.
+- `X-Page-Offset`: the offset applied to this response.
+"""
+
+from fastapi import Response
+
+
+def add_pagination_headers(
+    response: Response,
+    total: int,
+    limit: int,
+    offset: int,
+) -> None:
+    """Add X-Total-Count, X-Has-More, X-Page-Size, X-Page-Offset headers.
+
+    Args:
+        response: The FastAPI Response object to attach headers to.
+        total: Total number of items matching the query (before pagination).
+        limit: The limit applied to this response.
+        offset: The offset applied to this response.
+    """
+    has_more = (offset + limit) < total
+    response.headers["X-Total-Count"] = str(total)
+    response.headers["X-Has-More"] = "true" if has_more else "false"
+    response.headers["X-Page-Size"] = str(limit)
+    response.headers["X-Page-Offset"] = str(offset)

--- a/api/tests/test_pagination.py
+++ b/api/tests/test_pagination.py
@@ -1,0 +1,120 @@
+"""Tests for pagination metadata headers on list endpoints (#579).
+
+Verifies that:
+1. /notes/ returns X-Total-Count, X-Has-More, X-Page-Size, X-Page-Offset headers
+2. /personal-streaks/ returns the same pagination headers
+3. /tags/graph returns X-Total-Nodes and X-Total-Edges headers
+4. X-Has-More is correct when there are more items beyond the current page
+5. X-Has-More is "false" when all items fit in the current page
+6. Response body remains a plain list (backward compatible)
+
+Note: Tests run against the real database, so they must not assume an
+empty state. Instead, they create data and verify headers relative to
+the observed total.
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_notes_pagination_headers_present(client: TestClient):
+    """/notes/ should have all pagination headers."""
+    response = client.get("/notes/")
+    assert response.status_code == 200
+    assert "X-Total-Count" in response.headers
+    assert "X-Has-More" in response.headers
+    assert "X-Page-Size" in response.headers
+    assert "X-Page-Offset" in response.headers
+    # Body should still be a list (backward compatible)
+    assert isinstance(response.json(), list)
+
+
+def test_notes_pagination_has_more_true(client: TestClient):
+    """With limit=1, has_more should be true if there are >1 notes."""
+    # Create at least 2 notes
+    client.post("/notes/", json={"title": "Pag Test A", "content": "Content A", "tags": []})
+    client.post("/notes/", json={"title": "Pag Test B", "content": "Content B", "tags": []})
+
+    response = client.get("/notes/?limit=1&skip=0")
+    assert response.status_code == 200
+    total = int(response.headers["X-Total-Count"])
+    assert total >= 2
+    assert response.headers["X-Has-More"] == "true"
+    assert response.headers["X-Page-Size"] == "1"
+    assert response.headers["X-Page-Offset"] == "0"
+    assert len(response.json()) == 1
+
+
+def test_notes_pagination_has_more_false_with_large_limit(client: TestClient):
+    """With a very large limit, has_more should be false."""
+    response = client.get("/notes/?limit=1000&skip=0")
+    assert response.status_code == 200
+    total = int(response.headers["X-Total-Count"])
+    # With limit=1000 and skip=0, has_more is false if total <= 1000
+    if total <= 1000:
+        assert response.headers["X-Has-More"] == "false"
+    assert response.headers["X-Page-Size"] == "1000"
+
+
+def test_notes_pagination_with_skip(client: TestClient):
+    """Pagination headers should reflect skip correctly."""
+    response = client.get("/notes/?limit=1&skip=2")
+    assert response.status_code == 200
+    assert response.headers["X-Page-Offset"] == "2"
+    assert response.headers["X-Page-Size"] == "1"
+    # has_more should be true if there are items beyond skip+limit
+    total = int(response.headers["X-Total-Count"])
+    expected_has_more = (2 + 1) < total
+    assert response.headers["X-Has-More"] == ("true" if expected_has_more else "false")
+
+
+def test_personal_streaks_pagination_headers(client: TestClient):
+    """Personal streaks should have pagination headers."""
+    response = client.get("/personal-streaks/")
+    assert response.status_code == 200
+    assert "X-Total-Count" in response.headers
+    assert "X-Has-More" in response.headers
+    assert "X-Page-Size" in response.headers
+    assert "X-Page-Offset" in response.headers
+    # Body should still be a list (backward compatible)
+    assert isinstance(response.json(), list)
+
+
+def test_personal_streaks_pagination_with_limit(client: TestClient):
+    """Personal streaks with limit=1 should have has_more=true if >1 streaks."""
+    # Create at least 2 streaks
+    client.post(
+        "/personal-streaks/",
+        json={"name": "Pag Streak A", "frequency": "DAILY", "category": "salud"},
+    )
+    client.post(
+        "/personal-streaks/",
+        json={"name": "Pag Streak B", "frequency": "DAILY", "category": "salud"},
+    )
+
+    response = client.get("/personal-streaks/?limit=1&offset=0")
+    assert response.status_code == 200
+    total = int(response.headers["X-Total-Count"])
+    assert total >= 2
+    assert response.headers["X-Has-More"] == "true"
+    assert response.headers["X-Page-Size"] == "1"
+    assert len(response.json()) == 1
+
+
+def test_tags_graph_count_headers(client: TestClient):
+    """Tags graph should have X-Total-Nodes and X-Total-Edges headers."""
+    # Create a note with a tag to ensure graph has data
+    client.post("/notes/", json={"title": "Graph Pag Test", "content": "Content #pagtest", "tags": ["pagtest"]})
+
+    response = client.get("/tags/graph")
+    assert response.status_code == 200
+    assert "X-Total-Nodes" in response.headers
+    assert "X-Total-Edges" in response.headers
+    total_nodes = int(response.headers["X-Total-Nodes"])
+    total_edges = int(response.headers["X-Total-Edges"])
+    assert total_nodes > 0
+    # Body should still be {nodes, edges} (backward compatible)
+    data = response.json()
+    assert "nodes" in data
+    assert "edges" in data
+    assert len(data["nodes"]) == total_nodes
+    assert len(data["edges"]) == total_edges


### PR DESCRIPTION
## Summary
Adds non-breaking pagination metadata via HTTP headers to the three large-response endpoints identified in #579. Existing clients that expect a plain JSON array continue to work unchanged; new clients can read the headers to determine if more data is available without making an extra request.

### Endpoints updated
- **GET /notes/**: adds `X-Total-Count`, `X-Has-More`, `X-Page-Size`, `X-Page-Offset`
- **GET /personal-streaks/**: adds same pagination headers
- **GET /tags/graph**: adds `X-Total-Nodes`, `X-Total-Edges` (graph is not paginated, but counts help clients estimate payload size)

### New helper
`api/services/pagination.py` with `add_pagination_headers()` that computes `has_more = (offset + limit) < total` and sets all four headers on the FastAPI Response object.

### Tests
7 new tests in `api/tests/test_pagination.py` covering header presence, has_more logic, skip/offset reflection, and backward compatibility (response body remains a plain list/object).

Closes #579

#### Test plan
- [x] `python -m compileall` — 0 errors
- [x] `python -m pytest tests/test_pagination.py` — 7/7 tests pass
- [x] Existing tests (`test_routers_notes`, `test_routers_personal_streaks`, `test_routers_tags`) — 23/26 pass (3 pre-existing failures due to running against real DB, not caused by this change)
- [ ] Manual: Verify `curl -I http://localhost:8000/notes/?limit=10` shows pagination headers

Generated with [Devin](https://devin.ai)