### PR TITLE
fix(frontend): initialize svelte-i18n in vitest setup

### DIFF
--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -38,3 +38,14 @@ if (typeof globalThis.sessionStorage === 'undefined') {
     writable: true,
   });
 }
+
+// Initialize svelte-i18n for component tests. `initI18n()` is normally called
+// from the root layout, but component tests render components directly without
+// mounting it, so any component using `$t()` would throw "Cannot format a
+// message without first setting the initial locale" (#618).
+//
+// This must be a dynamic import: static `import` statements are hoisted above
+// the localStorage polyfill above, and `stores/locale` reads localStorage at
+// module-evaluation time via `detectLocale()`.
+const { initI18n } = await import('./src/lib/i18n');
+initI18n();


### PR DESCRIPTION
## Summary
- Call `initI18n()` from `vitest.setup.ts` so component tests have an initial locale
- Fixes 35 failing tests: `GoalCard.test.ts` (23) and `Plant.test.ts` (12), which threw `[svelte-i18n] Cannot format a message without first setting the initial locale`
- Uses a dynamic import so the existing localStorage polyfill still runs first (`stores/locale` reads localStorage at module-evaluation time)

This is a regression from the i18n migration (#572): `initI18n()` was only wired into `src/routes/+layout.svelte`, which component tests never mount.

Closes #618

#### Test plan
- [x] `npm run test:run` — **161/161 tests pass** (was 126 passed / 35 failed)
- [x] `npm run check` — 0 errors

Generated with [Devin](https://devin.ai)