### PR TITLE
fix(api): stream export endpoints in batches instead of loading all notes into memory

### DIFF
--- a/api/routers/export.py
+++ b/api/routers/export.py
@@ -5,6 +5,7 @@ Export endpoints for notes.
 import io
 import zipfile
 from datetime import datetime
+from typing import Iterator
 
 from database import get_db
 from fastapi import APIRouter, Depends, HTTPException
@@ -16,6 +17,37 @@ from sqlalchemy.orm import Session, selectinload
 router = APIRouter(prefix="/export", tags=["export"])
 
 EXPORT_MAX_NOTES = 5000
+EXPORT_BATCH_SIZE = 100
+
+
+def iter_notes_batched(db: Session, limit: int = EXPORT_MAX_NOTES) -> Iterator[Note]:
+    """Yield notes in batches using SQL pagination so that not all notes (and
+    their tag relationships) are loaded into memory at once.
+
+    Each batch is expunged from the session after it has been consumed, freeing
+    the associated ORM objects before the next batch is fetched.
+    """
+    offset = 0
+    remaining = limit
+    while remaining > 0:
+        batch_size = min(EXPORT_BATCH_SIZE, remaining)
+        batch = (
+            db.query(Note)
+            .options(selectinload(Note.tags).selectinload(NoteTag.tag))
+            .order_by(Note.created_at.desc())
+            .limit(batch_size)
+            .offset(offset)
+            .all()
+        )
+        if not batch:
+            break
+        for note in batch:
+            yield note
+        # Detach the consumed batch from the session so it can be garbage
+        # collected before the next batch is loaded.
+        db.expunge_all()
+        offset += len(batch)
+        remaining -= len(batch)
 
 
 def note_to_markdown(note: Note) -> str:
@@ -75,21 +107,19 @@ def note_to_html(note: Note) -> str:
 @router.get("/notes/markdown")
 def export_notes_markdown(db: Session = Depends(get_db), user: dict = Depends(get_current_user)):
     """Export all notes as a single markdown file."""
-    notes = (
-        db.query(Note)
-        .options(selectinload(Note.tags).selectinload(NoteTag.tag))
-        .order_by(Note.created_at.desc())
-        .limit(EXPORT_MAX_NOTES)
-        .all()
-    )
-
-    if not notes:
+    if db.query(Note).count() == 0:
         raise HTTPException(status_code=404, detail="No notes to export")
 
-    content = "\n---\n\n".join(note_to_markdown(n) for n in notes)
+    def generate():
+        first = True
+        for note in iter_notes_batched(db):
+            if not first:
+                yield b"\n---\n\n"
+            first = False
+            yield note_to_markdown(note).encode("utf-8")
 
     return StreamingResponse(
-        io.BytesIO(content.encode("utf-8")),
+        generate(),
         media_type="text/markdown",
         headers={"Content-Disposition": f"attachment; filename=joidy-export-{datetime.now().date()}.md"}
     )
@@ -98,23 +128,18 @@ def export_notes_markdown(db: Session = Depends(get_db), user: dict = Depends(ge
 @router.get("/notes/html")
 def export_notes_html(db: Session = Depends(get_db), user: dict = Depends(get_current_user)):
     """Export all notes as a single HTML file."""
-    notes = (
-        db.query(Note)
-        .options(selectinload(Note.tags).selectinload(NoteTag.tag))
-        .order_by(Note.created_at.desc())
-        .limit(EXPORT_MAX_NOTES)
-        .all()
-    )
-
-    if not notes:
+    if db.query(Note).count() == 0:
         raise HTTPException(status_code=404, detail="No notes to export")
 
-    html_parts = [note_to_html(n) for n in notes]
-    full_html = f"""<!DOCTYPE html>
+    export_date = datetime.now().date()
+    export_iso = datetime.now().isoformat()
+
+    def generate():
+        yield f"""<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Joidy Export - {datetime.now().date()}</title>
+  <title>Joidy Export - {export_date}</title>
   <style>
     body {{ font-family: system-ui, sans-serif; max-width: 800px; margin: 40px auto; padding: 20px; }}
     .note {{ margin-bottom: 60px; padding-bottom: 40px; border-bottom: 1px solid #eee; }}
@@ -122,36 +147,33 @@ def export_notes_html(db: Session = Depends(get_db), user: dict = Depends(get_cu
 </head>
 <body>
   <h1>Joidy Notes Export</h1>
-  <p>Exported on {datetime.now().isoformat()}</p>
+  <p>Exported on {export_iso}</p>
   <hr>
-  {"".join(f'<div class="note">{h}</div>' for h in html_parts)}
-</body>
-</html>"""
+""".encode("utf-8")
+        for note in iter_notes_batched(db):
+            yield f'<div class="note">{note_to_html(note)}</div>'.encode("utf-8")
+        yield b"\n</body>\n</html>"
 
     return StreamingResponse(
-        io.BytesIO(full_html.encode("utf-8")),
+        generate(),
         media_type="text/html",
-        headers={"Content-Disposition": f"attachment; filename=joidy-export-{datetime.now().date()}.html"}
+        headers={"Content-Disposition": f"attachment; filename=joidy-export-{export_date}.html"}
     )
 
 
 @router.get("/notes/zip")
 def export_notes_zip(db: Session = Depends(get_db), user: dict = Depends(get_current_user)):
     """Export all notes as individual markdown files in a ZIP."""
-    notes = (
-        db.query(Note)
-        .options(selectinload(Note.tags).selectinload(NoteTag.tag))
-        .order_by(Note.created_at.desc())
-        .limit(EXPORT_MAX_NOTES)
-        .all()
-    )
-
-    if not notes:
+    if db.query(Note).count() == 0:
         raise HTTPException(status_code=404, detail="No notes to export")
 
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
-        for note in notes:
+        # Notes are fetched in batches so that not all notes (and their tag
+        # relationships) are held in memory at once. The ZIP archive itself is
+        # still assembled in a buffer, but the per-note ORM objects are released
+        # between batches.
+        for note in iter_notes_batched(db):
             safe_title = "".join(c for c in note.title if c.isalnum() or c in " -_").strip()[:50]
             if not safe_title:
                 safe_title = "unnamed"


### PR DESCRIPTION
## Summary

All three export endpoints (`/export/notes/markdown`, `/export/notes/html`, `/export/notes/zip`) previously called `db.query(Note).all()`, loading every note and its tag relationships into memory at once before building the response as a single in-memory buffer. With 1,422 notes the markdown export took ~50s and the HTML export ~73s.

This PR replaces the bulk load with a batched SQL pagination approach:

- Added `iter_notes_batched()` helper that fetches notes in batches of 100 via `LIMIT`/`OFFSET` (with `selectinload` for tags), expunging each batch from the session after consumption so ORM objects are released before the next batch loads.
- **Markdown** and **HTML** endpoints now use `StreamingResponse` with a generator that yields each note's rendered content as it is fetched, instead of building the entire response in a single in-memory buffer.
- **ZIP** endpoint fetches notes in batches. The archive is still assembled in a buffer (stdlib `zipfile` does not support true streaming and no streaming-zip library is available in `requirements.txt`), but notes are no longer all held in memory at once.
- The 404 "No notes to export" check now uses a lightweight `COUNT` query instead of loading all notes.

The response format is unchanged; only how the data is produced differs.

## Test plan

- [x] `python3 -m py_compile api/routers/export.py` passes
- [ ] `GET /export/notes/markdown` returns the same markdown content as before, streamed in batches
- [ ] `GET /export/notes/html` returns a valid HTML document with all notes, streamed in batches
- [ ] `GET /export/notes/zip` returns a valid ZIP containing one markdown file per note
- [ ] All three endpoints return 404 when there are no notes
- [ ] Memory usage stays bounded with a large note count (no longer loads all notes at once)

Closes #651

Generated with [Devin](https://devin.ai)