### PR TITLE
fix(frontend): add load-more pagination to notes list

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -356,8 +356,8 @@ export const api = {
   },
 
   notes: {
-    list: (tag?: string, limit = 1000) =>
-      req<Note[]>('GET', `/notes/?limit=${limit}${tag ? `&tag=${encodeURIComponent(tag)}` : ''}`),
+    list: (tag?: string, limit = 1000, skip = 0) =>
+      req<Note[]>('GET', `/notes/?limit=${limit}&skip=${skip}${tag ? `&tag=${encodeURIComponent(tag)}` : ''}`),
     get: (id: number) => req<Note>('GET', `/notes/${id}`),
     create: (data: {
       title: string;

--- a/frontend/src/lib/stores/notes.test.ts
+++ b/frontend/src/lib/stores/notes.test.ts
@@ -105,7 +105,7 @@ describe('loadNotes', () => {
   it('passes the tag filter to the API', async () => {
     apiMock.notes.list.mockResolvedValue([]);
     await loadNotes('work');
-    expect(apiMock.notes.list).toHaveBeenCalledWith('work');
+    expect(apiMock.notes.list).toHaveBeenCalledWith('work', 200, 0);
   });
 
   it('does not throw when the API fails', async () => {

--- a/frontend/src/lib/stores/notes.ts
+++ b/frontend/src/lib/stores/notes.ts
@@ -18,11 +18,16 @@ export const notesLoading  = writable(false);
 export const notesLoadedOnce = writable(false);
 export const selectedNoteIds = writable<Set<number>>(new Set());
 export const bulkMode = writable(false);
+export const hasMoreNotes = writable(false);
+export const loadingMore = writable(false);
 
 let notesLoaded = false;
 let lastTag: string | undefined = undefined;
 let pendingLoad = false;
 let cacheLoadDone = false;
+
+/** Page size for paginated note fetching. */
+const NOTES_PAGE_SIZE = 200;
 
 const CACHE_KEY = 'joidy_notes_cache';
 
@@ -63,10 +68,11 @@ export async function loadNotes(tag?: string, force = false): Promise<void> {
   pendingLoad = true;
   notesLoading.set(get(notes).length === 0);
   lastTag = tag;
-  
+
   try {
-    const data = await api.notes.list(tag);
+    const data = await api.notes.list(tag, NOTES_PAGE_SIZE, 0);
     notes.set(data);
+    hasMoreNotes.set(data.length >= NOTES_PAGE_SIZE);
     saveNotesCache(data);
     notesLoaded = true;
     cacheLoadDone = true;
@@ -83,6 +89,7 @@ export async function loadNotes(tag?: string, force = false): Promise<void> {
         const cached = await getAllNotes();
         if (cached.length > 0) {
           notes.set(cached);
+          hasMoreNotes.set(false);
           notesLoaded = true;
           cacheLoadDone = true;
           notesLoadedOnce.set(true);
@@ -94,6 +101,35 @@ export async function loadNotes(tag?: string, force = false): Promise<void> {
   } finally {
     notesLoading.set(false);
     pendingLoad = false;
+  }
+}
+
+/**
+ * Fetch the next page of notes (using `skip`) and append them to the existing
+ * list. Resolves the "silent cap at 1000" issue (#648) by letting users load
+ * older notes on demand.
+ */
+export async function loadMore(): Promise<void> {
+  if (get(loadingMore) || !get(hasMoreNotes)) return;
+  loadingMore.set(true);
+  try {
+    const skip = get(notes).length;
+    const data = await api.notes.list(lastTag, NOTES_PAGE_SIZE, skip);
+    if (data.length > 0) {
+      // Append, de-duplicating by id in case of overlap.
+      const existingIds = new Set(get(notes).map((n) => n.id));
+      const fresh = data.filter((n) => !existingIds.has(n.id));
+      notes.update((ns) => [...ns, ...fresh]);
+      if (browser) {
+        Promise.all(fresh.map((n) => putNote(n))).catch(() => {});
+      }
+    }
+    hasMoreNotes.set(data.length >= NOTES_PAGE_SIZE);
+  } catch (e) {
+    logger.error('[notes] Failed to load more:', e);
+    hasMoreNotes.set(false);
+  } finally {
+    loadingMore.set(false);
   }
 }
 

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -249,7 +249,8 @@
     "delete": "Delete",
     "editorLoading": "Loading editor...",
     "searchNotePlaceholder": "Search note in your vault...",
-    "configureDailyNote": "Configure daily note path"
+    "configureDailyNote": "Configure daily note path",
+    "loadMore": "Load more"
   },
   "goalDetail": {
     "loading": "Loading...",

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -249,7 +249,8 @@
     "delete": "Eliminar",
     "editorLoading": "Cargando editor...",
     "searchNotePlaceholder": "Buscar nota en tu baúl...",
-    "configureDailyNote": "Configurar ruta de nota diaria"
+    "configureDailyNote": "Configurar ruta de nota diaria",
+    "loadMore": "Cargar más"
   },
   "goalDetail": {
     "loading": "Cargando...",

--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -19,7 +19,7 @@
   import QuickCaptureWidget from '$lib/components/QuickCaptureWidget.svelte';
   import ScientificCalculator from '$lib/components/ScientificCalculator.svelte';
   import VirtualList from '$lib/components/VirtualList.svelte';
-  import { notes, notesLoading, loadNotes, createNote, updateNote, deleteNote, aiSuggestions, notesLoadedOnce, selectedNoteIds, bulkMode, toggleNoteSelection, selectAllNotes, clearNoteSelection, deleteSelectedNotes, tagSelectedNotes, untagSelectedNotes } from '$lib/stores/notes';
+  import { notes, notesLoading, loadNotes, loadMore, hasMoreNotes, loadingMore, createNote, updateNote, deleteNote, aiSuggestions, notesLoadedOnce, selectedNoteIds, bulkMode, toggleNoteSelection, selectAllNotes, clearNoteSelection, deleteSelectedNotes, tagSelectedNotes, untagSelectedNotes } from '$lib/stores/notes';
   import { buildTree, flattenTree, extractFrontmatter, getFileIcon, type SortMode, type FlatNode } from '$lib/utils/fileTree';
   import TreeContextMenu from '$lib/components/TreeContextMenu.svelte';
   import FolderPicker from '$lib/components/FolderPicker.svelte';
@@ -808,6 +808,16 @@
           {/each}
         {/if}
       {/if}
+
+      {#if !$notesLoading && $hasMoreNotes && !search}
+        <button
+          class="load-more-btn"
+          onclick={() => loadMore()}
+          disabled={$loadingMore}
+        >
+          {$loadingMore ? $t('notesPage.loading') : $t('notesPage.loadMore')}
+        </button>
+      {/if}
     </div>
   </aside>
 
@@ -1235,6 +1245,28 @@
   .empty-msg {
     padding: 32px 16px; text-align: center;
     color: var(--text-muted); font-size: 12px;
+  }
+
+  .load-more-btn {
+    display: block;
+    width: 100%;
+    padding: 10px 12px;
+    margin-top: 4px;
+    border: none;
+    border-top: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 12px;
+    cursor: pointer;
+    text-align: center;
+  }
+  .load-more-btn:hover:not(:disabled) {
+    color: var(--text);
+    background: var(--hover-bg, rgba(128, 128, 128, 0.08));
+  }
+  .load-more-btn:disabled {
+    opacity: 0.6;
+    cursor: default;
   }
 
   /* ── Tree rows ── */


### PR DESCRIPTION
## Summary

The frontend notes store called `api.notes.list()` with a hardcoded `limit=1000` and no `skip`/offset parameter. The API supports `skip` and `limit` for pagination, but the frontend never used `skip` and provided no "load more" control. Users with more than 1,000 notes silently lost access to their oldest notes.

This PR implements a paginated "load more" mechanism:

- Added a `skip` parameter to the API client's `notes.list` function (`frontend/src/lib/api.ts`).
- Reduced the initial page size from 1000 to 200 and fetch subsequent pages on demand.
- Added a `loadMore()` function to the notes store (`frontend/src/lib/stores/notes.ts`) that fetches the next page using `skip`, appends new notes to the existing list (de-duplicating by id), and tracks whether more notes are available via the `hasMoreNotes` store.
- Added a "Load more" button at the bottom of the notes list (`frontend/src/routes/notes/+page.svelte`), shown only when more notes are available and no search filter is active. Uses i18n (`notesPage.loadMore`) with English and Spanish translations.

## Test plan

- [ ] `cd frontend && npm run check` passes with 0 errors
- [ ] With fewer than 200 notes, the "Load more" button does not appear
- [ ] With more than 200 notes, the "Load more" button appears at the bottom of the list
- [ ] Clicking "Load more" appends the next page of notes without replacing existing ones
- [ ] The button is disabled and shows a loading state while fetching
- [ ] The button disappears once all notes have been loaded
- [ ] The button is hidden when a search filter is active
- [ ] Both English and Spanish locales render the button label correctly

Closes #648

Generated with [Devin](https://devin.ai)