### PR TITLE
fix(tests): redirect API test suite to a dedicated test database

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -15,22 +15,62 @@ if "sqlite_vec" not in sys.modules:
     _stub.load = lambda _conn: None  # type: ignore
     sys.modules["sqlite_vec"] = _stub
 
+# Safety: only allow destructive drop_all on databases whose name contains
+# "test" to prevent accidentally wiping a shared dev/production database (#503).
+from urllib.parse import urlparse, urlunparse
+
+_DATABASE_URL = os.getenv("DATABASE_URL", "")
+_USE_POSTGRES = _DATABASE_URL.startswith("postgresql")
+_DB_NAME = urlparse(_DATABASE_URL).path.lstrip("/") if _USE_POSTGRES else ""
+
+
+def _redirect_to_test_database(url: str, db_name: str) -> tuple[str, str]:
+    """Point the suite at a dedicated ``<db_name>_test`` database.
+
+    ``make test-api`` runs inside the api container, which inherits
+    DATABASE_URL for the live development database. The #503 guard below then
+    refuses to drop_all, leaving tests with no isolation: they both fail on
+    accumulated state and write fixtures into real user data (#626).
+
+    Rather than depending on every caller to export the right DATABASE_URL,
+    redirect to a sibling test database (created on demand) so isolation holds
+    for `make test-api`, `docker compose run` and bare `pytest` alike.
+    """
+    parsed = urlparse(url)
+    test_db = f"{db_name}_test"
+    test_url = urlunparse(parsed._replace(path=f"/{test_db}"))
+
+    # CREATE DATABASE cannot run inside a transaction, hence AUTOCOMMIT. We
+    # connect to the original database purely as an entry point to the server.
+    admin_engine = create_engine(url, isolation_level="AUTOCOMMIT")
+    try:
+        with admin_engine.connect() as conn:
+            exists = conn.execute(
+                text("SELECT 1 FROM pg_database WHERE datname = :name"), {"name": test_db}
+            ).scalar()
+            if not exists:
+                conn.execute(text(f'CREATE DATABASE "{test_db}"'))
+    finally:
+        admin_engine.dispose()
+
+    return test_url, test_db
+
+
+# Must run before importing app modules: database.py builds its engine from
+# settings.database_url at import time, so redirecting afterwards would leave
+# every SessionLocal() (background tasks, services) pointed at the live DB.
+if _USE_POSTGRES and _DB_NAME and "test" not in _DB_NAME.lower():
+    _DATABASE_URL, _DB_NAME = _redirect_to_test_database(_DATABASE_URL, _DB_NAME)
+    os.environ["DATABASE_URL"] = _DATABASE_URL
+
+_CAN_DROP = "test" in _DB_NAME.lower() if _DB_NAME else False
+
 from database import Base, get_db
 import main as main_module
 from main import app
 from fastapi.testclient import TestClient
 from middleware.rate_limit import _default_limiter
 from services.auth_service import get_current_user
-
-_DATABASE_URL = os.getenv("DATABASE_URL", "")
-_USE_POSTGRES = _DATABASE_URL.startswith("postgresql")
-
-# Safety: only allow destructive drop_all on databases whose name contains
-# "test" to prevent accidentally wiping a shared dev/production database (#503).
-from urllib.parse import urlparse
-
-_DB_NAME = urlparse(_DATABASE_URL).path.lstrip("/") if _USE_POSTGRES else ""
-_CAN_DROP = "test" in _DB_NAME.lower() if _DB_NAME else False
 
 # Prevent the app lifespan from running Alembic migrations during tests. The
 # test fixture creates the schema directly via Base.metadata.create_all(), and


### PR DESCRIPTION
## Summary
`conftest.py` now redirects the suite to a sibling `<dbname>_test` database (created on demand) whenever the configured PostgreSQL database name does not contain `"test"`.

### Problem
`make test-api` runs pytest inside the api container, which inherits `DATABASE_URL` for the **live development database**. The #503 safety guard then refused `drop_all`, so tests ran with **no isolation**:

- **False failures**: 15 tests failed purely on accumulated state (`assert 97 == 1`, `assert 409 == 201`, `IntegrityError: duplicate key "user_stats_pkey"`) — indistinguishable from real regressions
- **Data pollution**: every run wrote fixtures into real user data. The dev DB had accumulated `Conflicted Note` ×35, `Hello` ×12, `Test Note` ×8, ~1600 notes and 14426 XP events across runs

CI was unaffected because it provisions `POSTGRES_DB: joidy_test`. The defect only hit local runs — exactly where changes get validated before a release.

### Approach
Fixing this in `conftest.py` rather than the Makefile makes isolation hold **by construction** for every invocation path (`make test-api`, `docker compose run`, bare `pytest`), instead of depending on each caller to export the right URL. The #503 protection against dropping non-test databases stays in force.

The redirect must run **before** importing app modules: `database.py` builds its engine from `settings.database_url` at import time, so redirecting afterwards would leave every `SessionLocal()` in background tasks and services still pointed at the live DB.

#### Test plan
- [x] `python -m compileall api/` passes
- [x] Full suite: **15 failed / 432 passed → 3 failed / 472 passed**
- [x] No remaining `Skipping drop_all for non-test database` warnings — isolation confirmed active
- [x] Dev database no longer receives test fixtures
- [ ] CI behaviour unchanged (already uses `joidy_test`, so the redirect is a no-op there)

The 3 residual failures are a separate pre-existing issue: `tests/test_obsidian_sync.py` depends on `AUTH_PASSWORD` being absent from the environment, so it fails on any machine whose `.env` configures auth. Tracked separately.

Closes #626

Generated with [Devin](https://devin.ai)