### PR TITLE
fix(ai-service): add pool_pre_ping and pool_recycle to database engine

### DIFF
--- a/ai-service/database.py
+++ b/ai-service/database.py
@@ -6,6 +6,8 @@ from sqlalchemy.orm import sessionmaker
 
 engine = create_engine(
     settings.database_url,
+    pool_pre_ping=True,
+    pool_recycle=3600,
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
## Summary
- Added `pool_pre_ping=True` and `pool_recycle=3600` to the ai-service SQLAlchemy engine, matching the API service's configuration
- Prevents stale connection errors after PostgreSQL restarts or idle timeout periods

Closes #611

#### Test plan
- [x] `python -m compileall ai-service/` passes
- [ ] Manual: restart PostgreSQL container, verify ai-service recovers without manual restart

Generated with [Devin](https://devin.ai)