### PR TITLE
fix(infra): do not abort API startup when /app/data/logs is not writable

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,7 +28,13 @@ services:
       - APP_ENV=development
       - VAULT_PATH=/vault
       - OBSIDIAN_VAULT_PATH=/vault
-    command: sh -c "mkdir -p /app/data/logs && exec uvicorn main:app --host 0.0.0.0 --port 8000 --reload --reload-include '*.py' --reload-exclude '__pycache__/*' --reload-exclude '*.pyc'"
+    # The ./api:/app bind mount shadows the image's pre-chowned /app/data/logs,
+    # so this mkdir runs against the host checkout and fails whenever the host
+    # UID differs from the container's app user (uid 1000) — e.g. in CI, where
+    # it crash-looped the container before uvicorn ever started (#622).
+    # Keep it best-effort: logging_config.py already creates the directory and
+    # degrades to console-only logging when it is not writable.
+    command: sh -c "mkdir -p /app/data/logs 2>/dev/null || true; exec uvicorn main:app --host 0.0.0.0 --port 8000 --reload --reload-include '*.py' --reload-exclude '__pycache__/*' --reload-exclude '*.pyc'"
 
   ai-service:
     build:


### PR DESCRIPTION
## Summary
- Made the `mkdir -p /app/data/logs` in the API dev command best-effort (`2>/dev/null || true`) so it can no longer abort container startup
- Fixes the `Docker Build & Smoke Test` CI job, which has been failing on every branch

### Root cause
`./api:/app` shadows the image's pre-chowned `/app/data/logs`. Since `api/data/` is gitignored, on a fresh checkout the container (`USER app`, uid 1000) must create `/app/data` inside a directory owned by the host user. When the host UID is not 1000 — as in CI (runner uid 1001) — the `mkdir` fails, the `&&` chain aborts before `exec uvicorn`, and `restart: unless-stopped` crash-loops the container. Port 8000 was never bound, so the smoke test timed out after 60s.

This passed on developer machines that happen to run as uid 1000, which is why it went unnoticed.

The mkdir is redundant: `api/logging_config.py` already creates the directory and degrades to console-only logging when it is unwritable (its comment even cites "a read-only bind-mount in CI smoke tests").

#### Test plan
- [x] `docker compose config` validates
- [x] Reproduced the CI failure locally: container as uid 1001 + checkout without `api/data` → `mkdir: cannot create directory '/app/data': Permission denied`, crash loop
- [x] With the fix, same setup starts and serves: `/health` → `{"status":"ok","service":"joidy-api","checks":{"database":"ok"}}`
- [x] Confirmed graceful degradation: `WARNING: file logging disabled — could not init 'data/logs'`
- [ ] `Docker Build & Smoke Test` passes green in CI (this PR's run is the test)

Closes #622

Generated with [Devin](https://devin.ai)