### PR TITLE
fix(frontend): display real app version in status bar from package.json

### DIFF
--- a/frontend/src/app.d.ts
+++ b/frontend/src/app.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  const __APP_VERSION__: string;
+}
+
+export {};

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -651,7 +651,7 @@
           showNotification($t('layout.testNotifInfo'), 'info');
           setTimeout(() => showNotification($t('layout.testNotifSuccess'), 'success'), 600);
           setTimeout(() => showNotification($t('layout.testNotifLevel'), 'level'), 1200);
-        }}>joidy v0.1</button
+        }}>joidy v{__APP_VERSION__}</button
       >
 
       <div class="status-live" title={$t('layout.currentStatus')}>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import { sveltekit } from '@sveltejs/kit/vite';
+import pkg from './package.json';
 
 // The browser connects to the host-mapped frontend port, which may differ from
 // the container's internal port (3000) when FRONTEND_PORT is overridden.
@@ -7,6 +8,9 @@ const FRONTEND_PORT = (typeof process !== 'undefined' && Number(process.env.FRON
 
 export default defineConfig({
   plugins: [sveltekit()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   esbuild: {
     target: 'esnext',
   },


### PR DESCRIPTION
## Summary
- Add `__APP_VERSION__` Vite define constant injected from `package.json` version field
- Add `frontend/src/app.d.ts` with global type declaration for `__APP_VERSION__`
- Replace hardcoded `joidy v0.1` with dynamic `joidy v{__APP_VERSION__}` in status bar

Closes #675

#### Test plan
- [ ] Open frontend — status bar shows `joidy v0.1.0` (matching package.json)
- [ ] Bump version in `package.json` to `0.2.0` — status bar updates after rebuild
- [ ] No hardcoded version strings remain in component files

Generated with [Devin](https://devin.ai)