### PR TITLE
fix(frontend,a11y): replace clickable span with button in status bar

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -642,14 +642,16 @@
 
     <!-- Status bar -->
     <footer class="app-statusbar">
-      <span
-        style="color: var(--text-muted); cursor: pointer;"
+      <button
+        type="button"
+        class="statusbar-version-btn"
         title={$t('layout.testNotification')}
+        aria-label={$t('layout.testNotification')}
         onclick={() => {
           showNotification($t('layout.testNotifInfo'), 'info');
           setTimeout(() => showNotification($t('layout.testNotifSuccess'), 'success'), 600);
           setTimeout(() => showNotification($t('layout.testNotifLevel'), 'level'), 1200);
-        }}>joidy v0.1</span
+        }}>joidy v0.1</button
       >
 
       <div class="status-live" title={$t('layout.currentStatus')}>
@@ -694,6 +696,15 @@
 {/if}
 
 <style>
+  .statusbar-version-btn {
+    color: var(--text-muted);
+    cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+  }
+
   .pwa-banner {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
The status bar footer had a clickable `<span>` with an `onclick` handler for the test notification feature, but no `tabindex`, `role`, or keyboard event handler. This caused Svelte a11y warnings and prevented keyboard-only users from activating the control.

### Changes
- Replaced the `<span>` with a `<button type="button">` in `frontend/src/routes/+layout.svelte` — natively focusable, keyboard-accessible, and announced as interactive by screen readers
- Added `aria-label` matching the existing `title` attribute
- Added `.statusbar-version-btn` CSS rule to preserve the original visual appearance (muted text, pointer cursor, no button chrome)

### Result
- Eliminates the last 2 a11y warnings in `+layout.svelte` (svelte-check warnings: 125 → 123)
- No other clickable `<span>` elements found in the frontend

#### Test plan
- [x] `npm run check` — 0 errors, 123 warnings (down from 125)
- [ ] Manual: keyboard-only navigation — Tab to "joidy v0.1" button, press Enter → test notifications fire
- [ ] Manual: no a11y warnings in browser console during navigation

Closes #653

Generated with [Devin](https://devin.ai)