### PR TITLE
fix(frontend): style editor text immediately via rAF instead of 300ms debounce

### DIFF
--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -215,7 +215,10 @@
     return val;
   })());
 
-  // Debounced content for expensive operations (markdown render + syntax highlight)
+  // Debounced content for the expensive full markdown render (preview mode:
+  // marked + DOMPurify + highlight.js). The editor syntax highlight uses a
+  // faster rAF-based update (see editorHighlightedHtml) so typed text is styled
+  // immediately instead of lagging 300ms (#703).
   let debouncedContent = $state(visibleEditorContent);
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -726,7 +729,29 @@
     return html;
   }
 
-  let editorHighlightedHtml = $derived(highlightMarkdown(debouncedContent));
+  // Editor syntax highlight: update on the next animation frame instead of the
+  // 300ms debounce. rAF coalesces multiple keystrokes into a single ~16ms
+  // render, so typed characters are styled immediately without re-running the
+  // regex highlighter more than once per frame (#703).
+  let editorHighlightedHtml = $state(highlightMarkdown(visibleEditorContent));
+  let highlightRaf: ReturnType<typeof requestAnimationFrame> | null = null;
+
+  $effect(() => {
+    const current = visibleEditorContent;
+    if (typeof requestAnimationFrame === 'function') {
+      if (highlightRaf !== null) cancelAnimationFrame(highlightRaf);
+      highlightRaf = requestAnimationFrame(() => {
+        editorHighlightedHtml = highlightMarkdown(current);
+        highlightRaf = null;
+      });
+    } else {
+      editorHighlightedHtml = highlightMarkdown(current);
+    }
+  });
+
+  onDestroy(() => {
+    if (highlightRaf !== null) cancelAnimationFrame(highlightRaf);
+  });
 </script>
 
 <svelte:window onkeydown={onKeydown} />


### PR DESCRIPTION
## Summary
- The note editor's syntax-highlight backdrop was derived from `debouncedContent` (300ms debounce), so typed characters stayed unstyled/invisible until the user paused typing (e.g. on space/enter) — #703.
- The expensive full markdown render (`renderedHtml`, used only in preview mode: marked + DOMPurify + highlight.js) stays debounced.
- The editor highlight now updates on the next animation frame (~16ms, coalesces keystrokes per frame), so text is styled immediately without re-running the regex highlighter more than once per frame.

## Acceptance criteria (#703)
- [x] Text is visible in the correct color immediately as the user types each character
- [x] No delay between typing and proper text styling
- [x] Works in both light and dark themes (no theme-specific code touched)
- [x] No performance regression — rAF coalesces keystrokes into one render per frame; the expensive `renderedHtml` remains debounced

#### Test plan
- [ ] Open a note in the markdown editor and type continuously — characters should be syntax-highlighted immediately, not after a pause
- [ ] Verify in both light and dark themes
- [ ] Open a large note and type — confirm no jank (rAF batches renders)
- [ ] `npm run check` passes (0 errors)
- [ ] Preview mode still renders correctly (debounced path unchanged)

Closes #703

Generated with [Devin](https://devin.ai)