### PR TITLE
fix(infrastructure,testing): add CI production build gate and pin Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
         working-directory: frontend
         run: npm run check
 
+      - name: Production build
+        working-directory: frontend
+        run: npm run build
+
       - name: Unit tests
         working-directory: frontend
         run: npm run test:run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Two concurrent asyncio tasks: `watch_vault()` (watches `/vault/*.md`, 2s debounc
 - Uses `pytest` for API tests (`pytest` discover under `tests/`), with `unittest` style fixtures in `conftest.py`
 - Single test: `PYTHONPATH=/app python -m unittest tests.test_file`
 - Ruff config exists in `pyproject.toml` + `.pre-commit-config.yaml`, but pre-commit is not installed by default and CI does not run ruff. Run `ruff check` / `ruff format` manually if desired.
-- CI: `compileall`, `unittest`, `npm run check`, Docker build
+- CI: `compileall`, `unittest`, `npm run check`, `npm run build`, Docker build
 
 ## Known Issues (from code audit)
 1. ~~CORS allows `*` in non-production~~ — **Fixed**: `_get_cors_origins()` in `api/main.py` respects `cors_allowed_origins` setting; dev fallback only. Same in `ai-service/main.py`.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,7 +33,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@playwright/test": "^1.62.1",
+        "@playwright/test": "1.62.1",
         "@sveltejs/adapter-node": "^5.2.9",
         "@sveltejs/kit": "^2.70.1",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
@@ -56,6 +56,9 @@
         "typescript-eslint": "^8.66.0",
         "vite": "^6.4.3",
         "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@playwright/test": "^1.62.1",
+    "@playwright/test": "1.62.1",
     "@sveltejs/adapter-node": "^5.2.9",
     "@sveltejs/kit": "^2.70.1",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",


### PR DESCRIPTION
## Summary
The CI workflow only ran `npm run check` (svelte-check/typecheck) but never ran `npm run build` (Vite production build). This meant build failures like #637 (d3 manualChunks SSR external) were not caught by CI.

### Changes
- **`.github/workflows/ci.yml`**: add a "Production build" step that runs `npm run build` after `npm run check` in the frontend-check job. This catches Vite/Rollup build failures that typecheck alone cannot detect.
- **`frontend/package.json`**: pin `@playwright/test` to `1.62.1` (was `^1.62.1` floating range) to avoid auto-upgrading to unvetted new releases.
- **`AGENTS.md`**: document that CI now runs `npm run build`.

### Notes
- The Docker Build & Smoke Test job already uses `curl -fsS` with retry and `exit 1` on failure — no `|| true` was found (may have been fixed in a prior commit).
- Playwright E2E tests and `playwright.config.ts` already exist in the repo (added in #506). The `make test-frontend` command (`npx playwright test`) works correctly.

#### Test plan
- [x] `npm run check` passes locally
- [x] `npm run build` passes locally (with the #640/#641 build fix merged)
- [ ] CI: verify the new "Production build" step passes in the frontend-check job

Closes #652

Generated with [Devin](https://devin.ai)