### PR TITLE
fix(ai-service): validate configured model providers at startup

### DIFF
--- a/ai-service/config.py
+++ b/ai-service/config.py
@@ -68,9 +68,34 @@ class Settings(BaseSettings):
     def available_providers(self) -> list[str]:
         return list(self.provider_config.keys())
 
+    def _model_provider(self, model: str) -> str:
+        """Extract the provider prefix from a 'provider:model' string."""
+        if ":" in model:
+            return model.split(":", 1)[0].lower()
+        return "gemini"
+
+    @property
+    def llm_provider(self) -> str:
+        return self._model_provider(self.llm_model)
+
+    @property
+    def embedding_provider(self) -> str:
+        return self._model_provider(self.embedding_model)
+
+    @property
+    def is_llm_configured(self) -> bool:
+        """True when the configured LLM provider is actually available."""
+        return self.llm_provider in self.available_providers
+
+    @property
+    def is_embedding_configured(self) -> bool:
+        """True when the configured embedding provider is actually available."""
+        return self.embedding_provider in self.available_providers
+
     @property
     def is_ai_enabled(self) -> bool:
-        return len(self.available_providers) > 0
+        """True only when the *configured* providers are available, not just any provider (#642)."""
+        return self.is_llm_configured and self.is_embedding_configured
 
 
 settings = Settings()

--- a/ai-service/main.py
+++ b/ai-service/main.py
@@ -34,25 +34,52 @@ async def lifespan(app: FastAPI):
     logger = logging.getLogger(__name__)
     logger.info("[ai-service] Starting up")
 
-    # Startup health check: ping configured providers and log availability (#568).
-    # This does NOT block startup — it only logs the result so operators can
-    # see which provider is actually reachable.
-    if settings.is_ai_enabled:
-        try:
-            llm_client = get_llm_client()
-            llm_healthy = await llm_client.health_check()
-            logger.info(f"[ai-service] LLM provider '{llm_client.provider_name}' health: {'OK' if llm_healthy else 'UNREACHABLE'}")
-        except Exception as exc:
-            logger.warning(f"[ai-service] LLM health check failed: {exc}")
+    # Startup validation: check that the configured model providers are
+    # actually available. If not, log a clear error so operators can fix
+    # the configuration. The service still starts so /health can report
+    # the degraded state (#642).
+    available = settings.available_providers
+    llm_provider = settings.llm_provider
+    emb_provider = settings.embedding_provider
 
-        try:
-            emb_client = get_embedding_client()
-            emb_healthy = await emb_client.health_check()
-            logger.info(f"[ai-service] Embedding provider '{emb_client.provider_name}' health: {'OK' if emb_healthy else 'UNREACHABLE'}")
-        except Exception as exc:
-            logger.warning(f"[ai-service] Embedding health check failed: {exc}")
-    else:
+    if not available:
         logger.info("[ai-service] No AI providers configured — AI features disabled")
+    else:
+        if not settings.is_llm_configured:
+            logger.error(
+                f"[ai-service] LLM model '{settings.llm_model}' uses provider "
+                f"'{llm_provider}' which is NOT configured. "
+                f"Available providers: {available}. "
+                f"Set LLM_MODEL to use an available provider (e.g. 'ollama:llama3')."
+            )
+        if not settings.is_embedding_configured:
+            logger.error(
+                f"[ai-service] Embedding model '{settings.embedding_model}' uses provider "
+                f"'{emb_provider}' which is NOT configured. "
+                f"Available providers: {available}. "
+                f"Set EMBEDDING_MODEL to use an available provider (e.g. 'ollama:nomic-embed-text')."
+            )
+
+        if settings.is_ai_enabled:
+            # Ping configured providers and log availability (#568).
+            try:
+                llm_client = get_llm_client()
+                llm_healthy = await llm_client.health_check()
+                logger.info(f"[ai-service] LLM provider '{llm_client.provider_name}' health: {'OK' if llm_healthy else 'UNREACHABLE'}")
+            except Exception as exc:
+                logger.warning(f"[ai-service] LLM health check failed: {exc}")
+
+            try:
+                emb_client = get_embedding_client()
+                emb_healthy = await emb_client.health_check()
+                logger.info(f"[ai-service] Embedding provider '{emb_client.provider_name}' health: {'OK' if emb_healthy else 'UNREACHABLE'}")
+            except Exception as exc:
+                logger.warning(f"[ai-service] Embedding health check failed: {exc}")
+        else:
+            logger.warning(
+                "[ai-service] AI features disabled — configured model providers "
+                "are not available. See errors above."
+            )
 
     yield
     logger.info("[ai-service] Shutting down")


### PR DESCRIPTION
## Summary
The AI service reported AI as "enabled" whenever **any** provider was configured (e.g. Ollama via its default URL), but the default `embedding_model` and `llm_model` are hardcoded to `gemini:*`. If no `GEMINI_API_KEY` was set, every embedding and LLM request failed with HTTP 500 at runtime — a release blocker for Ollama-only deployments.

### Changes
- **`config.py`**: `is_ai_enabled` now checks whether the *configured* model providers (extracted from the `llm_model`/`embedding_model` prefix) are in `available_providers`, not just whether any provider exists. Added `llm_provider`, `embedding_provider`, `is_llm_configured`, and `is_embedding_configured` properties for granular checks.
- **`main.py` lifespan**: at startup, log a clear `ERROR` when the configured LLM or embedding provider is not available, with actionable guidance (e.g. "Set LLM_MODEL to 'ollama:llama3'"). The service still starts so `/health` can report the degraded state. Provider health pings only run when `is_ai_enabled` is True.

### Behavior after fix
A deployment with only Ollama configured (no Gemini key) will have `is_ai_enabled = False`. All AI endpoints (`/embed`, `/classify`, `/rag`, `/daily-recap`) return `{"status": "disabled"}` instead of attempting Gemini calls and failing with HTTP 500. The `/health` endpoint already reported `"degraded"` — now `ai_enabled` also accurately reports `false`.

#### Test plan
- [x] `python3 -m py_compile ai-service/config.py ai-service/main.py` — compiles clean.
- [ ] Manual: start with `OLLAMA_BASE_URL` set and no `GEMINI_API_KEY` → startup logs ERROR with actionable message, `is_ai_enabled = False`, `/embed` returns `{"status": "disabled"}`.
- [ ] Manual: start with `GEMINI_API_KEY` set → startup pings Gemini, `is_ai_enabled = True`, `/embed` works.
- [ ] Manual: set `LLM_MODEL=ollama:llama3` and `EMBEDDING_MODEL=ollama:nomic-embed-text` with Ollama running → `is_ai_enabled = True`, requests route to Ollama.

Closes #642

Generated with [Devin](https://devin.ai)