### PR TITLE
fix(ci): bump frontend CI Node version from 20 to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
@@ -176,7 +176,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,9 @@
   "name": "joidy-frontend",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22.19.0"
+  },
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- Bumped both `node-version: '20'` entries in `.github/workflows/ci.yml` to `'22'`
- Added `engines.node: ">=22.19.0"` to `frontend/package.json` to document the requirement and catch future drift

### Why
`jsdom@30` and its transitive `undici@8` require Node >= 22:

| Package | `engines.node` |
|---------|----------------|
| `jsdom@30.0.1` | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` |
| `undici@8.9.0` | `>=22.19.0` |

`undici` 8 calls `worker_threads.markAsUncloneable`, absent on Node 20, so all 8 vitest workers crashed with `TypeError: webidl.util.markAsUncloneable is not a function` before running a single test. CI has been red on `development` since the jsdom 30 upgrade, and the crash masked 35 real test failures (fixed in #618 / #620).

CI now matches `frontend/Dockerfile`, which already used `node:22-slim`.

Closes #619

#### Test plan
- [ ] `Frontend Typecheck` job passes green in CI (this PR's own run is the test)
- [x] Verified engines constraints locally via `node_modules/*/package.json`

Generated with [Devin](https://devin.ai)