### PR TITLE
fix(frontend,ux): replace inline SVG bulk toggle with Lucide CheckSquare icon

### DIFF
--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy, tick } from 'svelte';
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
-  import { Search, Plus, X, List, FolderTree, ChevronRight, FileEdit, FolderPlus, ChevronsUpDown, ArrowUpDown, Settings } from 'lucide-svelte';
+  import { Search, Plus, X, List, FolderTree, ChevronRight, FileEdit, FolderPlus, ChevronsUpDown, ArrowUpDown, Settings, CheckSquare } from 'lucide-svelte';
   import DynamicIcon from '$lib/components/DynamicIcon.svelte';
   import NoteCard from '$lib/components/NoteCard.svelte';
 
@@ -671,7 +671,7 @@
         {/if}
       </div>
       <button class="toolbar-btn bulk-toggle" class:active={$bulkMode} aria-label={$t('notesPage.bulkMode')} onclick={() => { bulkMode.set(!$bulkMode); clearNoteSelection(); }}>
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/></svg>
+        <CheckSquare size={14} />
       </button>
     </div>
 


### PR DESCRIPTION
## Summary
- Replace the inline SVG `<rect>` in the bulk toggle button with the Lucide `CheckSquare` icon
- The inline SVG appeared as a meaningless placeholder; the new icon clearly communicates "bulk select"

Closes #691

#### Test plan
- [ ] Open notes page — bulk toggle button shows a check-square icon
- [ ] Click bulk toggle — enters bulk mode, icon is clearly visible
- [ ] All other toolbar buttons render correctly

Generated with [Devin](https://devin.ai)