### PR TITLE
feat(frontend): show current time prominently at the top of focus mode

### DIFF
--- a/frontend/src/lib/components/FocusMode.svelte
+++ b/frontend/src/lib/components/FocusMode.svelte
@@ -10,7 +10,25 @@
     toggleTimer,
   } from '$lib/stores/pomodoro';
   import { notes } from '$lib/stores/notes';
+  import { use24HourClock } from '$lib/stores/settings';
+  import { getTimezone, formatClock } from '$lib/utils/clock';
   import { t } from 'svelte-i18n';
+
+  // ── Wall clock (#706) ──────────────────────────────────────────────────────
+  // Large, readable clock at the top of the focus overlay. Respects the same
+  // timezone (joidy-timezone localStorage) and 24h/12h preference as TimeWidget.
+  let clockStr = $state('--:--:--');
+  let clockInterval: ReturnType<typeof setInterval> | null = null;
+
+  function updateFocusClock() {
+    clockStr = formatClock(getTimezone(), $use24HourClock);
+  }
+
+  // Re-format immediately when the 24h/12h preference changes.
+  $effect(() => {
+    $use24HourClock;
+    updateFocusClock();
+  });
 
   let reducedMotion = $state(false);
 
@@ -90,11 +108,14 @@
 
   onMount(() => {
     window.addEventListener('keydown', handleKeydown, true);
+    updateFocusClock();
+    clockInterval = setInterval(updateFocusClock, 1000);
   });
 
   onDestroy(() => {
     window.removeEventListener('keydown', handleKeydown, true);
     if (autoStopTimeout) clearTimeout(autoStopTimeout);
+    if (clockInterval) clearInterval(clockInterval);
   });
 
   function handleExit() {
@@ -113,6 +134,10 @@
     out:fade={reducedMotion ? { duration: 0 } : { duration: 180 }}
   >
     <div class="focus-content">
+      <div class="focus-clock mono" aria-label={$t('focus.clock')} title={clockStr}>
+        {clockStr}
+      </div>
+
       {#if activeNoteTitle}
         <div class="focus-note-title" in:fade={{ duration: 200 }}>
           <Target size={13} />
@@ -195,6 +220,11 @@
   .focus-content {
     display: flex; flex-direction: column; align-items: center;
     gap: var(--s5); padding: var(--s6); max-width: 480px; width: 100%;
+  }
+  .focus-clock {
+    font-size: 34px; font-weight: 300; color: var(--text-secondary);
+    letter-spacing: 0.06em; line-height: 1; text-align: center;
+    opacity: 0.85; user-select: none;
   }
   .focus-note-title {
     display: flex; align-items: center; gap: 8px;

--- a/frontend/src/lib/components/TimeWidget.svelte
+++ b/frontend/src/lib/components/TimeWidget.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { use24HourClock } from '$lib/stores/settings';
-  import { getLocale } from '$lib/stores/locale';
+  import { getTimezone, formatClock } from '$lib/utils/clock';
   import { t } from 'svelte-i18n';
 
   // ── Timezone ───────────────────────────────────────────────────────────────
@@ -48,11 +48,7 @@
   let tzError = '';
 
   function initTimezone() {
-    const saved = localStorage.getItem('joidy-timezone');
-    if (saved) { timezone = saved; return; }
-    try {
-      timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    } catch { timezone = 'UTC'; }
+    timezone = getTimezone();
   }
 
   function setTimezone(tz: string) {
@@ -79,15 +75,7 @@
   let clockStr = '--:--:--';
 
   function updateClock() {
-    try {
-      clockStr = new Date().toLocaleTimeString(getLocale(), {
-        timeZone: timezone,
-        hour:     $use24HourClock ? '2-digit' : 'numeric',
-        minute:   '2-digit',
-        second:   '2-digit',
-        hour12:   !$use24HourClock,
-      });
-    } catch { clockStr = '--:--:--'; }
+    clockStr = formatClock(timezone, $use24HourClock);
   }
 
   let clockInterval: ReturnType<typeof setInterval> | null = null;

--- a/frontend/src/lib/utils/clock.ts
+++ b/frontend/src/lib/utils/clock.ts
@@ -1,0 +1,45 @@
+import { browser } from '$app/environment';
+import { getLocale } from '$lib/stores/locale';
+
+const TZ_KEY = 'joidy-timezone';
+
+/**
+ * Read the user's selected timezone from localStorage (same key used by
+ * TimeWidget). Falls back to the browser's detected timezone, then UTC.
+ */
+export function getTimezone(): string {
+  if (!browser) return 'UTC';
+  try {
+    const saved = localStorage.getItem(TZ_KEY);
+    if (saved) return saved;
+  } catch {
+    /* localStorage unavailable (private mode) — fall through */
+  }
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+/**
+ * Format the current time for a timezone, honoring the 24h/12h preference.
+ * Returns `--:--:--` if the timezone is invalid (mirrors TimeWidget's guard).
+ */
+export function formatClock(
+  tz: string,
+  use24h: boolean,
+  locale: string = getLocale(),
+): string {
+  try {
+    return new Date().toLocaleTimeString(locale, {
+      timeZone: tz,
+      hour: use24h ? '2-digit' : 'numeric',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: !use24h,
+    });
+  } catch {
+    return '--:--:--';
+  }
+}

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -503,7 +503,8 @@
     "modeLabel": "Focus mode",
     "session": "Focus session",
     "queuedNotifications": "Queued notifications",
-    "exit": "Exit focus mode"
+    "exit": "Exit focus mode",
+    "clock": "Current time"
   },
   "commandPalette": {
     "label": "Command palette",

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -503,7 +503,8 @@
     "modeLabel": "Modo enfoque",
     "session": "Sesión de enfoque",
     "queuedNotifications": "Notificaciones en cola",
-    "exit": "Salir del modo enfoque"
+    "exit": "Salir del modo enfoque",
+    "clock": "Hora actual"
   },
   "commandPalette": {
     "label": "Paleta de comandos",


### PR DESCRIPTION
## Summary
- Adds a large, readable wall clock at the top of the focus mode overlay so users can see the time at a glance without the small status bar (#706).
- The clock respects the same timezone (`joidy-timezone` localStorage) and 24h/12h preference as the dashboard TimeWidget, updates every second, and uses a muted, non-distracting style that matches the focus mode aesthetic.
- Extracts the shared timezone-reading and clock-formatting logic into `\$lib/utils/clock.ts` (`getTimezone` / `formatClock`) and refactors TimeWidget to use it, removing duplication.

## Acceptance criteria (#706)
- [x] A large, readable clock is displayed at the top of the Focus Mode overlay
- [x] Clock updates every second
- [x] Clock respects the user's timezone setting (same as TimeWidget — reads `joidy-timezone`)
- [x] Clock respects 24h/12h preference (`use24HourClock` store; re-formats immediately on change)
- [x] Clock styling matches the focus mode aesthetic (minimal, non-distracting — muted color, mono font)
- [x] Clock is centered and large enough to read at a glance (34px, centered in `.focus-content`)

#### Test plan
- [ ] Start a focus session → a large clock appears at the top of the overlay, above the note title
- [ ] Watch the clock for a few seconds → it updates every second
- [ ] Change the timezone in the dashboard TimeWidget, then re-enter focus mode → the focus clock reflects the new timezone
- [ ] Toggle the 24h/12h preference in Settings → the focus clock format updates immediately (if a session is active) or on next session
- [ ] TimeWidget still works correctly (timezone picker, presets, format)
- [ ] `npm run check` passes (0 errors)
- [ ] `npm run build` passes

Closes #706

Generated with [Devin](https://devin.ai)