### PR TITLE
fix(frontend): deduplicate GitHub OAuth code display and auto-refresh dashboard

### DIFF
--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -177,6 +177,9 @@
         await checkGithubStatus();
         clearGithubAuth();
         showNotification('GitHub conectado correctamente', 'success');
+        // Notify other components (e.g. the dashboard) to refresh GitHub data
+        // without requiring a manual page reload.
+        window.dispatchEvent(new CustomEvent('joidy:github-connected'));
         return;
       }
       if (result.status === 'denied') {
@@ -212,6 +215,7 @@
     await api.config.update({ github_token: '', github_username: '' });
     await checkGithubStatus();
     showNotification('GitHub desconectado', 'info');
+    window.dispatchEvent(new CustomEvent('joidy:github-disconnected'));
   }
 
   async function openGoogleCalendarLink() {
@@ -705,7 +709,7 @@
             {#if githubAuthLoading}
               <span class="mono" style="font-size:12px; color: var(--text-muted);">
                 {#if githubUserCode}
-                  Código: <code style="margin-left:4px;">{githubUserCode}</code>
+                  Código: <code style="margin-left:4px; color: var(--accent); font-weight:600; letter-spacing:0.05em;">{githubUserCode}</code>
                 {:else}
                   Conectando…
                 {/if}
@@ -725,15 +729,7 @@
               >
             {/if}
           </div>
-          {#if githubAuthLoading && githubUserCode}
-            <p class="hint">
-              Abre <a href={githubVerificationUri} target="_blank">{githubVerificationUri}</a> e
-              introduce el código <code>{githubUserCode}</code> para autorizar a Joidy.
-              {#if githubAuthError}
-                <br /><span style="color:var(--danger)">{githubAuthError}</span>
-              {/if}
-            </p>
-          {:else if githubAuthError && !githubAuthLoading}
+          {#if githubAuthError && !githubAuthLoading}
             <p class="hint" style="color:var(--danger)">{githubAuthError}</p>
           {/if}
           {#if $devMode}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -164,6 +164,28 @@
     loadGitHubData(ghFilter);
   }
 
+  /** Re-check GitHub connection status and reload data (used when the user
+   *  connects/disconnects GitHub from the Settings panel). */
+  async function refreshGithubFromEvent() {
+    try {
+      const status = await api.github.status();
+      githubConnected = status.connected;
+      if (githubConnected) {
+        const [reposRes] = await Promise.all([
+          api.github.repos(),
+          loadGitHubData(ghFilter),
+        ]);
+        repoColors = Object.fromEntries((reposRes.repos || []).map((r: any) => [r.full_name, r.color || 'var(--accent)']));
+      } else {
+        githubIssues = [];
+        githubPRs = [];
+        clearGithubCache();
+      }
+    } catch (e) {
+      logger.error('GitHub refresh error:', e);
+    }
+  }
+
   $: isWilted = (() => {
     if (!$lastActivity) return false;
     const last = new Date($lastActivity);
@@ -228,13 +250,17 @@
     });
 
     window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('joidy:github-connected', refreshGithubFromEvent);
+    window.addEventListener('joidy:github-disconnected', refreshGithubFromEvent);
   });
 
   function handleBeforeUnload() {
     const scrollEls = document.querySelectorAll('[id^="panel-"]');
-    captureSnapshot('/', { moduleIdx, slideDir }, 
+    captureSnapshot('/', { moduleIdx, slideDir },
       Array.from(scrollEls).map(el => ({ id: el.id, scrollTop: (el as HTMLElement).scrollTop }))
     );
+    window.removeEventListener('joidy:github-connected', refreshGithubFromEvent);
+    window.removeEventListener('joidy:github-disconnected', refreshGithubFromEvent);
   }
 
   $: if (modulePrefsReady && MODULES[moduleIdx]) {


### PR DESCRIPTION
## Summary
- The GitHub OAuth device code was shown twice in the Settings panel — once inline (replacing the "Enlazar" button) and again in a hint paragraph below with the verification URL. Remove the duplicate hint paragraph and style the inline code with the accent color so it stands out.
- After successfully connecting GitHub, the dashboard did not refresh its GitHub widget — the user had to reload the page manually. Dispatch `joidy:github-connected` / `joidy:github-disconnected` window events from the Settings panel and listen for them on the dashboard to re-check connection status and reload issues/PRs without a full page reload.

#### Test plan
- [ ] Open Settings → click "Enlazar" on GitHub
- [ ] Verify only the inline code is shown (with accent color), no duplicate hint paragraph below
- [ ] Complete the device flow on GitHub
- [ ] Verify the dashboard GitHub widget updates automatically (issues/PRs appear) without a manual page reload
- [ ] Disconnect GitHub from Settings → verify the dashboard widget clears automatically
- [ ] `npm run check` passes (0 errors)

Generated with [Devin](https://devin.ai)