### PR TITLE
fix(frontend): distinguish editor visual and preview buttons in the toolbar

### DIFF
--- a/frontend/src/lib/components/NoteEditor.svelte
+++ b/frontend/src/lib/components/NoteEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy, onMount, tick, untrack } from 'svelte';
-  import { Eye, EyeOff, Save, Trash2, X, Settings, Search, Maximize, ChevronLeft, ChevronRight, Download, RotateCcw, Bold, Italic, Strikethrough, Heading1, Heading2, Heading3, List, ListOrdered, Link, Quote, Code, Image, Paperclip } from 'lucide-svelte';
+  import { Eye, EyeOff, Save, Trash2, X, Settings, Search, Maximize, ChevronLeft, ChevronRight, Download, RotateCcw, Bold, Italic, Strikethrough, Heading1, Heading2, Heading3, List, ListOrdered, Link, Quote, Code, Image, Paperclip, Type } from 'lucide-svelte';
   import DynamicIcon from './DynamicIcon.svelte';
   import LazyIconPicker from './LazyIconPicker.svelte';
   import 'highlight.js/styles/github-dark.css';
@@ -859,8 +859,9 @@
         class:active={wysiwygMode}
         onclick={() => wysiwygMode = !wysiwygMode}
         title={$t('noteEditor.wysiwyg')}
+        aria-label={$t('noteEditor.wysiwygShort')}
       >
-        <Eye size={14} />
+        <Type size={14} />
         <span>{wysiwygMode ? 'Raw' : 'Visual'}</span>
       </button>
 
@@ -868,7 +869,8 @@
         class="toolbar-btn"
         class:active={previewMode}
         onclick={() => previewMode = !previewMode}
-        title="Alternar preview (Ctrl+P)"
+        title={$t('noteEditor.preview')}
+        aria-label={$t('noteEditor.previewShort')}
       >
         {#if previewMode}<EyeOff size={14} />{:else}<Eye size={14} />{/if}
         <span>{previewMode ? 'Editor' : 'Vista previa'}</span>

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -415,7 +415,10 @@
     "file": "Attach file",
     "zenMode": "Zen Mode (Esc to exit)",
     "zenModeShort": "Zen Mode",
-    "wysiwyg": "Visual editor (WYSIWYG)"
+    "wysiwyg": "Visual editor (WYSIWYG) — write with formatting (Ctrl+Shift+V)",
+    "wysiwygShort": "Visual editor",
+    "preview": "Rendered preview — read only (Ctrl+P)",
+    "previewShort": "Preview"
   },
   "goalEditor": {
     "previewPlaceholder": "Write something to see the preview...",

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -415,7 +415,10 @@
     "file": "Adjuntar archivo",
     "zenMode": "Modo Zen (Esc para salir)",
     "zenModeShort": "Modo Zen",
-    "wysiwyg": "Editor visual (WYSIWYG)"
+    "wysiwyg": "Editor visual (WYSIWYG) — escribe con formato (Ctrl+Shift+V)",
+    "wysiwygShort": "Editor visual",
+    "preview": "Vista previa renderizada — solo lectura (Ctrl+P)",
+    "previewShort": "Vista previa"
   },
   "goalEditor": {
     "previewPlaceholder": "Escribe algo para ver el preview...",


### PR DESCRIPTION
## Summary
- The note editor's \"Visual\" (WYSIWYG rich-text editor) and \"Vista previa\" (read-only rendered markdown) toolbar buttons both used the `Eye` icon, making them look like duplicates even though they are functionally distinct (#704).
- This is a rework of #709 (closed): instead of removing the WYSIWYG editor, this keeps it and just makes the two buttons visually distinguishable.
- Each button now has a distinct icon and a clearer tooltip:
  - **Visual**: `Type` icon (represents rich-text editing) — tooltip: \"Editor visual (WYSIWYG) — escribe con formato (Ctrl+Shift+V)\"
  - **Vista previa**: `Eye`/`EyeOff` icon (represents viewing) — tooltip: \"Vista previa renderizada — solo lectura (Ctrl+P)\"
- Added `aria-label`s and moved the hardcoded Spanish preview tooltip into the i18n files (en/es).

## Acceptance criteria (#704)
- [x] No duplicate/redundant buttons in the editor toolbar — each has a distinct icon (`Type` vs `Eye`) and label
- [x] Clear visual indication of which mode is active — `class:active` highlight + label toggles (\"Visual\"↔\"Raw\", \"Vista previa\"↔\"Editor\")
- [x] Tooltips explain the distinct purpose of each button (editable rich-text vs read-only rendered)

#### Test plan
- [ ] Open a note: the \"Visual\" button shows a `Type` icon, \"Vista previa\" shows an `Eye` icon — clearly distinct
- [ ] Hover each button: tooltips explain the difference (WYSIWYG editable vs read-only preview)
- [ ] Click \"Visual\" → WYSIWYG rich-text editor opens (unchanged behavior); button shows active state
- [ ] Click \"Vista previa\" → read-only rendered markdown (unchanged behavior); button shows active state
- [ ] Ctrl+Shift+V toggles WYSIWYG; Ctrl+P toggles preview (unchanged)
- [ ] `npm run check` passes (0 errors)

Closes #704

Generated with [Devin](https://devin.ai)