### PR TITLE
feat(frontend): move Focus Mode trigger to global status bar

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -51,7 +51,7 @@
   import OfflineIndicator from '$lib/components/OfflineIndicator.svelte';
   import { initOfflineSync } from '$lib/stores/offlineSync';
   import ShareAchievementModal from '$lib/components/ShareAchievementModal.svelte';
-  import { initFocusModeConfig, queueNotificationIfActive } from '$lib/stores/focusMode';
+  import { initFocusModeConfig, queueNotificationIfActive, startFocusMode } from '$lib/stores/focusMode';
   import {
     initUsageTracking,
     trackPageView,
@@ -682,6 +682,16 @@
         >
         <span class="p-dot" class:beat={$running}></span>
       </div>
+
+      <!-- Focus Mode trigger -->
+      <button
+        class="mini-focus-btn"
+        onclick={() => startFocusMode()}
+        aria-label={$t('home.startFocusMode')}
+        title={$t('home.focusMode')}
+      >
+        <DynamicIcon name="Target" size={14} />
+      </button>
     </footer>
   </div>
 
@@ -780,6 +790,25 @@
   }
   .p-timer {
     font-size: 11px;
+  }
+
+  .mini-focus-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 6px;
+    padding: 4px 8px;
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    background: var(--elevated);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all var(--t-normal);
+  }
+  .mini-focus-btn:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 5%, transparent);
   }
 
   .status-live {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -11,8 +11,6 @@
   import OrbitModule    from '$lib/components/OrbitModule.svelte';
   import XPBar          from '$lib/components/XPBar.svelte';
   import PomodoroWidget from '$lib/components/PomodoroWidget.svelte';
-  import { Target } from 'lucide-svelte';
-  import { startFocusMode } from '$lib/stores/focusMode';
   import TimeWidget from '$lib/components/TimeWidget.svelte';
   import WeatherWidget from '$lib/components/WeatherWidget.svelte';
   import Widget         from '$lib/components/Widget.svelte';
@@ -367,10 +365,6 @@
     <WeatherWidget />
   {:else if wid === 'pomodoro'}
     <PomodoroWidget />
-    <button class="focus-mode-btn" onclick={() => startFocusMode()} aria-label={$t('home.startFocusMode')}>
-      <Target size={16} />
-      {$t('home.focusMode')}
-    </button>
   {:else if wid === 'quick-capture'}
     <!-- quick-capture widget moved to notes page -->
   {:else if wid === 'mood-tracker'}
@@ -662,24 +656,4 @@
       font-size: 9px;
     }
   }
-
-.focus-mode-btn {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  margin-top: 8px;
-  padding: 8px 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-md, 8px);
-  background: var(--surface);
-  color: var(--text-primary);
-  font-size: 13px;
-  cursor: pointer;
-  transition: background 0.2s, border-color 0.2s;
-}
-.focus-mode-btn:hover {
-  background: var(--elevated);
-  border-color: var(--accent);
-}
 </style>


### PR DESCRIPTION
## Summary
- Add Focus Mode trigger button to the `app-statusbar` footer in `+layout.svelte`, next to the Pomodoro mini-timer
- Remove the Focus Mode button from the home dashboard widget (`+page.svelte`)
- Focus Mode is now accessible from any page via the global status bar

Closes #668

#### Test plan
- [ ] Navigate to any page (home, notes, goals) — verify the Focus Mode button (Target icon) is visible in the bottom status bar
- [ ] Click the button — verify a focus session starts
- [ ] Verify the button is styled consistently with the Pomodoro mini-timer
- [ ] Verify the old Focus Mode button no longer appears on the home dashboard

Generated with [Devin](https://devin.ai)