### PR TITLE
fix(frontend): unbreak vite build — d3 manualChunks SSR external + esbuild target

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,11 +3,18 @@ import { sveltekit } from '@sveltejs/kit/vite';
 
 // The browser connects to the host-mapped frontend port, which may differ from
 // the container's internal port (3000) when FRONTEND_PORT is overridden.
-const FRONTEND_PORT =
-  (typeof process !== 'undefined' && Number(process.env.FRONTEND_PORT)) || 3000;
+const FRONTEND_PORT = (typeof process !== 'undefined' && Number(process.env.FRONTEND_PORT)) || 3000;
 
 export default defineConfig({
   plugins: [sveltekit()],
+  esbuild: {
+    target: 'esnext',
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: 'esnext',
+    },
+  },
   server: {
     port: 3000,
     host: '0.0.0.0',
@@ -17,37 +24,40 @@ export default defineConfig({
       // port. Without this, Vite tries to connect the WS to the container's
       // internal address and the browser gets a connection refused error.
       clientPort: FRONTEND_PORT,
-      host: 'localhost'
-    }
+      host: 'localhost',
+    },
   },
   ssr: {
-    noExternal: ['phosphor-svelte', 'svelte-hero-icons', 'svelte-bootstrap-icons', 'svelte-radix']
+    noExternal: ['phosphor-svelte', 'svelte-hero-icons', 'svelte-bootstrap-icons', 'svelte-radix'],
   },
   build: {
+    target: 'esnext',
     rollupOptions: {
       output: {
-        manualChunks: {
+        // Function form: only group modules resolved from `node_modules`.
+        // SvelteKit externalizes some deps (e.g. d3, force-graph) for the SSR
+        // build pass, where their ids are bare specifiers without a
+        // `node_modules` segment. The object form tried to chunk those bare
+        // specifiers and aborted the build with
+        // "d3 cannot be included in manualChunks because it is resolved as an
+        // external module". Skipping non-node_modules ids avoids that.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return;
           // Visualization: d3 + force-graph (used by SkillTree, KnowledgeGraph)
-          d3: ['d3', 'force-graph'],
+          if (id.includes('/d3/') || id.includes('/force-graph/')) return 'd3';
           // Markdown rendering: marked + dompurify + highlight.js (used by
           // NoteEditor, GoalEditor, ChatInterface, WysiwygEditor)
-          markdown: ['marked', 'dompurify', 'highlight.js'],
+          if (
+            id.includes('/marked/') ||
+            id.includes('/dompurify/') ||
+            id.includes('/highlight.js/')
+          ) {
+            return 'markdown';
+          }
           // Rich text editor: TipTap + extensions (used by WysiwygEditor)
-          tiptap: [
-            '@tiptap/core',
-            '@tiptap/starter-kit',
-            '@tiptap/pm',
-            '@tiptap/extension-code-block-lowlight',
-            '@tiptap/extension-image',
-            '@tiptap/extension-link',
-            '@tiptap/extension-placeholder',
-            '@tiptap/extension-strike',
-            '@tiptap/extension-task-item',
-            '@tiptap/extension-task-list',
-            '@tiptap/extension-underline'
-          ]
-        }
-      }
-    }
-  }
+          if (id.includes('/@tiptap/')) return 'tiptap';
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
`npm run build` (`vite build`) was completely broken on `development` due to two independent pre-existing errors. Discovered while verifying #209.

### 1. `manualChunks` references an external module (SSR build pass)
The object form `d3: ['d3', 'force-graph']` tried to chunk bare specifiers that SvelteKit externalizes for the SSR build pass, aborting with:
```
"d3" cannot be included in manualChunks because it is resolved as an external module by the "external" option or plugins.
```
**Fix:** Convert `manualChunks` to the function form and only return a chunk name when the id contains `node_modules` (skipping externalized bare specifiers). The `d3`/`markdown`/`tiptap` groupings are preserved for the client build.

### 2. esbuild target too low for Svelte 5 runtime (client build pass)
Svelte 5's compiled runtime uses `for (const [k, v] of map)` destructuring with private fields, which esbuild cannot transpile down to the default `es2020`/`safari14` target:
```
ERROR: Transforming destructuring to the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides) is not supported yet
```
**Fix:** Raise `esbuild.target`, `optimizeDeps.esbuildOptions.target`, and `build.target` to `esnext`.

#### Test plan
- [x] `cd frontend && npm run build` completes successfully on a clean checkout (SSR + client + service worker, ~2min).
- [x] `d3`/`markdown`/`tiptap` manual chunks are still produced for the client build.
- [x] No esbuild "Transforming destructuring ... is not supported yet" errors.
- [x] `npm run check` unaffected (0 errors).

Closes #637

Generated with [Devin](https://devin.ai)