### PR TITLE
fix(frontend,ux): eliminate double vertical scrollbar on notes page

### DIFF
--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -1315,17 +1315,16 @@
 
   .editor-panel {
     display: flex; flex-direction: column;
-    height: 100%; overflow: hidden;
+    height: 100%; overflow-y: auto;
     background: var(--bg); min-width: 0;
   }
-  
+
   /* ── Empty Dashboard ── */
   .empty-dashboard {
     display: flex; flex-direction: column;
     align-items: center; justify-content: start;
-    height: 100%; gap: 30px; padding: 60px 40px;
+    min-height: 100%; gap: 30px; padding: 60px 40px;
     background: var(--bg); color: var(--text-primary);
-    overflow-y: auto;
   }
   .dash-search-container {
     width: 100%; max-width: 850px;


### PR DESCRIPTION
## Summary
- Move `overflow-y` from `.empty-dashboard` to its parent `.editor-panel`
- Change `.empty-dashboard` from `height:100% + overflow-y:auto` to `min-height:100%` with no overflow
- Single scroll container eliminates the double scrollbar

Closes #690

#### Test plan
- [ ] Open notes page with no note selected (empty dashboard) — only one scrollbar
- [ ] Open notes page with a note selected — only one scrollbar
- [ ] Content scrolls smoothly without nested scroll conflicts
- [ ] Works on both desktop and mobile

Generated with [Devin](https://devin.ai)