### PR TITLE
fix(frontend): widen settings panel from 340px to 480px

### DIFF
--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -950,7 +950,8 @@
   }
 
   .panel {
-    width: 340px;
+    width: 480px;
+    max-width: 100%;
     height: 100%;
     background: var(--surface);
     border-left: 1px solid var(--border);
@@ -1386,5 +1387,11 @@
     opacity: 0;
     width: 0;
     height: 0;
+  }
+
+  @media (max-width: 520px) {
+    .panel {
+      width: 100%;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- Increase settings panel width from `340px` to `480px` for better use of horizontal space
- Add `max-width: 100%` to prevent overflow on narrow screens
- Add `@media (max-width: 520px)` breakpoint so panel goes full-width on mobile

Closes #676

#### Test plan
- [ ] Open settings on desktop — panel is visibly wider, less vertical scrolling
- [ ] Open settings on mobile/narrow window — panel fills width without overflow
- [ ] No horizontal scrolling required within the panel

Generated with [Devin](https://devin.ai)