### PR TITLE
fix(infra,docs): correct pytest coverage source and update docs to PostgreSQL

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -70,7 +70,7 @@ graph LR
     API[API 8000<br/>FastAPI]
     AI[AI 8002<br/>FastAPI]
     Worker[Worker 8001<br/>asyncio]
-    DB[(SQLite + sqlite-vec)]
+    DB[(PostgreSQL 16 + pgvector)]
     Vault[Obsidian Vault]
 
     User --> FE
@@ -112,7 +112,7 @@ Si prefieres correr sin Docker, necesitas:
 - Python 3.12+ en `ai-service/`: `pip install -r requirements.txt && uvicorn main:app --reload --port 8002`
 - Worker: `python main.py` dentro de `worker/`
 
-Recuerda que la base de datos SQLite se comparte entre servicios, así que debe estar en una ruta accesible.
+Recuerda que la base de datos PostgreSQL (con la extensión `pgvector`) se comparte entre servicios vía `DATABASE_URL`, así que necesitas una instancia accesible (local o remota).
 
 ## 8. Convenciones útiles
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ graph LR
     API[API 8000<br/>FastAPI]
     AI[AI 8002<br/>FastAPI]
     Worker[Worker 8001<br/>asyncio]
-    DB[(SQLite + sqlite-vec)]
+    DB[(PostgreSQL 16 + pgvector)]
     Vault[Obsidian Vault]
 
     User --> FE

--- a/api/.coveragerc
+++ b/api/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-source = api
+source = .

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
-testpaths = api/tests
+testpaths = tests
 pythonpath = .
 
 [coverage:run]
-source = api
+source = .


### PR DESCRIPTION
## Summary
- Fix `make test-api` coverage, which still reported `No data was collected` despite #231/#235 claiming to resolve #208. The api service is bind-mounted at `/app` (`./api:/app`), so there is no `api` package inside the container — but `api/.coveragerc` and `api/pytest.ini` pointed at `source = api` / `testpaths = api/tests`.
  - `api/.coveragerc`: `source = api` → `source = .`
  - `api/pytest.ini`: `testpaths = api/tests` → `tests`; `[coverage:run] source = api` → `source = .`
- Update stale `SQLite + sqlite-vec` references in `README.md` and `QUICKSTART.md` to `PostgreSQL 16 + pgvector` (the default `DATABASE_URL` since the Alembic/pgvector migration). `ARCHITECTURE.md`, `AGENTS.md`, and `TODO.md` were already updated.

#### Test plan
- [x] `make test-api` now emits a real coverage report (no `module-not-imported` / `no-data-collected` warnings); verified with a single test file → `TOTAL 9739 7614 22%`.
- [x] `make lint` (compileall) unaffected — already passing.
- [x] No SQLite references remain in `README.md` / `QUICKSTART.md`.

Closes #208

Generated with [Devin](https://devin.ai)