### PR TITLE
fix(worker): add health endpoint, Docker healthcheck, and task liveness tracking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import os, signal; os.kill(1, 0)\" || exit 1"]
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -24,6 +24,6 @@ COPY --chown=app:app . .
 USER app
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=10s \
-  CMD python -c "import os, signal; os.kill(1, 0)" || exit 1
+  CMD curl -f http://localhost:8001/health || exit 1
 
 CMD ["python", "main.py"]

--- a/worker/main.py
+++ b/worker/main.py
@@ -5,17 +5,53 @@ Joidy Worker — runs background tasks concurrently:
 """
 
 import asyncio
+import contextlib
 import logging
 import signal
 
 from logging_config import setup_logging
 from metrics_server import start_metrics_server
 from tasks.joidy_daily_writer import schedule_daily_writes
+from task_status import mark_crashed, mark_stopped, record_activity, record_start
 from watchers.vault_watcher import shutdown_event, watch_vault
 
 logger = logging.getLogger(__name__)
 
 SHUTDOWN_TIMEOUT = 15.0
+HEARTBEAT_INTERVAL = 30.0
+
+
+async def _heartbeat(name: str) -> None:
+    """Refresh the last-seen-alive timestamp for ``name`` while it runs."""
+    while True:
+        record_activity(name)
+        await asyncio.sleep(HEARTBEAT_INTERVAL)
+
+
+async def _supervise(name: str, coro) -> None:
+    """Run a background task, surfacing crashes instead of swallowing them.
+
+    Replaces the old ``asyncio.gather(..., return_exceptions=True)`` pattern
+    (#644): exceptions are logged at ERROR level and recorded in the shared
+    task-status registry so ``/health`` reports ``degraded``. The exception is
+    not re-raised so a single crashed task does not take down its sibling —
+    the crash is surfaced via the health endpoint and the ERROR log instead.
+    """
+    record_start(name)
+    heartbeat = asyncio.create_task(_heartbeat(name), name=f"{name}_heartbeat")
+    try:
+        await coro
+    except asyncio.CancelledError:
+        mark_stopped(name)
+        raise
+    except Exception as exc:
+        logger.error("[worker] Task %s crashed: %s", name, exc, exc_info=True)
+        mark_crashed(name, exc)
+        return
+    finally:
+        heartbeat.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await heartbeat
 
 
 async def main():
@@ -23,11 +59,12 @@ async def main():
     logger.info("[worker] Joidy Worker starting...")
 
     # Start the Prometheus metrics server so the worker is scrapable (#406).
+    # It also serves /health, which reflects task liveness from task_status.
     start_metrics_server()
 
     tasks = [
-        asyncio.create_task(watch_vault(), name="vault_watcher"),
-        asyncio.create_task(schedule_daily_writes(), name="daily_writer"),
+        asyncio.create_task(_supervise("vault_watcher", watch_vault()), name="vault_watcher"),
+        asyncio.create_task(_supervise("daily_writer", schedule_daily_writes()), name="daily_writer"),
     ]
 
     def shutdown(sig):
@@ -47,7 +84,10 @@ async def main():
         loop.add_signal_handler(sig, lambda s=sig: shutdown(s))
 
     try:
-        await asyncio.gather(*tasks, return_exceptions=True)
+        # No return_exceptions=True: _supervise catches and records crashes so
+        # they surface via /health (degraded) and ERROR logs instead of being
+        # silently swallowed.
+        await asyncio.gather(*tasks)
     finally:
         remaining = [t for t in tasks if not t.done()]
         if remaining:

--- a/worker/metrics_server.py
+++ b/worker/metrics_server.py
@@ -6,11 +6,15 @@ in a background thread that serves the default Prometheus registry on port
 8001, so Prometheus can scrape it alongside the other services (#406).
 """
 
+import json
 import logging
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 from prometheus_client import Counter, Histogram, generate_latest
+
+import task_status
 
 logger = logging.getLogger(__name__)
 
@@ -47,10 +51,26 @@ class _MetricsHandler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(body)
         elif self.path == "/health":
-            self.send_response(200)
+            status = task_status.overall_status()
+            tasks = {
+                name: {
+                    "state": entry["state"],
+                    "last_activity": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(entry["last_activity"])
+                    ),
+                    "error": entry["error"],
+                }
+                for name, entry in task_status.snapshot().items()
+            }
+            body = json.dumps(
+                {"status": status, "service": "joidy-worker", "tasks": tasks}
+            ).encode()
+            code = 200 if status == "ok" else 503
+            self.send_response(code)
             self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
             self.end_headers()
-            self.wfile.write(b'{"status":"ok","service":"joidy-worker"}')
+            self.wfile.write(body)
         else:
             self.send_response(404)
             self.end_headers()

--- a/worker/task_status.py
+++ b/worker/task_status.py
@@ -1,0 +1,64 @@
+"""Shared task-liveness registry for the worker background tasks (#644).
+
+The worker runs two long-lived asyncio tasks (vault watcher + daily writer).
+Previously ``asyncio.gather(..., return_exceptions=True)`` silently swallowed
+crashes, so a dead task went unnoticed. This registry is updated by the task
+supervisor in ``main.py`` and read by the ``/health`` endpoint in
+``metrics_server.py`` (which runs in a separate thread), so it is guarded by a
+lock to stay thread-safe across the asyncio loop and the HTTP server thread.
+"""
+
+import threading
+import time
+
+_lock = threading.Lock()
+_tasks: dict[str, dict] = {}
+
+
+def _entry(state: str, error: str | None = None) -> dict:
+    return {"state": state, "last_activity": time.time(), "error": error}
+
+
+def record_start(name: str) -> None:
+    """Register a task as running (called when the task is about to start)."""
+    with _lock:
+        _tasks[name] = _entry("running")
+
+
+def record_activity(name: str) -> None:
+    """Refresh the last-seen-alive timestamp for a running task (heartbeat)."""
+    with _lock:
+        entry = _tasks.setdefault(name, _entry("running"))
+        entry["state"] = "running"
+        entry["last_activity"] = time.time()
+
+
+def mark_crashed(name: str, exc: BaseException) -> None:
+    """Record that a task crashed with ``exc`` (surfaced via /health)."""
+    with _lock:
+        entry = _tasks.setdefault(name, _entry("crashed"))
+        entry["state"] = "crashed"
+        entry["last_activity"] = time.time()
+        entry["error"] = repr(exc)
+
+
+def mark_stopped(name: str) -> None:
+    """Record that a task stopped cleanly (e.g. during graceful shutdown)."""
+    with _lock:
+        entry = _tasks.setdefault(name, _entry("stopped"))
+        entry["state"] = "stopped"
+        entry["last_activity"] = time.time()
+
+
+def snapshot() -> dict[str, dict]:
+    """Return a point-in-time copy of every task's liveness state."""
+    with _lock:
+        return {name: dict(entry) for name, entry in _tasks.items()}
+
+
+def overall_status() -> str:
+    """``"ok"`` when every known task is running, ``"degraded"`` otherwise."""
+    with _lock:
+        if not _tasks:
+            return "ok"
+        return "degraded" if any(e["state"] == "crashed" for e in _tasks.values()) else "ok"


### PR DESCRIPTION
## Summary

The worker had no real healthcheck and silently swallowed crashed background tasks. `asyncio.gather(..., return_exceptions=True)` meant a dead `vault_watcher` or `daily_writer` went unnoticed — the container reported healthy (the old `os.kill(1, 0)` check only verified the PID existed) while doing no work.

This adds real task-liveness tracking and surfaces it through the existing `/health` endpoint:

- **`worker/task_status.py`** (new): a thread-safe registry of task liveness (`state`, `last_activity` timestamp, `error`) shared between the asyncio supervisor and the `/health` HTTP handler (which runs in a separate daemon thread).
- **`worker/main.py`**: each task is wrapped in `_supervise()`, which logs crashes at `ERROR` level and records them via `mark_crashed()` instead of swallowing them. A `_heartbeat()` task refreshes `last_activity` every 30s while a task is alive. Removed `return_exceptions=True` so crashes surface via `/health` and ERROR logs rather than being silently dropped.
- **`worker/metrics_server.py`**: `/health` now reports per-task `state`, `last_activity`, and overall `status` (`ok` / `degraded`), returning **503** when any task has crashed.
- **`docker-compose.yml`** + **`worker/Dockerfile`**: replaced the weak `os.kill(1, 0)` healthcheck with `curl -f http://localhost:8001/health` so the container is only healthy when the background tasks are actually alive.

The health endpoint runs in the existing metrics HTTP server thread alongside the asyncio tasks — it does not block them.

## Test plan

- [x] `python3 -m py_compile worker/main.py worker/metrics_server.py worker/task_status.py`
- [x] Functional check: `record_start` → `overall_status() == "ok"`; `mark_crashed` → `"degraded"`; snapshot reports correct per-task state/error
- [ ] Docker: `docker compose up worker` — `/health` returns `200 {"status":"ok",...}` with both tasks `running`
- [ ] Docker: kill one task (e.g. raise in `daily_writer`) — `/health` returns `503 {"status":"degraded",...}` and an ERROR log is emitted with the task name
- [ ] `docker compose ps` shows worker health transitioning to `unhealthy` when a task crashes

Closes #644

Generated with [Devin](https://devin.ai)