### PR TITLE
feat(frontend): clean up dashboard, relocate widgets to notes, UI polish

### DIFF
--- a/frontend/src/lib/components/GoalCard.svelte
+++ b/frontend/src/lib/components/GoalCard.svelte
@@ -122,12 +122,12 @@
     background: var(--surface);
     border: 2px solid var(--goal-color);
     border-radius: 12px;
-    padding: 20px;
+    padding: 14px 16px;
     transition: all 0.25s ease;
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    text-align: left;
+    gap: 8px;
+    text-align: center;
     position: relative;
     overflow: hidden;
   }
@@ -137,13 +137,14 @@
     border: none;
     padding: 0;
     cursor: pointer;
-    text-align: left;
+    text-align: center;
     color: inherit;
     font: inherit;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 8px;
     flex: 1;
+    align-items: center;
   }
 
   .goal-editor-card:hover {
@@ -168,22 +169,24 @@
 
   .card-header {
     display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    position: relative;
   }
 
   .card-header-left {
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 8px;
   }
 
   .pin-btn {
     position: absolute;
-    top: 16px;
-    right: 16px;
-    width: 28px;
-    height: 28px;
+    top: 0;
+    right: 0;
+    width: 24px;
+    height: 24px;
     border-radius: 6px;
     background: var(--surface-hover);
     border: 1px solid var(--border);
@@ -249,33 +252,36 @@
   }
 
   .card-title {
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 600;
     color: var(--text-primary);
-    line-height: 1.4;
+    line-height: 1.3;
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     line-clamp: 2;
     overflow: hidden;
+    text-align: center;
   }
 
   .card-description {
-    font-size: 12px;
+    font-size: 11px;
     color: var(--text-muted);
-    line-height: 1.5;
+    line-height: 1.4;
     display: -webkit-box;
-    -webkit-line-clamp: 2;
+    -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
-    line-clamp: 2;
+    line-clamp: 1;
     overflow: hidden;
+    text-align: center;
   }
 
   .card-meta {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 4px;
+    gap: 6px;
+    margin-top: 2px;
+    justify-content: center;
   }
 
   .meta-item {
@@ -295,16 +301,17 @@
   }
 
   .card-progress {
-    margin-top: 8px;
-    padding-top: 12px;
+    margin-top: 4px;
+    padding-top: 8px;
     border-top: 1px solid var(--border-light);
+    width: 100%;
   }
 
   .progress-info {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 8px;
+    margin-bottom: 6px;
   }
 
   .progress-text {
@@ -323,11 +330,12 @@
 
   .card-footer {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
+    gap: 8px;
     font-size: 10px;
     color: var(--text-disabled);
-    margin-top: 4px;
+    margin-top: 2px;
   }
 
   .goal-id {

--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -1104,17 +1104,20 @@
   /* ── Toolbar ── */
   .toolbar {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
     justify-content: space-between;
-    padding: 6px 20px;
+    padding: 4px 12px;
     border-bottom: 1px solid var(--border);
     background: var(--surface);
     flex-shrink: 0;
-    gap: var(--s3);
+    gap: var(--s2);
     position: relative;
     z-index: 20;
+    overflow-x: auto;
+    scrollbar-width: none;
   }
+  .toolbar::-webkit-scrollbar { display: none; }
 
   /* Icon customize modal */
   .folder-modal-backdrop {
@@ -1186,7 +1189,7 @@
   .toolbar-left {
     display: flex;
     align-items: center;
-    gap: var(--s2);
+    gap: 2px;
     flex: 1 1 auto;
     min-width: 0;
     overflow: hidden;
@@ -1195,9 +1198,9 @@
   .toolbar-right {
     display: flex;
     align-items: center;
-    gap: var(--s2);
+    gap: 2px;
     flex-shrink: 0;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     justify-content: flex-end;
   }
 
@@ -1215,31 +1218,33 @@
 
   .format-divider {
     width: 1px;
-    height: 18px;
+    height: 14px;
     background: var(--border);
-    margin: 0 4px;
+    margin: 0 2px;
     flex-shrink: 0;
   }
 
   .stat {
-    font-size: 11px;
+    font-size: 10px;
     font-family: var(--font-mono);
     color: var(--text-muted);
+    white-space: nowrap;
   }
 
   .toolbar-btn {
     display: inline-flex;
     align-items: center;
-    gap: 5px;
-    padding: 4px 10px;
+    gap: 4px;
+    padding: 3px 7px;
     border: 1px solid var(--border);
     border-radius: var(--r);
     background: transparent;
     color: var(--text-secondary);
-    font-size: 11px;
+    font-size: 10px;
     font-family: var(--font-sans);
     cursor: pointer;
     transition: all var(--t-fast);
+    white-space: nowrap;
   }
   .toolbar-btn:hover { background: var(--elevated); color: var(--text-primary); }
   .toolbar-btn.active { border-color: var(--text-secondary); color: var(--text-primary); }

--- a/frontend/src/lib/components/ScientificCalculator.svelte
+++ b/frontend/src/lib/components/ScientificCalculator.svelte
@@ -1,0 +1,237 @@
+<script lang="ts">
+  import DynamicIcon from './DynamicIcon.svelte';
+
+  let calcInput = $state('');
+  let calcResult = $state('0');
+  let lastResult = $state('');
+
+  function evaluateCalc() {
+    try {
+      if (!calcInput.trim()) {
+        calcResult = '0';
+        return;
+      }
+
+      let expr = calcInput
+        .replace(/sin\(/g, 'Math.sin(')
+        .replace(/cos\(/g, 'Math.cos(')
+        .replace(/tan\(/g, 'Math.tan(')
+        .replace(/log\(/g, 'Math.log10(')
+        .replace(/ln\(/g, 'Math.log(')
+        .replace(/√\(/g, 'Math.sqrt(')
+        .replace(/π/g, 'Math.PI')
+        .replace(/e/g, 'Math.E')
+        .replace(/\^/g, '**')
+        .replace(/(\d+)!/g, (_match: string, n: string) => {
+          let f = 1;
+          for (let i = 1; i <= +n; i++) f *= i;
+          return f + '';
+        })
+        .replace(/Ans/g, lastResult || '0')
+        .replace(/÷/g, '/')
+        .replace(/×/g, '*');
+
+      const sanitize = expr.replace(/[^0-9+\-*/(). Math[a-z0-9]!]/g, '');
+      const res = new Function('return ' + sanitize)();
+      if (typeof res === 'number') {
+        calcResult = Number(res.toFixed(8)).toString();
+      } else {
+        calcResult = res + '';
+      }
+    } catch {
+      calcResult = '...';
+    }
+  }
+
+  function addCalc(val: string) {
+    if (val === '=') {
+      evaluateCalc();
+      if (calcResult !== '...') lastResult = calcResult;
+      return;
+    }
+    if (val === 'AC') {
+      calcInput = '';
+      calcResult = '0';
+      return;
+    }
+    if (val === 'Ans') {
+      calcInput += 'Ans';
+      evaluateCalc();
+      return;
+    }
+    if (val === 'x!') {
+      calcInput += '!';
+      evaluateCalc();
+      return;
+    }
+    if (val === 'xy') {
+      calcInput += '^';
+      evaluateCalc();
+      return;
+    }
+    if (val === '√') {
+      calcInput += '√(';
+      evaluateCalc();
+      return;
+    }
+
+    if (['sin', 'cos', 'tan', 'log', 'ln'].includes(val)) {
+      calcInput += val + '(';
+    } else {
+      calcInput += val;
+    }
+    evaluateCalc();
+  }
+</script>
+
+<div class="scientific-calc">
+  <div class="calc-display">
+    <div class="calc-history"><DynamicIcon name="History" size={10} /></div>
+    <input class="calc-input" bind:value={calcInput} oninput={evaluateCalc} placeholder="0" />
+    <div class="calc-res">{calcResult}</div>
+  </div>
+  <div class="calc-grid">
+    <button class="calc-btn sm" onclick={() => {}}>Deg</button>
+    <button class="calc-btn sm" onclick={() => addCalc('x!')}>x!</button>
+    <button class="calc-btn sm" onclick={() => addCalc('(')}>(</button>
+    <button class="calc-btn sm" onclick={() => addCalc(')')}>)</button>
+    <button class="calc-btn sm" onclick={() => addCalc('%')}>%</button>
+    <button class="calc-btn sm clear" onclick={() => addCalc('AC')}>AC</button>
+    <button class="calc-btn op" onclick={() => addCalc('÷')}>÷</button>
+
+    <button class="calc-btn sm" onclick={() => addCalc('inv')}>Inv</button>
+    <button class="calc-btn sm" onclick={() => addCalc('sin')}>sin</button>
+    <button class="calc-btn sm" onclick={() => addCalc('ln')}>ln</button>
+    <button class="calc-btn num" onclick={() => addCalc('7')}>7</button>
+    <button class="calc-btn num" onclick={() => addCalc('8')}>8</button>
+    <button class="calc-btn num" onclick={() => addCalc('9')}>9</button>
+    <button class="calc-btn op" onclick={() => addCalc('×')}>×</button>
+
+    <button class="calc-btn sm" onclick={() => addCalc('π')}>π</button>
+    <button class="calc-btn sm" onclick={() => addCalc('cos')}>cos</button>
+    <button class="calc-btn sm" onclick={() => addCalc('log')}>log</button>
+    <button class="calc-btn num" onclick={() => addCalc('4')}>4</button>
+    <button class="calc-btn num" onclick={() => addCalc('5')}>5</button>
+    <button class="calc-btn num" onclick={() => addCalc('6')}>6</button>
+    <button class="calc-btn op" onclick={() => addCalc('-')}>-</button>
+
+    <button class="calc-btn sm" onclick={() => addCalc('e')}>e</button>
+    <button class="calc-btn sm" onclick={() => addCalc('tan')}>tan</button>
+    <button class="calc-btn sm" onclick={() => addCalc('√')}>√</button>
+    <button class="calc-btn num" onclick={() => addCalc('1')}>1</button>
+    <button class="calc-btn num" onclick={() => addCalc('2')}>2</button>
+    <button class="calc-btn num" onclick={() => addCalc('3')}>3</button>
+    <button class="calc-btn op" onclick={() => addCalc('+')}>+</button>
+
+    <button class="calc-btn sm" onclick={() => addCalc('Ans')}>Ans</button>
+    <button class="calc-btn sm" onclick={() => addCalc('EXP')}>EXP</button>
+    <button class="calc-btn sm" onclick={() => addCalc('xy')}>x<sup>y</sup></button>
+    <button class="calc-btn num" onclick={() => addCalc('0')}>0</button>
+    <button class="calc-btn num" onclick={() => addCalc('.')}>.</button>
+    <button class="calc-btn equals" onclick={() => addCalc('=')}>=</button>
+    <div></div>
+  </div>
+</div>
+
+<style>
+  .scientific-calc {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .calc-display {
+    position: relative;
+    background: color-mix(in srgb, var(--text-primary) 8%, var(--bg));
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    padding: 8px 10px;
+    min-height: 70px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+  }
+
+  .calc-history {
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    opacity: 0.2;
+  }
+
+  .calc-input {
+    background: transparent;
+    border: none;
+    outline: none;
+    font-family: var(--font-mono);
+    font-size: 14px;
+    text-align: right;
+    color: var(--text-primary);
+    width: 100%;
+    padding: 2px 0;
+  }
+
+  .calc-res {
+    font-family: var(--font-mono);
+    font-size: 20px;
+    font-weight: 700;
+    text-align: right;
+    color: var(--accent);
+    min-height: 22px;
+  }
+
+  .calc-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 3px;
+  }
+
+  .calc-btn {
+    width: 100%;
+    aspect-ratio: 1.2;
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    background: var(--surface);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.1s;
+    padding: 0;
+  }
+
+  .calc-btn:hover {
+    background: var(--elevated);
+    border-color: var(--text-muted);
+  }
+
+  .calc-btn:active {
+    transform: scale(0.95);
+  }
+
+  .calc-btn.sm {
+    font-size: 9px;
+  }
+  .calc-btn.num {
+    font-weight: 600;
+  }
+  .calc-btn.op {
+    color: var(--accent);
+    font-weight: 600;
+  }
+  .calc-btn.clear {
+    color: var(--error);
+    font-weight: 600;
+  }
+  .calc-btn.equals {
+    background: var(--accent);
+    color: var(--bg);
+    font-weight: 700;
+  }
+  .calc-btn.equals:hover {
+    opacity: 0.85;
+  }
+</style>

--- a/frontend/src/lib/stores/layout.ts
+++ b/frontend/src/lib/stores/layout.ts
@@ -39,8 +39,8 @@ export interface DashboardLayout {
 }
 
 const DEFAULT: DashboardLayout = {
-  left:  ['plant-carousel', 'stats-xp', 'activity-progress', 'time-widget', 'pomodoro', 'quick-capture', 'mood-tracker'],
-  right: ['recent-notes', 'github-issues'],
+  left:  ['plant-carousel', 'stats-xp', 'time-widget', 'pomodoro'],
+  right: ['github-issues'],
 };
 
 export const dashboardLayout = writable<DashboardLayout>(DEFAULT);

--- a/frontend/src/lib/stores/settings.ts
+++ b/frontend/src/lib/stores/settings.ts
@@ -217,7 +217,7 @@ export type ThemeMode = 'light' | 'dark' | 'auto';
 const THEME_MODE_KEY = 'joidy-theme-mode';
 
 function createThemeModeStore() {
-  const { subscribe, set } = writable<ThemeMode>('light');
+  const { subscribe, set } = writable<ThemeMode>('dark');
   let _initialized = false;
 
   function applyMode(mode: ThemeMode) {
@@ -236,7 +236,7 @@ function createThemeModeStore() {
     subscribe: (run: (v: ThemeMode) => void, invalidate?: () => void) => {
       if (!_initialized && browser) {
         _initialized = true;
-        const saved = (localStorage.getItem(THEME_MODE_KEY) as ThemeMode) || 'light';
+        const saved = (localStorage.getItem(THEME_MODE_KEY) as ThemeMode) || 'dark';
         set(saved);
         applyMode(saved);
       }
@@ -251,7 +251,7 @@ function createThemeModeStore() {
     init: () => {
       if (!browser) return;
       _initialized = true;
-      const saved = (localStorage.getItem(THEME_MODE_KEY) as ThemeMode) || 'light';
+      const saved = (localStorage.getItem(THEME_MODE_KEY) as ThemeMode) || 'dark';
       set(saved);
       applyMode(saved);
     },

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -70,7 +70,7 @@
     { href: '/notes', label: $t('nav.notes'), icon: 'BookOpen', status: 'ready' },
     { href: '/graph', label: $t('nav.graph'), icon: 'Network', status: 'dev' },
     { href: '/skills', label: $t('nav.skills'), icon: 'Zap', status: 'dev' },
-    { href: '/ai', label: $t('nav.ai'), icon: 'Brain', status: 'ready' },
+    { href: '/ai', label: $t('nav.ai'), icon: 'Brain', status: 'dev' },
     { href: '/goals', label: $t('nav.goals'), icon: 'Target', status: 'ready' },
     { href: '/streaks', label: $t('nav.streaks'), icon: 'Flame', status: 'ready' },
     { href: '/analytics', label: $t('nav.analytics'), icon: 'BarChart3', status: 'ready' },

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -10,10 +10,7 @@
   import CityModule     from '$lib/components/CityModule.svelte';
   import OrbitModule    from '$lib/components/OrbitModule.svelte';
   import XPBar          from '$lib/components/XPBar.svelte';
-  import NoteCard       from '$lib/components/NoteCard.svelte';
   import PomodoroWidget from '$lib/components/PomodoroWidget.svelte';
-  import QuickCaptureWidget from '$lib/components/QuickCaptureWidget.svelte';
-  import MoodWidget from '$lib/components/MoodWidget.svelte';
   import { Target } from 'lucide-svelte';
   import { startFocusMode } from '$lib/stores/focusMode';
   import TimeWidget from '$lib/components/TimeWidget.svelte';
@@ -24,7 +21,6 @@
   import { totalXP, currentStreak, lastActivity, nextStageXP, globalLevel } from '$lib/stores/gamification';
   import { openShare } from '$lib/stores/shareAchievement';
   import { Share2 } from 'lucide-svelte';
-  import ActivityProgress from '$lib/components/ActivityProgress.svelte';
   import { notes, loadNotes, notesLoadedOnce } from '$lib/stores/notes';
   import { dashboardLayout } from '$lib/stores/layout';
   import { accentColors } from '$lib/stores/settings';
@@ -178,8 +174,6 @@
 
   let githubStatusChecked = false;
   let ttiMeasured = false;
-
-  $: recentNotes = $notes.slice(0, 5);
 
   onMount(() => {
     if (typeof performance !== 'undefined') {
@@ -366,7 +360,7 @@
       {/if}
     </div>
   {:else if wid === 'activity-progress'}
-    <ActivityProgress />
+    <!-- activity-progress widget removed from dashboard per user request -->
   {:else if wid === 'time-widget'}
     <TimeWidget />
   {:else if wid === 'weather-widget'}
@@ -378,23 +372,11 @@
       {$t('home.focusMode')}
     </button>
   {:else if wid === 'quick-capture'}
-    <QuickCaptureWidget />
+    <!-- quick-capture widget moved to notes page -->
   {:else if wid === 'mood-tracker'}
-    <MoodWidget />
+    <!-- mood-tracker widget removed from dashboard per user request -->
   {:else if wid === 'recent-notes'}
-    <div class="section-header">
-      <h4 style="color: {$accentColors[0]}">{$t('home.recentNotes')}</h4>
-      <a href="/notes" class="btn btn-ghost" style="font-size:11px; padding:2px 8px;">{$t('home.seeAll')}</a>
-    </div>
-    <div class="recent-notes">
-      {#if recentNotes.length === 0}
-        <div class="empty-state"><span class="caption">{$t('home.noNotesYet')}</span></div>
-      {:else}
-        {#each recentNotes as note}
-          <NoteCard {note} showTags={false} on:select={() => goto(`/notes?id=${note.id}`)} />
-        {/each}
-      {/if}
-    </div>
+    <!-- recent-notes widget removed from dashboard per user request -->
   {:else if wid === 'github-issues'}
     <GithubWidget
       accentColor={$accentColors[1]}

--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -16,6 +16,8 @@
     }
   }
   import LazyIconPicker from '$lib/components/LazyIconPicker.svelte';
+  import QuickCaptureWidget from '$lib/components/QuickCaptureWidget.svelte';
+  import ScientificCalculator from '$lib/components/ScientificCalculator.svelte';
   import VirtualList from '$lib/components/VirtualList.svelte';
   import { notes, notesLoading, loadNotes, createNote, updateNote, deleteNote, aiSuggestions, notesLoadedOnce, selectedNoteIds, bulkMode, toggleNoteSelection, selectAllNotes, clearNoteSelection, deleteSelectedNotes, tagSelectedNotes, untagSelectedNotes } from '$lib/stores/notes';
   import { buildTree, flattenTree, extractFrontmatter, getFileIcon, type SortMode, type FlatNode } from '$lib/utils/fileTree';
@@ -33,7 +35,7 @@
   let selectedNote: Note | null = null;
   let showEditor = false;
   let editingNew = false;
-  let viewMode: 'tree' | 'list' = 'list';
+  let viewMode: 'tree' | 'list' = 'tree';
   let dailySourcePath: string | null = null;
   let dailyInitialTitle = '';
   let dailyNotesConfigured = false;
@@ -639,6 +641,15 @@
         </button>
       </div>
 
+      <div class="actions-right">
+        <button class="icon-btn" class:active={viewMode === 'tree'} title="Vista de carpetas" aria-label="Vista de carpetas" onclick={() => { viewMode = 'tree'; if (notesPrefsReady) persistNotesPrefs(); }}>
+          <FolderTree size={13} />
+        </button>
+        <button class="icon-btn" class:active={viewMode === 'list'} title="Vista de lista" aria-label="Vista de lista" onclick={() => { viewMode = 'list'; if (notesPrefsReady) persistNotesPrefs(); }}>
+          <List size={13} />
+        </button>
+      </div>
+
     </div>
 
     <div class="list-toolbar">
@@ -985,12 +996,16 @@
     {:else}
       <div class="empty-dashboard">
         <DynamicIcon name="Box" size={48} color="var(--border)" />
-        
+
         <div class="dash-search-container">
           <div class="dash-search">
             <Search size={14} color="var(--text-muted)" />
             <input type="text" placeholder={$t('notesPage.searchNotePlaceholder')} bind:value={search} />
           </div>
+        </div>
+
+        <div class="dash-quick-capture">
+          <QuickCaptureWidget />
         </div>
 
         <div class="dash-widgets">
@@ -1027,6 +1042,13 @@
               {/each}
             </div>
           </div>
+
+          <div class="dash-widget">
+            <div class="dash-widget-title" style="margin-bottom: 5px;">
+              <DynamicIcon name="Calculator" size={13}/> Calculadora
+            </div>
+            <ScientificCalculator />
+          </div>
         </div>
       </div>
     {/if}
@@ -1062,6 +1084,12 @@
   }
 
   .actions-left {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .actions-right {
     display: flex;
     align-items: center;
     gap: 2px;
@@ -1276,6 +1304,9 @@
 
   .dash-widgets {
     display: grid; grid-template-columns: 1fr 1.2fr; gap: 24px;
+    width: 100%; max-width: 850px;
+  }
+  .dash-quick-capture {
     width: 100%; max-width: 850px;
   }
   .dash-widget {

--- a/frontend/src/routes/streaks/+page.svelte
+++ b/frontend/src/routes/streaks/+page.svelte
@@ -455,8 +455,7 @@
             <!-- Activity calendar -->
             <div class="heatmap-section">
               {#if StreakHeatmap}
-                <svelte:component
-                  this={StreakHeatmap}
+                <StreakHeatmap
                   history={selected.history}
                   color={selected.color || 'var(--xp)'}
                   startDate={selected.start_date}
@@ -560,8 +559,7 @@
 {/if}
 
 {#if StreakCreateModal}
-  <svelte:component
-    this={StreakCreateModal}
+  <StreakCreateModal
     bind:open={showModal}
     editStreak={editTarget}
     on:close={() => { showModal = false; editTarget = null; }}


### PR DESCRIPTION
## Summary

### Dashboard cleanup (#632)
- Remove `activity-progress`, `mood-tracker`, `recent-notes`, and `quick-capture` widgets from the dashboard default layout and their render branches.
- Simplify the default dashboard layout to `plant-carousel`, `stats-xp`, `time-widget`, `pomodoro` (left) and `github-issues` (right).
- Remove now-unused imports (`NoteCard`, `QuickCaptureWidget`, `MoodWidget`, `ActivityProgress`) and the `recentNotes` reactive from the dashboard page.

### Notes page enhancements
- Default to tree (folder) view instead of list view.
- Add explicit tree/list toggle buttons in the list header.
- Add `QuickCaptureWidget` to the notes empty-state dashboard (relocated from the main dashboard).
- Add a new `ScientificCalculator` widget to the notes empty-state dashboard.

### UI polish
- **GoalCard**: compact, centered layout (tighter padding/gaps, centered headers/footers/meta, smaller title/description font sizes).
- **NoteEditor**: toolbar switches from wrapping to horizontal scroll with hidden scrollbar; tighter spacing and smaller font sizes for a denser toolbar.

### Other tweaks
- Default theme mode changed from `light` to `dark`.
- AI nav item status changed from `ready` to `dev` (shows "En Construcción" unless dev mode is on, matching the placeholder UI noted in AGENTS.md).
- `streaks/+page.svelte`: replace deprecated `<svelte:component this={...}>` with direct component usage (Svelte 5 — components are dynamic by default).

#### Test plan
- [x] `cd frontend && npm run check` → 0 errors, 125 warnings (all pre-existing a11y/CSS; the streaks `<svelte:component>` deprecation warnings are gone).
- [x] `cd frontend && npm run build` completes successfully (requires #640 to be merged first for the d3/esbuild build fix; verified locally with that fix cherry-picked).
- [ ] Manual: verify dashboard shows only plant-carousel, stats-xp, time-widget, pomodoro, github-issues.
- [ ] Manual: verify notes page defaults to tree view, toggle buttons work, QuickCapture + Calculator render in empty state.
- [ ] Manual: verify GoalCard compact centered layout and NoteEditor toolbar horizontal scroll.
- [ ] Manual: verify default theme is dark on first visit (no localStorage key).

> **Note:** `npm run build` is currently broken on `development` due to #637. PR #640 fixes it. This PR was verified with #640 cherry-picked locally. Merge #640 first, or merge both together.

Closes #632

Generated with [Devin](https://devin.ai)