### PR TITLE
fix(frontend): virtual list renders nothing when scrolled to bottom

### DIFF
--- a/frontend/src/lib/components/VirtualList.svelte
+++ b/frontend/src/lib/components/VirtualList.svelte
@@ -37,8 +37,17 @@
 
   // Binary search for start index (since positions is sorted)
   function findIndex(scrollTop: number) {
+    if (positions.length === 0) return 0;
+    // If the query point is beyond the last item (scrolled to the bottom),
+    // return the last index instead of falling through to 0 — otherwise
+    // endIndex collapses below startIndex and the list renders nothing
+    // (the user sees a black/empty gap at the bottom of the list).
+    const lastIdx = positions.length - 1;
+    if (positions[lastIdx] + (heights[lastIdx] || itemHeight) <= scrollTop) {
+      return lastIdx;
+    }
     let low = 0;
-    let high = positions.length - 1;
+    let high = lastIdx;
     while (low <= high) {
       const mid = Math.floor((low + high) / 2);
       const pos = positions[mid];


### PR DESCRIPTION
## Summary
- `VirtualList.findIndex()` used a binary search that returned `0` when the scroll position was beyond the last item (scrolled to the bottom of the list).
- This made `endIndex` collapse below `startIndex`, so `items.slice(startIndex, endIndex)` returned an empty array and the list showed a black/empty gap at the bottom.
- Fix: return the last index when the query point is past the last item, so the final items stay visible at the bottom of the scroll range.

#### Test plan
- [ ] Open Notes with >50 notes (triggers VirtualList)
- [ ] Scroll to the very bottom of the list
- [ ] Verify the last notes remain visible (no black/empty gap)
- [ ] Scroll back up and down — list renders correctly throughout
- [ ] `npm run check` passes (0 errors)

Generated with [Devin](https://devin.ai)