### PR TITLE
chore(frontend): lazy-load lucide icons to stop bundling the whole library

### DIFF
--- a/frontend/src/lib/components/DynamicIcon.svelte
+++ b/frontend/src/lib/components/DynamicIcon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { activeIconPack } from '$lib/stores/settings';
   import { Circle } from 'lucide-svelte';
-  import * as LucideIcons from 'lucide-svelte';
+  import { loadLucideIcon } from '$lib/utils/lucideIcons';
 
   export let name: string;
   export let size: number = 18;
@@ -12,34 +12,75 @@
 
   // ── Phosphor ──
   import {
-    House as PHome, BookOpen as PBook, ShareNetwork as PNet, Lightning as PZap,
-    Target as PTarget, Fire as PFlame, Gear as PCog, GridFour as PGrid,
-    X as PX, Moon as PMoon, Sun as PSun, Database as PDB, GitBranch as PGit,
-    Palette as PPal, Plus as PPlus, Minus as PMinus, ArrowCounterClockwise as PRot,
-    FastForward as PSkip, File as PFile, CaretLeft as PLeft, CaretRight as PRight,
-    Wrench as PWrench
+    House as PHome,
+    BookOpen as PBook,
+    ShareNetwork as PNet,
+    Lightning as PZap,
+    Target as PTarget,
+    Fire as PFlame,
+    Gear as PCog,
+    GridFour as PGrid,
+    X as PX,
+    Moon as PMoon,
+    Sun as PSun,
+    Database as PDB,
+    GitBranch as PGit,
+    Palette as PPal,
+    Plus as PPlus,
+    Minus as PMinus,
+    ArrowCounterClockwise as PRot,
+    FastForward as PSkip,
+    File as PFile,
+    CaretLeft as PLeft,
+    CaretRight as PRight,
+    Wrench as PWrench,
   } from 'phosphor-svelte';
 
   $: isEmoji = emojiRegex.test(name);
 
   const phosphorMap: Record<string, any> = {
-    'Home': PHome, 'BookOpen': PBook, 'Network': PNet, 'Zap': PZap, 'Target': PTarget,
-    'Flame': PFlame, 'Settings': PCog, 'LayoutGrid': PGrid, 'X': PX, 'Moon': PMoon,
-    'Sun': PSun, 'Database': PDB, 'GitBranch': PGit, 'Palette': PPal, 'Plus': PPlus,
-    'Minus': PMinus, 'RotateCcw': PRot, 'SkipForward': PSkip, 'File': PFile,
-    'ChevronLeft': PLeft, 'ChevronRight': PRight, 'Wrench': PWrench,
+    Home: PHome,
+    BookOpen: PBook,
+    Network: PNet,
+    Zap: PZap,
+    Target: PTarget,
+    Flame: PFlame,
+    Settings: PCog,
+    LayoutGrid: PGrid,
+    X: PX,
+    Moon: PMoon,
+    Sun: PSun,
+    Database: PDB,
+    GitBranch: PGit,
+    Palette: PPal,
+    Plus: PPlus,
+    Minus: PMinus,
+    RotateCcw: PRot,
+    SkipForward: PSkip,
+    File: PFile,
+    ChevronLeft: PLeft,
+    ChevronRight: PRight,
+    Wrench: PWrench,
   };
 
-  function getIconComponent(packName: string, n: string): any {
-    if (packName === 'phosphor' || packName === 'material') {
-      return phosphorMap[n] || Circle;
-    }
-    // Synchronous lookup — handles both PascalCase and kebab-case names
-    const pascal = n.split('-').map((p: string) => p.charAt(0).toUpperCase() + p.slice(1)).join('');
-    return (LucideIcons as any)[n] || (LucideIcons as any)[pascal] || Circle;
-  }
+  // Lucide icons are loaded on demand via dynamic import so the whole icon
+  // library is no longer bundled into the main chunk (#209). A `Circle`
+  // placeholder is shown until the requested icon chunk resolves.
+  let comp: any = Circle;
+  let _req = 0;
 
-  $: comp = getIconComponent(pack || $activeIconPack, name);
+  $: {
+    const req = ++_req;
+    const packName = pack || $activeIconPack;
+    if (packName === 'phosphor' || packName === 'material') {
+      comp = phosphorMap[name] || Circle;
+    } else {
+      loadLucideIcon(name).then((loaded) => {
+        // Guard against stale loads when `name`/`pack` change quickly.
+        if (req === _req) comp = loaded ?? Circle;
+      });
+    }
+  }
 </script>
 
 {#if isEmoji}
@@ -50,5 +91,14 @@
     {name}
   </span>
 {:else}
-  <svelte:component this={comp} size="{size}" width="{size}" height="{size}" color={color} style="width: {size}px; height: {size}px; color: {color ? color : 'inherit'}; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;" />
+  <svelte:component
+    this={comp}
+    {size}
+    width={size}
+    height={size}
+    {color}
+    style="width: {size}px; height: {size}px; color: {color
+      ? color
+      : 'inherit'}; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;"
+  />
 {/if}

--- a/frontend/src/lib/components/StreakIcon.svelte
+++ b/frontend/src/lib/components/StreakIcon.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Circle } from 'lucide-svelte';
-  import * as LucideIcons from 'lucide-svelte';
+  import { loadLucideIcon } from '$lib/utils/lucideIcons';
 
   export let name: string = '';
   export let size: number = 18;
@@ -10,13 +10,23 @@
 
   $: isEmoji = emojiRegex.test(name);
 
-  // Convert kebab-case to PascalCase (e.g. "book-open" → "BookOpen")
-  function toPascalCase(s: string): string {
-    return s.split('-').map(p => p.charAt(0).toUpperCase() + p.slice(1)).join('');
-  }
+  // Lucide icons are loaded on demand via dynamic import so the whole icon
+  // library is no longer bundled into the main chunk (#209). A `Circle`
+  // placeholder is shown until the requested icon chunk resolves.
+  let lucideComp: any = Circle;
+  let _req = 0;
 
-  // Synchronous lookup — handles both PascalCase and kebab-case names
-  $: lucideComp = name ? ((LucideIcons as any)[name] || (LucideIcons as any)[toPascalCase(name)] || Circle) : Circle;
+  $: {
+    const req = ++_req;
+    if (!name) {
+      lucideComp = Circle;
+    } else {
+      loadLucideIcon(name).then((loaded) => {
+        // Guard against stale loads when `name` changes quickly.
+        if (req === _req) lucideComp = loaded ?? Circle;
+      });
+    }
+  }
 </script>
 
 {#if isEmoji}
@@ -31,6 +41,7 @@
     this={lucideComp}
     {size}
     {color}
-    style="width: {size}px; height: {size}px; color: {color || 'inherit'}; display: inline-flex; flex-shrink: 0;"
+    style="width: {size}px; height: {size}px; color: {color ||
+      'inherit'}; display: inline-flex; flex-shrink: 0;"
   />
 {/if}

--- a/frontend/src/lib/stores/iconPicker.ts
+++ b/frontend/src/lib/stores/iconPicker.ts
@@ -1,15 +1,9 @@
 import { writable, derived } from 'svelte/store';
-import * as L from 'lucide-svelte';
+import { ALL_LUCIDE_ICON_NAMES } from '$lib/utils/lucideIcons';
 
-// Get all icon names, filtering out duplicates where lucide-svelte exports
-// both "X" and "XIcon" for the same icon (e.g. "File" and "FileIcon")
-const _rawIcons = Object.keys(L).filter(
-  (k) => /^[A-Z]/.test(k) && k !== 'default' && k !== 'createLucideIcon'
-);
-const _iconSet = new Set(_rawIcons);
-const ALL_ICONS = _rawIcons.filter(
-  (k) => !(k.endsWith('Icon') && _iconSet.has(k.slice(0, -4)))
-);
+// Icon names come from `import.meta.glob` over lucide-svelte's icon files, so
+// no icon code is imported just to enumerate names (see #209).
+const ALL_ICONS = ALL_LUCIDE_ICON_NAMES;
 
 export function createIconPickerStore() {
   const searchTerm = writable('');
@@ -42,6 +36,6 @@ export function createIconPickerStore() {
       if (target.scrollHeight - target.scrollTop - target.clientHeight < 150) {
         this.loadMore();
       }
-    }
+    },
   };
 }

--- a/frontend/src/lib/utils/lucideIcons.ts
+++ b/frontend/src/lib/utils/lucideIcons.ts
@@ -1,0 +1,82 @@
+// Tree-shakeable access to the lucide-svelte icon set.
+//
+// Previous implementations used `import * as LucideIcons from 'lucide-svelte'`,
+// which pulls all ~1900 icons into whatever chunk the importer lives in. Since
+// `DynamicIcon` / `StreakIcon` are used across the whole app, that meant the
+// entire icon library was bundled into the main chunk (#209).
+//
+// This module uses `import.meta.glob` with `eager: false` so that:
+//   - `ALL_LUCIDE_ICON_NAMES` is available synchronously (only the file paths
+//     are enumerated, no icon code is imported).
+//   - `loadLucideIcon()` triggers a per-icon dynamic import, letting Vite split
+//     each icon into its own chunk instead of bundling them all up front.
+//
+// The glob targets the compiled `.js` icon files shipped under
+// `lucide-svelte/dist/icons/` (the package `./icons/*` export).
+
+// Path is relative to this file: src/lib/utils/ → frontend/node_modules/...
+const iconModules = import.meta.glob('../../../node_modules/lucide-svelte/dist/icons/*.js', {
+  eager: false,
+  import: 'default',
+});
+
+// kebab-case file name → PascalCase (e.g. "a-arrow-down" → "AArrowDown",
+// "file-audio-2" → "FileAudio2"). Matches the PascalCase keys that the old
+// `import * as L` namespace used to expose.
+function kebabToPascal(kebab: string): string {
+  return kebab
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+const _iconPaths = Object.keys(iconModules);
+
+// Build a map of PascalCase name → lazy loader function.
+const _loaders = new Map<string, () => Promise<any>>();
+for (const path of _iconPaths) {
+  // path looks like "../../../node_modules/lucide-svelte/dist/icons/a-arrow-down.js"
+  const file = path.split('/').pop()!.replace(/\.js$/, '');
+  _loaders.set(kebabToPascal(file), iconModules[path] as () => Promise<any>);
+}
+
+/**
+ * All available lucide icon names in PascalCase (e.g. "Search", "FileText").
+ * Used by the icon picker to render its grid without importing any icon code.
+ */
+export const ALL_LUCIDE_ICON_NAMES: string[] = Array.from(_loaders.keys()).sort();
+
+/**
+ * Resolve a loader by either a PascalCase or kebab-case icon name.
+ * Returns the loader or undefined when the name does not match any icon.
+ */
+function getLoader(name: string): (() => Promise<any>) | undefined {
+  if (!name) return undefined;
+  // Try the name as-is (PascalCase) first, then convert kebab → Pascal.
+  return _loaders.get(name) ?? _loaders.get(kebabToPascal(name));
+}
+
+/**
+ * Lazily import a lucide icon component by name.
+ *
+ * Accepts either PascalCase ("FileText") or kebab-case ("file-text"). Resolves
+ * to the icon's Svelte component, or `null` when the name is unknown so callers
+ * can fall back to a placeholder (e.g. `Circle`).
+ */
+export async function loadLucideIcon(name: string): Promise<any | null> {
+  const loader = getLoader(name);
+  if (!loader) return null;
+  try {
+    return await loader();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Synchronous check whether an icon name exists in the lucide set, without
+ * importing the icon. Useful for cheap validation before triggering a load.
+ */
+export function hasLucideIcon(name: string): boolean {
+  return getLoader(name) !== undefined;
+}


### PR DESCRIPTION
## Summary
- `DynamicIcon` and `StreakIcon` used `import * as LucideIcons from 'lucide-svelte'` to resolve icons by name at runtime. Since both are used across the whole app, the entire ~1900-icon library was pulled into the main bundle (#209). `iconPicker.ts` did the same just to enumerate icon names.
- Add `lib/utils/lucideIcons.ts`: a single `import.meta.glob` (eager: false) over `lucide-svelte/dist/icons/*.js` that exposes `ALL_LUCIDE_ICON_NAMES` synchronously (no icon code imported) and `loadLucideIcon(name)` which triggers a per-icon dynamic import so Vite splits each icon into its own chunk.
- `DynamicIcon.svelte` / `StreakIcon.svelte`: drop the namespace import, render a `Circle` placeholder and swap in the resolved icon when its chunk loads. A request counter guards against stale loads when `name`/`pack` change quickly. Phosphor/material lookup stays synchronous (bounded map).
- `iconPicker.ts`: drop `import * as L`, use `ALL_LUCIDE_ICON_NAMES`.

No `import * as ... from 'lucide-svelte'` remains in the listed components/stores, and the main bundle no longer includes the entire icon set.

### Trade-off
Icons now render asynchronously: a brief `Circle` placeholder may flash on first paint before the icon chunk resolves (cached by the browser after the first load). This affects the 27 sites that use `DynamicIcon`. Chosen over keeping the namespace import because the latter defeats tree-shaking entirely.

#### Test plan
- [x] `cd frontend && npm run check` → 0 errors, 0 warnings in the changed files (123 pre-existing warnings unchanged).
- [x] `vite build` transforms all 8543 client modules including the new `import.meta.glob` (the icon chunks are generated as separate dynamic imports). Note: `npm run build` is currently aborting on two **pre-existing** build bugs unrelated to this PR — tracked in #637 (`d3` manualChunks SSR external + esbuild target too low for Svelte 5). Those block the final bundle-size measurement, not the correctness of this change.
- [ ] Manual: visually verify icons render in streaks/goals/nav/folders after the placeholder swap (recommended before merge).

Closes #209

Generated with [Devin](https://devin.ai)