### PR TITLE
fix(tests): make obsidian webhook tests independent of ambient auth config

### DIFF
--- a/api/tests/test_obsidian_sync.py
+++ b/api/tests/test_obsidian_sync.py
@@ -28,6 +28,8 @@ def _create_note(db_session, note_id):
     return note
 
 
+@patch("config.settings.obsidian_webhook_secret", "")
+@patch("config.settings.auth_password", "")
 def test_obsidian_webhook_unconfigured_accepts_any(client, db_session):
     _create_note(db_session, 1)
     resp = client.post("/webhook/obsidian/legacy", json={
@@ -47,6 +49,8 @@ def test_sync_state_model_exists():
     assert SyncState.__tablename__ == "sync_state"
 
 
+@patch("config.settings.obsidian_webhook_secret", "")
+@patch("config.settings.auth_password", "")
 def test_obsidian_webhook_detects_conflict(client, db_session):
     _create_note(db_session, 2)
     sync = SyncState(note_id=2, local_mtime=datetime.fromtimestamp(1_600_000_000, tz=timezone.utc))
@@ -65,6 +69,8 @@ def test_obsidian_webhook_detects_conflict(client, db_session):
     assert updated.conflict is True
 
 
+@patch("config.settings.obsidian_webhook_secret", "")
+@patch("config.settings.auth_password", "")
 def test_obsidian_webhook_no_conflict_when_mtimes_match(client, db_session):
     _create_note(db_session, 3)
     mtime = 1_700_000_000
@@ -90,6 +96,7 @@ def test_obsidian_webhook_no_conflict_when_mtimes_match(client, db_session):
 # ── New webhook endpoint tests (create/update/delete) ──────────────────────────
 
 
+@patch("config.settings.obsidian_webhook_secret", "")
 @patch("config.settings.auth_password", "")
 def test_webhook_create_note(client, db_session):
     resp = client.post("/webhook/obsidian", json={
@@ -111,6 +118,7 @@ def test_webhook_create_note(client, db_session):
     assert note.source == "obsidian"
 
 
+@patch("config.settings.obsidian_webhook_secret", "")
 @patch("config.settings.auth_password", "")
 def test_webhook_update_note(client, db_session):
     # First create
@@ -133,6 +141,7 @@ def test_webhook_update_note(client, db_session):
     assert note.content == "updated content"
 
 
+@patch("config.settings.obsidian_webhook_secret", "")
 @patch("config.settings.auth_password", "")
 def test_webhook_delete_note(client, db_session):
     # First create
@@ -156,6 +165,7 @@ def test_webhook_delete_note(client, db_session):
     assert note is None
 
 
+@patch("config.settings.obsidian_webhook_secret", "")
 @patch("config.settings.auth_password", "")
 def test_webhook_delete_unknown_path(client, db_session):
     resp = client.post("/webhook/obsidian", json={
@@ -175,6 +185,7 @@ def test_webhook_invalid_event(client, db_session):
     assert resp.status_code == 422
 
 
+@patch("config.settings.obsidian_webhook_secret", "")
 @patch("config.settings.auth_password", "")
 def test_webhook_create_missing_content(client, db_session):
     resp = client.post("/webhook/obsidian", json={


### PR DESCRIPTION
## Summary
- Explicitly patch both `obsidian_webhook_secret` and `auth_password` in the three tests that assert unauthenticated webhook access
- Added the missing secret patch to the five dev-mode `/webhook/obsidian` tests, which would break the same way for a developer who sets `OBSIDIAN_WEBHOOK_SECRET`

### Problem
`_verify_access()` allows unauthenticated access only when **both** `obsidian_webhook_secret` and `auth_password` are unset (the documented dev-convenience path). Three tests asserted `200` on that path without setting either value, so they inherited whatever the mounted `.env` provided:

```
test_obsidian_webhook_unconfigured_accepts_any        assert 401 == 200
test_obsidian_webhook_detects_conflict                assert 401 == 200
test_obsidian_webhook_no_conflict_when_mtimes_match   assert 401 == 200
```

They passed in CI (`AUTH_PASSWORD` unset) but failed on any machine whose `.env` configures auth — so the suite produced different results per developer, which makes real regressions easy to dismiss as "the usual local failures".

The application logic is correct; only the tests needed to be hermetic. This follows the pattern already used by `test_obsidian_webhook_requires_secret` and the JWT fallback tests. Production behaviour stays covered: those fallback tests still assert a Bearer token is required when `auth_password` is set.

Closes #628

#### Test plan
- [x] `pytest tests/test_obsidian_sync.py` — **15/15 pass** on a machine with `AUTH_PASSWORD` configured
- [x] Full suite (combined with #627): **475 passed, 0 failed**
- [ ] CI unchanged (already passing there)

> Note: verified in combination with #627, which fixes test database isolation. On its own this branch still shows the state-accumulation failures that #627 addresses.

Generated with [Devin](https://devin.ai)