### PR TITLE
fix(frontend): reload GitHub data when type filter changes

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -161,6 +161,7 @@
 
   function setGhType(t: string) {
     ghType = t;
+    loadGitHubData(ghFilter);
   }
 
   $: isWilted = (() => {


### PR DESCRIPTION
## Summary
- `setGhType()` now calls `loadGitHubData(ghFilter)` after updating `ghType`
- Previously only the state was updated without reloading data, making the All/Issues/PRs buttons appear non-functional

Closes #692

#### Test plan
- [ ] Dashboard GitHub widget: click "Issues" — shows only issues
- [ ] Dashboard GitHub widget: click "PRs" — shows only PRs
- [ ] Dashboard GitHub widget: click "All" — shows both
- [ ] Filter buttons (assigned/created) still work correctly

Generated with [Devin](https://devin.ai)