### PR TITLE
fix(api): async file I/O in upload endpoints and magic-bytes MIME validation

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,6 +6,7 @@ pydantic==2.13.4
 pydantic-settings==2.14.2
 httpx==0.28.1
 python-multipart==0.0.32
+aiofiles==24.1.0
 psycopg2-binary==2.9.12
 pgvector==0.5.0
 pyjwt==2.13.0

--- a/api/routers/upload.py
+++ b/api/routers/upload.py
@@ -4,6 +4,7 @@ import re
 import uuid
 from pathlib import Path
 
+import aiofiles
 from config import settings
 from fastapi import APIRouter, File, HTTPException, UploadFile
 
@@ -34,6 +35,16 @@ ALLOWED_FILE_TYPES = {
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 }
 
+# Text-based MIME types have no reliable magic bytes; they are validated by
+# ensuring the payload decodes as UTF-8 with no NUL bytes (binary indicator).
+_TEXT_TYPES = {
+    "text/plain",
+    "text/markdown",
+    "text/x-markdown",
+    "application/json",
+    "application/rtf",
+}
+
 
 def _ensure_upload_dir() -> Path:
     path = Path(settings.upload_dir)
@@ -51,7 +62,64 @@ def _secure_filename(name: str | None) -> str:
     return base
 
 
-def _save_upload(file: UploadFile, max_bytes: int, allowed: set[str]) -> dict:
+def _matches_magic(content: bytes, content_type: str) -> bool:
+    """Verify that ``content`` starts with the magic bytes expected for
+    ``content_type``. Returns ``True`` when the signature matches (or the type
+    is text-based and decodes cleanly), ``False`` otherwise."""
+    # Text-based types: validate as UTF-8 text without NUL bytes (binary marker).
+    if content_type in _TEXT_TYPES:
+        if b"\x00" in content:
+            return False
+        try:
+            content.decode("utf-8")
+        except UnicodeDecodeError:
+            return False
+        return True
+
+    signatures = _magic_signatures().get(content_type)
+    if not signatures:
+        # Unknown type with no known signature: cannot verify, reject.
+        return False
+
+    for sig, offset in signatures:
+        if content[offset : offset + len(sig)] == sig:
+            # WebP: RIFF....WEBP — also confirm the WEBP fourcc at offset 8.
+            if content_type == "image/webp" and content[8:12] != b"WEBP":
+                continue
+            # AVIF: ISOBMFF ftyp box — confirm brand is avif/avis at offset 8.
+            if content_type == "image/avif" and content[8:12] not in (b"avif", b"avis"):
+                continue
+            return True
+    return False
+
+
+def _magic_signatures() -> dict[str, list[tuple[bytes, int]]]:
+    """Map MIME type to a list of ``(magic_bytes, offset)`` candidates."""
+    return {
+        "image/png": [(b"\x89PNG\r\n\x1a\n", 0)],
+        "image/jpeg": [(b"\xff\xd8\xff", 0)],
+        "image/gif": [(b"GIF87a", 0), (b"GIF89a", 0)],
+        "image/webp": [(b"RIFF", 0)],
+        "image/avif": [(b"ftyp", 4)],
+        "application/pdf": [(b"%PDF", 0)],
+        # OLE2 compound document (legacy Office formats).
+        "application/msword": [(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1", 0)],
+        "application/vnd.ms-excel": [(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1", 0)],
+        "application/vnd.ms-powerpoint": [(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1", 0)],
+        # OOXML formats are ZIP containers.
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [
+            (b"PK\x03\x04", 0)
+        ],
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [
+            (b"PK\x03\x04", 0)
+        ],
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation": [
+            (b"PK\x03\x04", 0)
+        ],
+    }
+
+
+async def _save_upload(file: UploadFile, max_bytes: int, allowed: set[str]) -> dict:
     upload_path = _ensure_upload_dir()
 
     content_type = file.content_type or "application/octet-stream"
@@ -61,9 +129,15 @@ def _save_upload(file: UploadFile, max_bytes: int, allowed: set[str]) -> dict:
             detail=f"Tipo de archivo no permitido: {content_type}",
         )
 
-    content = file.file.read()
+    content = await file.read()
     if len(content) > max_bytes:
         raise HTTPException(status_code=413, detail="Archivo demasiado grande")
+
+    if not _matches_magic(content, content_type):
+        raise HTTPException(
+            status_code=400,
+            detail="El contenido del archivo no coincide con el tipo declarado",
+        )
 
     safe_name = _secure_filename(file.filename)
     ext = Path(file.filename or "").suffix
@@ -75,8 +149,8 @@ def _save_upload(file: UploadFile, max_bytes: int, allowed: set[str]) -> dict:
     unique_name = f"{uuid.uuid4().hex[:8]}_{safe_name}"
     dest = upload_path / unique_name
 
-    with open(dest, "wb") as f:
-        f.write(content)
+    async with aiofiles.open(dest, "wb") as f:
+        await f.write(content)
 
     logger.info("[upload] saved %s (%s bytes) -> %s", content_type, len(content), dest)
 
@@ -91,10 +165,10 @@ def _save_upload(file: UploadFile, max_bytes: int, allowed: set[str]) -> dict:
 @router.post("/image")
 async def upload_image(file: UploadFile = File(...)):
     """Sube una imagen y devuelve la URL pública."""
-    return _save_upload(file, settings.upload_max_image_bytes, ALLOWED_IMAGE_TYPES)
+    return await _save_upload(file, settings.upload_max_image_bytes, ALLOWED_IMAGE_TYPES)
 
 
 @router.post("/file")
 async def upload_file(file: UploadFile = File(...)):
     """Sube un archivo adjunto y devuelve la URL pública."""
-    return _save_upload(file, settings.upload_max_file_bytes, ALLOWED_FILE_TYPES)
+    return await _save_upload(file, settings.upload_max_file_bytes, ALLOWED_FILE_TYPES)

--- a/api/tests/test_routers_upload.py
+++ b/api/tests/test_routers_upload.py
@@ -6,16 +6,26 @@ from fastapi.testclient import TestClient
 
 
 def test_upload_image_succeeds(client: TestClient):
+    png_data = b"\x89PNG\r\n\x1a\n" + b"fake-png-data"
     response = client.post(
         "/upload/image",
-        files={"file": ("test.png", io.BytesIO(b"fake-png-data"), "image/png")},
+        files={"file": ("test.png", io.BytesIO(png_data), "image/png")},
     )
     assert response.status_code == 200
     data = response.json()
     assert data["url"].startswith("/uploads/")
     assert data["filename"].endswith(".png")
     assert data["mime"] == "image/png"
-    assert data["size"] == len(b"fake-png-data")
+    assert data["size"] == len(png_data)
+
+
+def test_upload_image_magic_bytes_mismatch_rejected(client: TestClient):
+    # Client claims PNG but payload is an executable — must be rejected.
+    response = client.post(
+        "/upload/image",
+        files={"file": ("evil.png", io.BytesIO(b"MZ\x90\x00binary"), "image/png")},
+    )
+    assert response.status_code == 400
 
 
 def test_upload_image_invalid_type_rejected(client: TestClient):


### PR DESCRIPTION
## Summary

Fixes two security/performance issues in the upload endpoints (`api/routers/upload.py`):

1. **Blocking file I/O inside `async def` endpoints** — `_save_upload()` read the entire file into memory with `file.file.read()` and wrote it synchronously with `open(dest, "wb")`, all inside `async def` handlers, blocking the event loop. Now uses `await file.read()` and `aiofiles.open()` for fully non-blocking I/O.
2. **MIME type validation trusted client-provided `Content-Type`** — the check only inspected `file.content_type` (set by the client) without verifying actual file content. A malicious client could upload an executable disguised as an allowed type. Added `_matches_magic()` which verifies the file's magic bytes against the declared MIME type for all allowed formats (PNG, JPEG, GIF, WebP, AVIF, PDF, Office OLE2/OOXML). Text-based types (plain, markdown, JSON, RTF) are validated by ensuring the payload decodes as UTF-8 with no NUL bytes.

Added `aiofiles==24.1.0` (pinned) to `api/requirements.txt`.

## Test plan

- [x] `python3 -m py_compile api/routers/upload.py api/tests/test_routers_upload.py` passes
- [ ] Existing upload tests pass (updated `test_upload_image_succeeds` to use real PNG magic bytes)
- [ ] New `test_upload_image_magic_bytes_mismatch_rejected` covers the disguised-executable case
- [ ] Manual: upload a valid PNG/JPEG/PDF → succeeds; upload an `.exe` renamed to `.png` with `Content-Type: image/png` → rejected with 400

Closes #646

Generated with [Devin](https://devin.ai)