### PR TITLE
fix(frontend): use primary text color for clock in TimeWidget

### DIFF
--- a/frontend/src/lib/components/TimeWidget.svelte
+++ b/frontend/src/lib/components/TimeWidget.svelte
@@ -166,7 +166,7 @@
   .clock {
     font-size: 22px;
     font-weight: 300;
-    color: var(--text-secondary);
+    color: var(--text-primary);
     letter-spacing: 0.08em;
     cursor: pointer;
     transition: color var(--t-fast);


### PR DESCRIPTION
## Summary
- Change clock color from `var(--text-secondary)` (muted/light) to `var(--text-primary)` for full visibility
- The time was rendering in a washed-out color compared to other dashboard text

Closes #667

#### Test plan
- [ ] Load `http://localhost:3000` — verify clock text is fully visible (same color as primary text)
- [ ] Verify hover state still turns XP color
- [ ] Verify both light and dark themes

Generated with [Devin](https://devin.ai)