### PR TITLE
fix(frontend,ux): improve streak preview card spacing and layout

### DIFF
--- a/frontend/src/lib/components/StreakCreateModal.svelte
+++ b/frontend/src/lib/components/StreakCreateModal.svelte
@@ -368,10 +368,10 @@
 
   /* Preview card */
   .preview-card {
-    display: flex; align-items: center; gap: 10px;
-    padding: 10px 12px;
+    display: flex; align-items: center; gap: 16px;
+    padding: 18px 20px;
     border: 1px solid var(--border);
-    border-radius: 8px;
+    border-radius: 10px;
     background: var(--surface);
     position: relative;
     overflow: hidden;
@@ -410,22 +410,26 @@
 
   .preview-icon {
     flex-shrink: 0;
-    width: 28px;
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     text-align: center;
-    font-size: 20px;
+    font-size: 22px;
   }
 
-  .preview-emoji { font-size: 20px; }
+  .preview-emoji { font-size: 22px; }
   .preview-info {
     flex: 1;
     min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 1px;
+    gap: 3px;
   }
 
   .preview-name {
-    font-size: 13px;
+    font-size: 14px;
     font-weight: 500;
     color: var(--text-primary);
     white-space: nowrap;
@@ -434,8 +438,8 @@
   }
 
   .preview-meta {
-    font-size: 9px;
-    color: var(--text-disabled);
+    font-size: 10px;
+    color: var(--text-muted);
   }
 
   /* Fields */


### PR DESCRIPTION
## Summary
- Increase preview card padding (10px 12px → 18px 20px) and gap (10px → 16px)
- Enlarge icon container (28px → 36px with centered flex layout)
- Bump font sizes: name 13px → 14px, meta 9px → 10px
- Use `--text-muted` instead of `--text-disabled` for frequency label
- Increase info column gap (1px → 3px) for better visual separation

Closes #685

#### Test plan
- [ ] Open Streaks page → click "New Streak" — preview card has comfortable spacing
- [ ] Edit an existing streak — preview card looks like a real streak card preview
- [ ] Icon, name, and frequency label are clearly separated
- [ ] Modal layout overall feels less cramped

Generated with [Devin](https://devin.ai)