### PR TITLE
fix(frontend): redirect dev routes to home when dev mode is off

### DIFF
--- a/frontend/src/routes/ai/+page.svelte
+++ b/frontend/src/routes/ai/+page.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
   import { api } from '$lib/api';
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
   import { devMode } from '$lib/stores/settings';
   import { t } from 'svelte-i18n';
+
+  // Redirect to home when dev mode is off — dev routes should not be
+  // accessible via direct URL in production (#649).
+  $effect(() => {
+    if (!$devMode) goto('/');
+  });
 
   let usage = $state<{ ai_enabled: boolean; estimated_cost_usd: number } | null>(null);
   let loadingUsage = $state(true);

--- a/frontend/src/routes/graph/+page.svelte
+++ b/frontend/src/routes/graph/+page.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
   import TopicClusters from '$lib/components/TopicClusters.svelte';
   import { graphData, graphLoading, loadGraph, selectedTag } from '$lib/stores/graph';
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
   import { devMode } from '$lib/stores/settings';
   import type { GraphNode, GraphEdge } from '$lib/api';
   import { t } from 'svelte-i18n';
+
+  // Redirect to home when dev mode is off — dev routes should not be
+  // accessible via direct URL in production (#649).
+  $effect(() => {
+    if (!$devMode) goto('/');
+  });
 
   // Lazy-load the heavy graph component (d3 + force-graph, 1300+ lines) so it
   // is split into a separate chunk and only downloaded when the user actually

--- a/frontend/src/routes/skills/+page.svelte
+++ b/frontend/src/routes/skills/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
   import { api, type Skill, type SkillTree as SkillTreeData } from '$lib/api';
   import { logger } from '$lib/utils/logger';
   import { displayTagName } from '$lib/utils/format';
@@ -8,6 +9,12 @@
   import { openShare } from '$lib/stores/shareAchievement';
   import { Search, X, Share2 } from 'lucide-svelte';
   import { t } from 'svelte-i18n';
+
+  // Redirect to home when dev mode is off — dev routes should not be
+  // accessible via direct URL in production (#649).
+  $effect(() => {
+    if (!$devMode) goto('/');
+  });
 
   // Lazy-load the heavy SkillTree (236 lines, pulls in d3) so it is split
   // into a separate chunk and only downloaded when dev mode is on (#347).


### PR DESCRIPTION
## Summary
Dev-mode routes (`/graph`, `/skills`, `/ai`) were accessible via direct URL even when Dev Mode was OFF, showing "En Construccion" placeholder pages to regular users. The sidebar already hides these routes when Dev Mode is off, but the pages themselves had no guard.

### Changes
Added a `$effect` redirect to `/` in each dev route's `<script>` block that fires when `$devMode` is false:
- `frontend/src/routes/graph/+page.svelte`
- `frontend/src/routes/skills/+page.svelte`
- `frontend/src/routes/ai/+page.svelte`

### Behavior after fix
- Direct URL navigation to `/graph`, `/skills`, or `/ai` redirects to `/` when Dev Mode is OFF
- The placeholder pages are never shown to non-dev users
- When Dev Mode is ON, routes are fully accessible as before
- The sidebar filtering (`{#if status === 'ready' || $devMode}`) was already in place — this adds the page-level guard

#### Test plan
- [x] `npm run check` — 0 errors (125 pre-existing warnings, none new)
- [ ] Manual: with Dev Mode OFF, navigate to `/graph`, `/skills`, `/ai` → redirects to `/`
- [ ] Manual: with Dev Mode ON, navigate to `/graph`, `/skills`, `/ai` → pages render normally
- [ ] Manual: sidebar hides dev routes when Dev Mode OFF (already worked)

Closes #649

Generated with [Devin](https://devin.ai)