### PR TITLE
fix(e2e): add global teardown to clean up test data after runs

### DIFF
--- a/frontend/e2e/helpers/cleanup.ts
+++ b/frontend/e2e/helpers/cleanup.ts
@@ -1,0 +1,138 @@
+/**
+ * Global teardown for E2E tests — cleans up test data left in the database (#565).
+ *
+ * This runs after all Playwright tests complete. It deletes any notes, goals,
+ * and personal streaks whose names match known E2E test patterns. This prevents
+ * test artifacts from accumulating in the dev database across multiple test runs.
+ *
+ * The cleanup uses the API directly (with JWT auth) rather than UI interactions,
+ * so it's fast and doesn't depend on the frontend being in a specific state.
+ */
+
+const API_BASE = process.env.PLAYWRIGHT_API_URL ?? 'http://localhost:8000';
+const TEST_PASSWORD = process.env.JOIDY_TEST_PASSWORD ?? 'root';
+
+/**
+ * Known E2E test data name patterns. Any note/goal/streak whose title/name
+ * matches one of these patterns (case-insensitive) will be deleted.
+ */
+const E2E_PATTERNS = [
+  'E2E',
+  'Test Goal',
+  'Test Title from E2E',
+  'Goal Title from E2E',
+  'Updated E2E Note',
+  'E2E API Test Note',
+  'Test Audit Goal',
+  '33 E2E',
+  'Streak A',
+  'Streak B',
+  'Freeze Streak',
+  'Drink Water', // Created by streak tests
+  'Pag Test',
+  'Pag Streak',
+  'Graph Pag Test',
+];
+
+async function getAuthToken(): Promise<string> {
+  const res = await fetch(`${API_BASE}/auth/login?username=user&password=${TEST_PASSWORD}`, {
+    method: 'POST',
+  });
+  if (!res.ok) {
+    console.error(`[cleanup] Login failed: ${res.status}`);
+    return '';
+  }
+  const data = await res.json();
+  return data.access_token;
+}
+
+function matchesPattern(name: string): boolean {
+  const lower = name.toLowerCase();
+  return E2E_PATTERNS.some((p) => lower.includes(p.toLowerCase()));
+}
+
+async function cleanupNotes(token: string): Promise<number> {
+  let deleted = 0;
+  try {
+    const res = await fetch(`${API_BASE}/notes/?limit=1000`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return 0;
+    const notes = await res.json();
+    for (const note of notes) {
+      if (matchesPattern(note.title || '')) {
+        const delRes = await fetch(`${API_BASE}/notes/${note.id}`, {
+          method: 'DELETE',
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (delRes.ok) deleted++;
+      }
+    }
+  } catch (e) {
+    console.error('[cleanup] Notes cleanup error:', e);
+  }
+  return deleted;
+}
+
+async function cleanupGoals(token: string): Promise<number> {
+  let deleted = 0;
+  try {
+    const res = await fetch(`${API_BASE}/goals/?limit=200`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return 0;
+    const goals = await res.json();
+    for (const goal of goals) {
+      if (matchesPattern(goal.title || '')) {
+        const delRes = await fetch(`${API_BASE}/goals/${goal.id}`, {
+          method: 'DELETE',
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (delRes.ok) deleted++;
+      }
+    }
+  } catch (e) {
+    console.error('[cleanup] Goals cleanup error:', e);
+  }
+  return deleted;
+}
+
+async function cleanupStreaks(token: string): Promise<number> {
+  let deleted = 0;
+  try {
+    const res = await fetch(`${API_BASE}/personal-streaks/?include_archived=true&limit=200`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return 0;
+    const streaks = await res.json();
+    for (const streak of streaks) {
+      if (matchesPattern(streak.name || '')) {
+        const delRes = await fetch(`${API_BASE}/personal-streaks/${streak.id}`, {
+          method: 'DELETE',
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (delRes.ok) deleted++;
+      }
+    }
+  } catch (e) {
+    console.error('[cleanup] Streaks cleanup error:', e);
+  }
+  return deleted;
+}
+
+export default async function globalTeardown() {
+  console.log('[cleanup] Starting E2E test data cleanup (#565)...');
+  const token = await getAuthToken();
+  if (!token) {
+    console.warn('[cleanup] No auth token — skipping cleanup');
+    return;
+  }
+
+  const notesDeleted = await cleanupNotes(token);
+  const goalsDeleted = await cleanupGoals(token);
+  const streaksDeleted = await cleanupStreaks(token);
+
+  console.log(
+    `[cleanup] Done: ${notesDeleted} notes, ${goalsDeleted} goals, ${streaksDeleted} streaks deleted.`
+  );
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import globalTeardown from './e2e/helpers/cleanup';
 
 /**
  * Playwright E2E configuration for Joidy frontend.
@@ -13,6 +14,10 @@ import { defineConfig, devices } from '@playwright/test';
  *
  * In CI, the full Docker stack should be running before executing these
  * tests (see the `docker-build` job in .github/workflows/ci.yml).
+ *
+ * Global teardown (#565): after all tests complete, any test artifacts
+ * (notes, goals, streaks with E2E test names) are deleted from the
+ * database to prevent accumulation across runs.
  */
 export default defineConfig({
   testDir: './e2e',
@@ -40,4 +45,5 @@ export default defineConfig({
         reuseExistingServer: true,
         timeout: 60_000,
       },
+  globalTeardown,
 });


### PR DESCRIPTION
## Summary
E2E tests (Playwright) create notes, goals, and streaks via UI interactions but don't clean up after themselves. After multiple test runs, the dev database accumulates duplicate test entries.

### Changes
- **New `frontend/e2e/helpers/cleanup.ts`**: Global teardown that runs after all Playwright tests. It authenticates via the API, fetches all notes/goals/streaks, and deletes any whose title/name matches known E2E test patterns.
- **Updated `frontend/playwright.config.ts`**: Registers the global teardown.

### Patterns matched
`E2E`, `Test Goal`, `Test Title from E2E`, `Goal Title from E2E`, `Updated E2E Note`, `E2E API Test Note`, `Test Audit Goal`, `33 E2E`, `Streak A`, `Streak B`, `Freeze Streak`, `Drink Water`, `Pag Test`, `Pag Streak`, `Graph Pag Test`

The cleanup uses the API directly (not UI interactions) so it's fast and doesn't depend on the frontend state.

Closes #565

#### Test plan
- [x] `npm run check` — 0 errors, 123 warnings (pre-existing)
- [ ] Manual: Run `npx playwright test`, then check DB for test artifacts — should be cleaned
- [ ] Manual: Verify teardown logs `[cleanup] Done: N notes, N goals, N streaks deleted.`

Generated with [Devin](https://devin.ai)