### PR TITLE
fix(api): do not abort startup when data directories are not writable

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -38,7 +38,12 @@ def init_db():
     # The project is PostgreSQL-only (16 + pgvector) since #273. The previous
     # SQLite branch created a stale joidy.db and silently skipped migrations
     # and the vector extension, causing schema drift and broken AI features.
-    Path("/data/db").mkdir(parents=True, exist_ok=True)
+    #
+    # Creating /data/db was a leftover of that SQLite era: the API stores
+    # nothing there (PostgreSQL owns its own volume), and only the worker uses
+    # the directory, for its own event log — which it creates itself. The
+    # unguarded mkdir could raise PermissionError and abort API startup
+    # entirely when /data was not writable (#624).
     with engine.connect() as conn:
         conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
         conn.commit()

--- a/api/main.py
+++ b/api/main.py
@@ -197,8 +197,18 @@ app.include_router(analytics.router, dependencies=[Depends(get_current_user)])
 app.include_router(sync.router, dependencies=[Depends(get_current_user)])
 app.include_router(upload.router, dependencies=[Depends(get_current_user)])
 
-# Ensure the upload directory exists before serving it.
-Path(settings.upload_dir).mkdir(parents=True, exist_ok=True)
+# Ensure the upload directory exists before serving it. This is best-effort:
+# uploads are a non-critical feature, so an unwritable path (read-only mount,
+# host/container UID mismatch) must degrade rather than abort startup and take
+# down notes, goals and sync with it (#624).
+_uploads_available = True
+try:
+    Path(settings.upload_dir).mkdir(parents=True, exist_ok=True)
+except OSError:
+    _uploads_available = False
+    logger.warning(
+        "Uploads disabled — could not create upload_dir '%s'", settings.upload_dir, exc_info=True
+    )
 
 
 class SafeStaticFiles(StaticFiles):
@@ -212,7 +222,9 @@ class SafeStaticFiles(StaticFiles):
         return response
 
 
-app.mount("/uploads", SafeStaticFiles(directory=settings.upload_dir), name="uploads")
+# StaticFiles resolves the directory eagerly, so only mount when it exists.
+if _uploads_available:
+    app.mount("/uploads", SafeStaticFiles(directory=settings.upload_dir), name="uploads")
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
Two unguarded `mkdir` calls could crash the API before it served a single request, turning a non-critical degradation into a full outage.

**`api/main.py`** — `Path(settings.upload_dir).mkdir()` ran at module *import* time with no error handling. An unwritable upload path raised `PermissionError` during import and the app never started. Now wrapped, with the `/uploads` static mount made conditional (StaticFiles resolves its directory eagerly). This mirrors `logging_config.py`, which already degrades to console-only logging.

**`api/database.py`** — `init_db()` created `/data/db`, a leftover of the SQLite era. The API has been PostgreSQL-only since #273 and writes nothing there; the only consumer is the **worker** (`event_log_path: /data/db/vault_events.db`), and `PersistentEventLog.__init__` creates its own parent directory inside a `try/except`. Removed the dead call rather than guarding it.

Uploads, notes, goals, gamification and sync are independent — an unwritable upload dir should not take down the service.

Closes #624

#### Test plan
- [x] `python -m compileall api/` passes
- [x] `pytest tests/test_routers_upload.py tests/test_embedding_service.py` — 15 passed
- [x] Container as uid 1001 with no writable `/data` and no `api/data`: **before** → `PermissionError` on `/data`, startup failed; **after** → `Up`, `/health` returns `{"status":"ok","service":"joidy-api","checks":{"database":"ok"}}`
- [x] Degradations reported instead of crashing:
      `Uploads disabled — could not create upload_dir 'data/uploads'`
      `WARNING: file logging disabled — could not init 'data/logs'`
- [x] Normal path unchanged: writable dir → directory created and `/uploads` mounted

Generated with [Devin](https://devin.ai)