### PR TITLE
fix(api,security): require auth in production, harden /auth/status, move login to POST body

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -62,6 +62,21 @@ class RequestTimingMiddleware(BaseHTTPMiddleware):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     setup_logging()
+
+    # Security guard (#647): refuse to boot in production without an
+    # AUTH_PASSWORD. An empty password previously caused get_current_user()
+    # to bypass auth entirely, leaving every authenticated endpoint open.
+    # Failing fast at startup is safer than silently running an open server.
+    if settings.app_env == "production" and not settings.auth_password:
+        logger.critical(
+            "AUTH_PASSWORD is not set in production. Refusing to start with "
+            "authentication disabled. Set AUTH_PASSWORD in your .env."
+        )
+        raise RuntimeError(
+            "AUTH_PASSWORD must be set when APP_ENV=production. "
+            "Authentication is disabled without it — refusing to start."
+        )
+
     init_db()
     logger.info("Database initialization complete")
 

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -10,34 +10,46 @@ from services.auth_service import create_access_token, verify_password, hash_pas
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
+class LoginRequest(BaseModel):
+    password: str = ""
+    username: str = "user"
+
+
 class LoginResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
 
 
 @router.post("/login", response_model=LoginResponse)
-def login(password: str = "", username: str = "user"):
+def login(body: LoginRequest):
     """Simple login endpoint.
 
     For a personal app, we use a simple single-user auth.
     The password should be configured via AUTH_PASSWORD in .env.
+
+    Credentials are read from the JSON request body, not query parameters,
+    to avoid credentials leaking into URLs, proxy access logs, and browser
+    history (#647).
     """
     if not settings.secret_key:
         raise HTTPException(status_code=500, detail="Server not configured for auth")
 
     expected_password = settings.auth_password or ""
-    if expected_password and not verify_password(password, expected_password):
+    if expected_password and not verify_password(body.password, expected_password):
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
     # Create token for the single user (user_id=1)
-    token = create_access_token(user_id=1, username=username)
+    token = create_access_token(user_id=1, username=body.username)
     return LoginResponse(access_token=token)
 
 
 @router.get("/status")
 def auth_status():
-    """Check if authentication is configured."""
+    """Check if authentication is configured.
+
+    Only exposes whether auth is enabled — never whether a password is set,
+    to avoid giving attackers a reconnaissance signal (#647).
+    """
     return {
         "enabled": bool(settings.secret_key),
-        "has_password": bool(settings.auth_password),
     }

--- a/api/tests/test_routers_auth.py
+++ b/api/tests/test_routers_auth.py
@@ -25,7 +25,7 @@ def test_login_with_valid_credentials(client: TestClient):
     try:
         settings.secret_key = "test-secret-key-for-auth-router"
         settings.auth_password = hash_password("s3cret")
-        response = client.post("/auth/login", params={"password": "s3cret"})
+        response = client.post("/auth/login", json={"password": "s3cret"})
         assert response.status_code == 200
         data = response.json()
         assert data["token_type"] == "bearer"
@@ -42,7 +42,7 @@ def test_login_with_invalid_credentials(client: TestClient):
     try:
         settings.secret_key = "test-secret-key-for-auth-router"
         settings.auth_password = hash_password("s3cret")
-        response = client.post("/auth/login", params={"password": "wrong"})
+        response = client.post("/auth/login", json={"password": "wrong"})
         assert response.status_code == 401
         assert response.json()["detail"] == "Invalid credentials"
     finally:
@@ -57,7 +57,7 @@ def test_login_without_password_configured_succeeds(client: TestClient):
         settings.secret_key = "test-secret-key-for-auth-router"
         settings.auth_password = ""
         # No password configured → any password is accepted.
-        response = client.post("/auth/login", params={"password": "anything"})
+        response = client.post("/auth/login", json={"password": "anything"})
         assert response.status_code == 200
         assert "access_token" in response.json()
     finally:
@@ -71,7 +71,7 @@ def test_login_without_secret_key_returns_500(client: TestClient):
     try:
         settings.secret_key = ""
         settings.auth_password = hash_password("s3cret")
-        response = client.post("/auth/login", params={"password": "s3cret"})
+        response = client.post("/auth/login", json={"password": "s3cret"})
         assert response.status_code == 500
         assert response.json()["detail"] == "Server not configured for auth"
     finally:
@@ -89,7 +89,8 @@ def test_auth_status_when_configured(client: TestClient):
         assert response.status_code == 200
         data = response.json()
         assert data["enabled"] is True
-        assert data["has_password"] is True
+        # has_password must not be exposed (#647)
+        assert "has_password" not in data
     finally:
         settings.auth_password = orig_password
         settings.secret_key = orig_key
@@ -105,7 +106,8 @@ def test_auth_status_when_not_configured(client: TestClient):
         assert response.status_code == 200
         data = response.json()
         assert data["enabled"] is False
-        assert data["has_password"] is False
+        # has_password must not be exposed (#647)
+        assert "has_password" not in data
     finally:
         settings.auth_password = orig_password
         settings.secret_key = orig_key
@@ -117,13 +119,28 @@ def test_login_returns_valid_token(client: TestClient):
     try:
         settings.secret_key = "test-secret-key-for-auth-router"
         settings.auth_password = hash_password("s3cret")
-        response = client.post("/auth/login", params={"password": "s3cret", "username": "alice"})
+        response = client.post("/auth/login", json={"password": "s3cret", "username": "alice"})
         assert response.status_code == 200
         token = response.json()["access_token"]
         # The token should be verifiable with the same secret.
         from services.auth_service import get_current_user_id
 
         assert get_current_user_id(token) == 1
+    finally:
+        settings.auth_password = orig_password
+        settings.secret_key = orig_key
+
+
+def test_login_rejects_query_param_credentials(client: TestClient):
+    """Credentials must not be accepted via query params (#647)."""
+    orig_password = settings.auth_password
+    orig_key = settings.secret_key
+    try:
+        settings.secret_key = "test-secret-key-for-auth-router"
+        settings.auth_password = hash_password("s3cret")
+        # Sending password as a query param with no body → 422 (missing body)
+        response = client.post("/auth/login?password=s3cret")
+        assert response.status_code == 422
     finally:
         settings.auth_password = orig_password
         settings.secret_key = orig_key

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,8 +49,8 @@ interactive OpenAPI docs at `/docs` for full schemas.
 
 | Method | Path | Auth | Description | Request Body | Response |
 |--------|------|------|-------------|--------------|----------|
-| POST | `/auth/login` | No | Single-user login; returns JWT | `password` (query), `username` (query) | `{access_token, token_type}` |
-| GET | `/auth/status` | No | Whether auth is configured | — | `{enabled, has_password}` |
+| POST | `/auth/login` | No | Single-user login; returns JWT | `{password, username}` (JSON body) | `{access_token, token_type}` |
+| GET | `/auth/status` | No | Whether auth is configured | — | `{enabled}` |
 
 ### 2.3 Notes (`notes.py`)
 

--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -24,8 +24,10 @@ let cachedToken: string | null = null;
 
 export async function getAuthToken(): Promise<string> {
   if (cachedToken) return cachedToken;
-  const res = await fetch(`${API_BASE}/auth/login?username=user&password=${TEST_PASSWORD}`, {
+  const res = await fetch(`${API_BASE}/auth/login`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'user', password: TEST_PASSWORD }),
   });
   if (!res.ok) {
     throw new Error(`Login failed: ${res.status} ${await res.text()}`);

--- a/frontend/e2e/helpers/cleanup.ts
+++ b/frontend/e2e/helpers/cleanup.ts
@@ -35,8 +35,10 @@ const E2E_PATTERNS = [
 ];
 
 async function getAuthToken(): Promise<string> {
-  const res = await fetch(`${API_BASE}/auth/login?username=user&password=${TEST_PASSWORD}`, {
+  const res = await fetch(`${API_BASE}/auth/login`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'user', password: TEST_PASSWORD }),
   });
   if (!res.ok) {
     console.error(`[cleanup] Login failed: ${res.status}`);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -351,11 +351,8 @@ export interface SyncConflict {
 export const api = {
   auth: {
     login: (password: string, username = 'user') =>
-      req<{ access_token: string; token_type: string }>(
-        'POST',
-        `/auth/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`
-      ),
-    status: () => req<{ enabled: boolean; has_password: boolean }>('GET', '/auth/status'),
+      req<{ access_token: string; token_type: string }>('POST', '/auth/login', { password, username }),
+    status: () => req<{ enabled: boolean }>('GET', '/auth/status'),
   },
 
   notes: {

--- a/worker/tasks/joidy_daily_writer.py
+++ b/worker/tasks/joidy_daily_writer.py
@@ -29,7 +29,7 @@ async def _get_auth_token(client: httpx.AsyncClient) -> str | None:
     try:
         resp = await client.post(
             f"{settings.api_url}/auth/login",
-            params={"password": settings.auth_password},
+            json={"password": settings.auth_password},
         )
         resp.raise_for_status()
         _auth_token = resp.json().get("access_token")

--- a/worker/watchers/vault_watcher.py
+++ b/worker/watchers/vault_watcher.py
@@ -164,7 +164,7 @@ async def get_auth_token(client: httpx.AsyncClient, *, force: bool = False) -> s
                 cid = get_correlation_id()
                 r = await client.post(
                     f"{settings.api_url}/auth/login",
-                    params={"password": settings.auth_password},
+                    json={"password": settings.auth_password},
                     headers={"X-Request-ID": cid},
                     timeout=10.0,
                 )


### PR DESCRIPTION
## Summary

Fixes three security issues in the authentication flow (#647):

1. **Auth bypass in production**: When `AUTH_PASSWORD` is empty (the default), `get_current_user()` returned user ID `1` without checking any credentials, leaving all authenticated endpoints fully open. Now the API **refuses to start** in production (`APP_ENV=production`) with an empty `AUTH_PASSWORD` — a CRITICAL log is emitted and startup fails with a clear error message. Development mode keeps the convenience bypass.

2. **`/auth/status` config exposure**: The endpoint publicly returned `has_password: true/false`, giving attackers a reconnaissance signal. Removed `has_password` from the response — only `{"enabled": true/false}` is returned, which is sufficient for the frontend to decide whether to show a login form.

3. **Login via query parameters**: `/auth/login` accepted credentials via query params (`?username=...&password=...`), which can be logged in URLs and proxy access logs. Changed the endpoint to accept credentials via a JSON request body (`LoginRequest` Pydantic model). Updated all callers: frontend API client, worker auth callers (`joidy_daily_writer`, `vault_watcher`), and Playwright e2e helpers.

## Changes

- `api/main.py`: Startup guard — fail fast in production with empty `AUTH_PASSWORD`
- `api/routers/auth.py`: `LoginRequest` body model, remove `has_password` from `/auth/status`
- `api/tests/test_routers_auth.py`: Updated tests to use JSON body, assert `has_password` absent, added test for query-param rejection
- `frontend/src/lib/api.ts`: Login sends JSON body, status type drops `has_password`
- `frontend/e2e/helpers/auth.ts`, `frontend/e2e/helpers/cleanup.ts`: E2E helpers use JSON body
- `worker/tasks/joidy_daily_writer.py`, `worker/watchers/vault_watcher.py`: Worker auth uses JSON body
- `docs/api.md`: Updated auth endpoint documentation

## Test plan

- [x] `python3 -m py_compile` on all modified Python files (api/main.py, api/routers/auth.py, api/tests/test_routers_auth.py, worker/tasks/joidy_daily_writer.py, worker/watchers/vault_watcher.py)
- [x] `npx svelte-check --tsconfig ./tsconfig.json` — 0 errors (warnings are pre-existing)
- [ ] `make test-api` — auth router tests pass with new JSON body contract
- [ ] Manual: start API with `APP_ENV=production` and empty `AUTH_PASSWORD` → startup fails with clear error
- [ ] Manual: login via frontend → credentials sent in POST body, not URL
- [ ] Manual: `GET /auth/status` → only `{"enabled": ...}` returned

Closes #647

Generated with [Devin](https://devin.ai)
