### PR TITLE
fix(api): use timezone-aware day boundaries for streak and gamification logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,3 +107,8 @@ FRONTEND_PORT=3000
 API_PORT=8000
 AI_SERVICE_PORT=8002
 WORKER_PORT=8001
+
+# ── User Timezone ─────────────────────────────────
+# IANA zone name for day-boundary calculations (streaks, gamification, mood).
+# Defaults to UTC. Example: America/Santiago, Europe/Madrid.
+USER_TIMEZONE=UTC

--- a/api/config.py
+++ b/api/config.py
@@ -60,5 +60,10 @@ class Settings(BaseSettings):
     spotify_client_secret: str = ""
     spotify_redirect_uri: str = ""
 
+    # User timezone for day-boundary calculations (streaks, gamification, mood).
+    # IANA zone name (e.g. "America/Santiago", "Europe/Madrid"). Defaults to UTC
+    # so behaviour is unchanged when not configured. See issue #650.
+    user_timezone: str = "UTC"
+
 
 settings = Settings()

--- a/api/repositories.py
+++ b/api/repositories.py
@@ -32,6 +32,7 @@ from models.note import (
 from models.personal_streaks import PersonalStreak, StreakCheckIn
 from models.planning import PlanningAssignment
 from models.skill import Skill
+from services.timezone_utils import get_local_today
 
 ModelT = TypeVar("ModelT")
 
@@ -301,7 +302,7 @@ class StreakRecordRepository(BaseRepository[StreakRecord]):
         super().__init__(db, StreakRecord)
 
     def get_today(self) -> StreakRecord | None:
-        today = datetime.now(timezone.utc).date()
+        today = get_local_today()
         return (
             self._db.query(StreakRecord)
             .filter(StreakRecord.activity_date == today)

--- a/api/routers/ai.py
+++ b/api/routers/ai.py
@@ -8,6 +8,7 @@ from models.gamification import UserStats
 from models.note import Note, NoteTag, Tag
 from pydantic import BaseModel
 from services.auth_service import get_current_user
+from services.timezone_utils import get_local_today, to_utc_datetime
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 from datetime import datetime, date, timedelta, timezone
@@ -80,15 +81,17 @@ async def daily_recap(
     then asks the ai-service to generate a natural-language summary.
     """
     if target_date is None:
-        target_date = date.today().isoformat()
+        target_date = get_local_today().isoformat()
 
     try:
         day = datetime.strptime(target_date, "%Y-%m-%d").date()
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid date format, use YYYY-MM-DD")
 
-    start = datetime.combine(day, datetime.min.time(), tzinfo=timezone.utc)
-    end = start + timedelta(days=1)
+    # Query the DB using UTC boundaries that correspond to the user-local day,
+    # since created_at/updated_at/completed_at are stored as UTC timestamps.
+    start = to_utc_datetime(day)
+    end = to_utc_datetime(day + timedelta(days=1))
 
     # Gather the day's activity from the DB
     notes_created = db.query(Note).filter(Note.created_at >= start, Note.created_at < end).all()

--- a/api/routers/gamification.py
+++ b/api/routers/gamification.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends
 from models.gamification import StreakRecord, UserStats, XPEvent
 from services.gamification_engine import PLANT_STAGES, process_event
 from services.response_cache import clear_api_caches, register_cache_clearer, ttl_cache
+from services.timezone_utils import get_local_today
 from sqlalchemy.orm import Session
 
 router = APIRouter(prefix="/gamification", tags=["gamification"])
@@ -24,8 +25,7 @@ def _cached_stats(db: Session):
     next_stage_xp = PLANT_STAGES[stats.plant_stage + 1][0] if stats.plant_stage + 1 < len(PLANT_STAGES) else None
 
     # Heal: active today but streak still at 0 (written by old buggy engine)
-    from datetime import datetime, timezone
-    if stats.current_streak == 0 and stats.last_activity_date == datetime.now(timezone.utc).date():
+    if stats.current_streak == 0 and stats.last_activity_date == get_local_today():
         stats.current_streak = 1
         if stats.longest_streak < 1:
             stats.longest_streak = 1

--- a/api/routers/personal_streaks.py
+++ b/api/routers/personal_streaks.py
@@ -9,6 +9,7 @@ from services.personal_streak_service import (
     backfill_streak_history,
     compute_streak,
 )
+from services.timezone_utils import get_local_today
 from sqlalchemy.orm import Session, selectinload
 
 router = APIRouter(prefix="/personal-streaks", tags=["personal-streaks"])
@@ -25,7 +26,7 @@ def _backfill_streak_history(db: Session, streak: PersonalStreak):
     if not streak.start_date:
         return
 
-    today = datetime.now(timezone.utc).date()
+    today = get_local_today()
     end_date = streak.created_at.date() if streak.created_at else today
     current = streak.start_date
 
@@ -68,7 +69,7 @@ def _compute_streak(checkin_dates: list[date], frequency: str = "daily", frequen
         return 0, 0
 
     dates_set = set(checkin_dates)
-    today = datetime.now(timezone.utc).date()
+    today = get_local_today()
 
     if frequency == "every_n" and frequency_days > 1:
         # For every-N-days: streak counts how many consecutive "on-time" check-ins
@@ -128,7 +129,7 @@ def _compute_streak(checkin_dates: list[date], frequency: str = "daily", frequen
 
 
 def _streak_to_dict(streak: PersonalStreak, days_history: int = 365) -> dict:
-    today = datetime.now(timezone.utc).date()
+    today = get_local_today()
     checkin_dates = [c.check_date for c in streak.checkins]
     checkin_map = {c.check_date: c for c in streak.checkins}
     current, longest = compute_streak(checkin_dates, streak.frequency or "daily", streak.frequency_days or 1)
@@ -266,7 +267,7 @@ def global_stats(db: Session = Depends(get_db)):
         total_checkins += len(checkin_dates)
 
     # Check-in rate for active streaks in last 30 days
-    today = datetime.now(timezone.utc).date()
+    today = get_local_today()
     thirty_ago = today - timedelta(days=30)
     possible_checkins = 0
     actual_checkins = 0
@@ -332,7 +333,7 @@ def create_streak(data: StreakCreate, db: Session = Depends(get_db)):
         color=data.color,
         theme=data.theme,
         category=data.category,
-        start_date=data.start_date or datetime.now(timezone.utc).date(),
+        start_date=data.start_date or get_local_today(),
         target_date=data.target_date,
         offset=data.offset,
         frequency=data.frequency,
@@ -344,7 +345,7 @@ def create_streak(data: StreakCreate, db: Session = Depends(get_db)):
     db.refresh(streak)
 
     # Automatically backfill if start_date is in the past
-    if streak.start_date and streak.start_date < datetime.now(timezone.utc).date():
+    if streak.start_date and streak.start_date < get_local_today():
         backfill_streak_history(db, streak)
 
     return _streak_to_dict(streak)
@@ -374,7 +375,7 @@ def update_streak(streak_id: int, data: StreakUpdate, db: Session = Depends(get_
     db.refresh(streak)
 
     # If start_date was moved back, backfill again
-    if streak.start_date and streak.start_date < datetime.now(timezone.utc).date():
+    if streak.start_date and streak.start_date < get_local_today():
         backfill_streak_history(db, streak)
 
     return _streak_to_dict(streak)
@@ -398,7 +399,7 @@ def checkin(streak_id: int, data: CheckInData = None, db: Session = Depends(get_
     if not streak:
         raise HTTPException(status_code=404, detail="Streak not found")
 
-    today = data.check_date or datetime.now(timezone.utc).date()
+    today = data.check_date or get_local_today()
     existing = db.query(StreakCheckIn).filter(
         StreakCheckIn.streak_id == streak_id,
         StreakCheckIn.check_date == today,
@@ -441,7 +442,7 @@ def undo_checkin(streak_id: int, db: Session = Depends(get_db)):
     if not streak:
         raise HTTPException(status_code=404, detail="Streak not found")
 
-    today = datetime.now(timezone.utc).date()
+    today = get_local_today()
     ci = db.query(StreakCheckIn).filter(
         StreakCheckIn.streak_id == streak_id,
         StreakCheckIn.check_date == today,
@@ -468,7 +469,7 @@ def use_freeze(streak_id: int, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="No freezes available")
 
     # Check if already checked in today
-    today = datetime.now(timezone.utc).date()
+    today = get_local_today()
     already = db.query(StreakCheckIn).filter(
         StreakCheckIn.streak_id == streak_id,
         StreakCheckIn.check_date == today,
@@ -503,7 +504,7 @@ def get_history(
     if not streak:
         raise HTTPException(status_code=404, detail="Streak not found")
 
-    today = datetime.now(timezone.utc).date()
+    today = get_local_today()
     since = today - timedelta(days=days)
     checkins = (
         db.query(StreakCheckIn)

--- a/api/routers/vault.py
+++ b/api/routers/vault.py
@@ -1,10 +1,9 @@
 """Endpoints for triggering _joidy/ vault file writes."""
 
-from datetime import datetime, timezone
-
 from database import get_db
 from fastapi import APIRouter, Depends, HTTPException
 from services.joidy_vault_writer import restore_goals_from_vault, write_daily, write_objectives, write_skills
+from services.timezone_utils import get_local_today
 from sqlalchemy.orm import Session
 
 router = APIRouter(prefix="/vault", tags=["vault"])
@@ -13,7 +12,7 @@ router = APIRouter(prefix="/vault", tags=["vault"])
 @router.post("/write-daily")
 def trigger_write_daily(db: Session = Depends(get_db)):
     ok = write_daily(db)
-    return {"status": "ok" if ok else "no_vault", "file": f"_joidy/daily/{datetime.now(timezone.utc).date().isoformat()}.md"}
+    return {"status": "ok" if ok else "no_vault", "file": f"_joidy/daily/{get_local_today().isoformat()}.md"}
 
 
 @router.post("/write-objectives")

--- a/api/services/gamification_engine.py
+++ b/api/services/gamification_engine.py
@@ -18,6 +18,7 @@ from models.config import SystemConfig
 from models.gamification import StreakRecord, UserStats, XPEvent
 from repositories import ConfigRepository, StreakRecordRepository, UserStatsRepository, XPEventRepository
 from services.response_cache import clear_api_caches
+from services.timezone_utils import get_local_today
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -149,8 +150,13 @@ GRACE_PERIOD_DAYS = 1  # One missed day forgiven per week
 
 
 def _today_utc() -> date:
-    """Return today's date in UTC to avoid timezone-related streak bugs."""
-    return datetime.now(timezone.utc).date()
+    """Return today's date in the configured user timezone.
+
+    Despite the legacy name, this now respects ``settings.user_timezone`` so
+    streak day-boundaries follow the user-local calendar day instead of the
+    server UTC day. See issue #650.
+    """
+    return get_local_today()
 
 
 @dataclass

--- a/api/services/goal_service.py
+++ b/api/services/goal_service.py
@@ -11,6 +11,7 @@ from models.goal import (
 )
 from models.note import Note, NoteTag
 from repositories import GoalRepository
+from services.timezone_utils import get_local_today
 from sqlalchemy.orm import Session
 
 
@@ -216,6 +217,7 @@ def get_bulk_goal_progress(goals: list[Goal], db: Session) -> dict[int, float]:
 
 def evaluate_active_goals(db: Session):
     now = datetime.now(timezone.utc)
+    today = get_local_today()
     active_goals = GoalRepository(db).get_active()
 
     # Bulk-load progress for all active goals once to avoid N+1 queries
@@ -226,18 +228,18 @@ def evaluate_active_goals(db: Session):
         expired = False
         if goal.temporality == GoalTemporality.DAILY:
             # We assume it expires at the end of the created_at day
-            if now.date() > goal.created_at.date():
+            if today > goal.created_at.date():
                 expired = True
         elif goal.temporality == GoalTemporality.WEEKLY:
-            if (now.date() - goal.created_at.date()).days >= 7:
+            if (today - goal.created_at.date()).days >= 7:
                 expired = True
         elif goal.temporality == GoalTemporality.MONTHLY:
             # Expire after ~30 days rather than on month boundary, so a goal
             # created on the 31st doesn't expire on the 1st of the next month.
-            if (now.date() - goal.created_at.date()).days >= 30:
+            if (today - goal.created_at.date()).days >= 30:
                 expired = True
         elif goal.temporality == GoalTemporality.ANNUAL:
-            if now.year != goal.created_at.year:
+            if today.year != goal.created_at.year:
                 expired = True
 
         if expired:
@@ -337,7 +339,7 @@ def get_goal_streak(db: Session) -> dict:
         return {"current_streak": 0, "best_streak": 0}
 
     # Current streak: count backwards from today
-    today = datetime.now(timezone.utc).date()
+    today = get_local_today()
     current_streak = 0
     day = today
     while day in completion_dates:

--- a/api/services/joidy_vault_writer.py
+++ b/api/services/joidy_vault_writer.py
@@ -12,6 +12,7 @@ from models.gamification import StreakRecord, UserStats
 from models.goal import Goal
 from models.note import NoteTag, Tag
 from models.skill import Skill
+from services.timezone_utils import get_local_today
 from sqlalchemy.orm import Session
 
 JOIDY_DIR = "_joidy"
@@ -190,7 +191,7 @@ def write_daily(db: Session, target_date: date | None = None) -> bool:
     if not vault:
         return False
 
-    today = target_date or datetime.now(timezone.utc).date()
+    today = target_date or get_local_today()
     daily_dir = vault / JOIDY_DIR / "daily"
     daily_dir.mkdir(parents=True, exist_ok=True)
     filepath = daily_dir / f"{today.isoformat()}.md"

--- a/api/services/mood_service.py
+++ b/api/services/mood_service.py
@@ -3,11 +3,12 @@
 from datetime import date, datetime, timedelta, timezone
 
 from models.mood_entry import MoodEntry
+from services.timezone_utils import get_local_today
 from sqlalchemy.orm import Session
 
 
 def _today() -> date:
-    return datetime.now(timezone.utc).date()
+    return get_local_today()
 
 
 def create_or_update_mood(db: Session, user_id: int, score: int, note: str | None = None) -> MoodEntry:

--- a/api/services/personal_streak_service.py
+++ b/api/services/personal_streak_service.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta, timezone
 
 from models.personal_streaks import PersonalStreak, StreakCheckIn
 from repositories import PersonalStreakRepository, StreakCheckInRepository
+from services.timezone_utils import get_local_today
 from sqlalchemy.orm import Session
 
 
@@ -11,7 +12,7 @@ def backfill_streak_history(db: Session, streak: PersonalStreak) -> None:
     if not streak.start_date:
         return
 
-    today = datetime.now(timezone.utc).date()
+    today = get_local_today()
     end_date = streak.created_at.date() if streak.created_at else today
     current = streak.start_date
 
@@ -51,7 +52,7 @@ def compute_streak(checkin_dates: list[date], frequency: str = "daily", frequenc
         return 0, 0
 
     dates_set = set(checkin_dates)
-    today = datetime.now(timezone.utc).date()
+    today = get_local_today()
 
     if frequency == "every_n" and frequency_days > 1:
         sorted_dates = sorted(dates_set, reverse=True)

--- a/api/services/timezone_utils.py
+++ b/api/services/timezone_utils.py
@@ -1,0 +1,64 @@
+"""Timezone-aware day-boundary helpers for streak and gamification logic.
+
+The Docker container runs in UTC by default, but the user's local calendar day
+may differ. These helpers compute "today" and "now" in the configured user
+timezone (``settings.user_timezone``, an IANA zone name) so that streaks, daily
+activity, XP timestamps, and mood entries use the user-local day rather than the
+server UTC day.
+
+Timestamps stored in the DB should still be UTC; only the "what day is it for
+the user" logic should use these helpers. See issue #650.
+"""
+
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from config import settings
+
+# Cache the ZoneInfo object — constructing it on every call is wasteful and the
+# setting rarely changes at runtime.
+_tz_cache: ZoneInfo | None = None
+_tz_cache_key: str | None = None
+
+
+def get_user_tz() -> ZoneInfo:
+    """Return the configured user timezone as a ``ZoneInfo`` instance.
+
+    Falls back to UTC if the configured zone name is invalid.
+    """
+    global _tz_cache, _tz_cache_key
+    key = settings.user_timezone or "UTC"
+    if _tz_cache is None or _tz_cache_key != key:
+        try:
+            _tz_cache = ZoneInfo(key)
+        except ZoneInfoNotFoundError:
+            _tz_cache = ZoneInfo("UTC")
+        _tz_cache_key = key
+    return _tz_cache
+
+
+def get_local_now() -> datetime:
+    """Return the current moment as a timezone-aware datetime in the user tz."""
+    return datetime.now(get_user_tz())
+
+
+def get_local_today() -> date:
+    """Return today's date in the configured user timezone.
+
+    Use this instead of ``datetime.now(timezone.utc).date()`` or
+    ``date.today()`` for any day-boundary calculation (streaks, daily activity,
+    XP idempotency, mood entries, goal expiry).
+    """
+    return get_local_now().date()
+
+
+def to_utc_datetime(local_day: date) -> datetime:
+    """Convert a user-local calendar day to a UTC-aware datetime at midnight.
+
+    Useful when querying DB columns that store UTC timestamps but the query
+    boundary should be the user-local day (e.g. "notes created today").
+    The returned datetime is the start of ``local_day`` expressed in UTC.
+    """
+    # Midnight in the user tz, then convert to UTC.
+    local_midnight = datetime.combine(local_day, datetime.min.time(), tzinfo=get_user_tz())
+    return local_midnight.astimezone(timezone.utc)


### PR DESCRIPTION
## Summary

The Docker container runs in UTC by default, so streak tracking, gamification XP, mood entries, and goal expiry all used the UTC calendar day instead of the user's local day. This caused streaks to break/reset at the wrong time for users in non-UTC timezones (e.g. a user in America/Santiago could lose a streak at 20:00 local time when UTC rolled past midnight).

This PR makes day boundaries timezone-aware:

- **New `USER_TIMEZONE` setting** (`api/config.py`, IANA zone name, default `UTC`) — configurable via `.env`, documented in `.env.example`.
- **New `api/services/timezone_utils.py`** — shared helpers backed by `zoneinfo` (Python 3.9+ stdlib, **no new dependency**):
  - `get_local_today()` — today's date in the configured user timezone
  - `get_local_now()` — current moment as a timezone-aware datetime in the user tz
  - `get_user_tz()` — cached `ZoneInfo` (falls back to UTC on invalid zone)
  - `to_utc_datetime(local_day)` — converts a user-local calendar day to a UTC-aware datetime at midnight (for DB queries on UTC-stored timestamps)
- **Replaced `datetime.now(timezone.utc).date()` / `date.today()`** in all day-boundary logic:
  - `services/gamification_engine.py` (`_today_utc` → `get_local_today`)
  - `services/personal_streak_service.py` (backfill + `compute_streak`)
  - `routers/personal_streaks.py` (all 11 day-boundary call sites)
  - `routers/gamification.py` (streak heal check)
  - `services/mood_service.py` (`_today`)
  - `services/goal_service.py` (`evaluate_active_goals` expiry + `get_goal_streak`)
  - `repositories.py` (`StreakRecordRepository.get_today`)
  - `services/joidy_vault_writer.py` (`write_daily`)
  - `routers/vault.py` (daily file name)
  - `routers/ai.py` (daily recap default date + UTC query boundaries via `to_utc_datetime`)

**DB-stored timestamps remain UTC** — only the "what day is it for the user" logic changed. The AI daily recap now queries notes/goals using UTC boundaries that correspond to the user-local day.

The frontend stores a `timezone` preference in the session store but does not currently send it to streak/gamification endpoints, so a server-side config setting is the correct minimal fix. A future enhancement could pass the client timezone per-request.

## Test plan

- [x] `python3 -m py_compile` passes on all 12 modified Python files
- [ ] Set `USER_TIMEZONE=America/Santiago` and verify streaks roll over at local midnight (20:00 UTC) instead of UTC midnight
- [ ] With `USER_TIMEZONE` unset (default UTC), behaviour is unchanged
- [ ] Verify `get_user_tz()` falls back to UTC on an invalid zone name (no crash)
- [ ] Verify daily recap (`/ai/daily-recap`) returns notes for the user-local day when `USER_TIMEZONE` is set
- [ ] Verify mood entries and personal streak check-ins use the user-local day

Closes #650

Generated with [Devin](https://devin.ai)