### PR TITLE
fix(frontend): persist pinned goals in localStorage

### DIFF
--- a/frontend/src/lib/utils/userSettings.ts
+++ b/frontend/src/lib/utils/userSettings.ts
@@ -21,6 +21,9 @@ export interface UserSettings {
   streaksUi?: {
     panelWidth?: number;
   };
+  goalsUi?: {
+    pinnedGoalIds?: number[];
+  };
 }
 
 const KEY = 'joidy-user-settings-v1';
@@ -75,6 +78,7 @@ export function patchUserSettings(patch: Partial<UserSettings>): void {
     pomodoro: { ...current.pomodoro, ...patch.pomodoro },
     notesUi: { ...current.notesUi, ...patch.notesUi },
     streaksUi: { ...current.streaksUi, ...patch.streaksUi },
+    goalsUi: { ...current.goalsUi, ...patch.goalsUi },
   };
   localStorage.setItem(KEY, JSON.stringify(next));
 }

--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -9,7 +9,7 @@
   import { use24HourClock } from '$lib/stores/settings';
   import { getLocale } from '$lib/stores/locale';
   import { applyGamificationResult, showXPGain } from '$lib/stores/gamification';
-  import { getCachedData, setCachedData } from '$lib/utils/userSettings';
+  import { getCachedData, setCachedData, loadUserSettings, patchUserSettings } from '$lib/utils/userSettings';
   import { logger } from '$lib/utils/logger';
   import { GOAL_COLOR_PRESETS, DEFAULT_GOAL_COLOR, TEMPORALITY_COLORS } from '$lib/utils/goalColors';
   import StreakIcon from '$lib/components/StreakIcon.svelte';
@@ -49,6 +49,7 @@
       newPinned.add(goalId);
     }
     pinnedGoals = newPinned;
+    patchUserSettings({ goalsUi: { pinnedGoalIds: [...newPinned] } });
   }
 
   const EMOJIS = Array.from(new Set([
@@ -185,6 +186,16 @@
     const cachedTags = getCachedData<TagType[]>('tags');
     if (cachedGoals) goals = cachedGoals;
     if (cachedTags) tags = cachedTags;
+
+    // Restore pinned goals from localStorage
+    try {
+      const saved = loadUserSettings().goalsUi;
+      if (saved?.pinnedGoalIds && Array.isArray(saved.pinnedGoalIds)) {
+        pinnedGoals = new Set(saved.pinnedGoalIds);
+      }
+    } catch {
+      // ignore storage errors
+    }
 
     try {
       // Load only essential data immediately (goals + tags)


### PR DESCRIPTION
## Summary
- Add `goalsUi.pinnedGoalIds` field to `UserSettings` interface
- Load pinned goal IDs from `localStorage` on mount in the goals page
- Save pinned goal IDs to `localStorage` on every `togglePinned` call
- Pinned goals now survive page reloads and navigation

Closes #670

#### Test plan
- [ ] Open `/goals`, pin one or more goals — they move to the top
- [ ] Reload the page (F5) — pinned goals remain pinned and at the top
- [ ] Navigate to another page and back to `/goals` — pins are preserved
- [ ] Unpin a goal, reload — it returns to its normal position
- [ ] Verify no console errors from localStorage access

Generated with [Devin](https://devin.ai)