### PR TITLE
feat: folder picker for vault path and daily notes folder in settings

### DIFF
--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -1,6 +1,7 @@
+import os
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from services.auth_service import get_current_user, hash_password
 
@@ -183,6 +184,54 @@ def get_gamification_config():
     )
 
 import secrets
+
+
+class BrowseDirItem(BaseModel):
+    name: str
+    path: str
+    is_dir: bool
+
+
+class BrowseDirResponse(BaseModel):
+    current: str
+    parent: str | None = None
+    entries: list[BrowseDirItem] = []
+
+
+@router.get("/browse-dirs", response_model=BrowseDirResponse, dependencies=[Depends(get_current_user)])
+def browse_dirs(path: str = Query("/vault", description="Directory to browse")):
+    """List subdirectories of a given path. Used by the Settings folder picker
+    to let the user navigate and select a directory (e.g. the Obsidian vault
+    or the daily-notes folder) with a file-explorer-like UI instead of typing
+    the path manually.
+    """
+    # Resolve and validate the path — must be a real directory.
+    target = Path(path).resolve()
+    if not target.exists():
+        raise HTTPException(status_code=404, detail=f"Path not found: {path}")
+    if not target.is_dir():
+        raise HTTPException(status_code=400, detail=f"Not a directory: {path}")
+
+    entries: list[BrowseDirItem] = []
+    try:
+        for entry in sorted(os.scandir(str(target)), key=lambda e: e.name.lower()):
+            if entry.is_dir() and not entry.name.startswith("."):
+                entries.append(BrowseDirItem(
+                    name=entry.name,
+                    path=str(Path(entry.path)),
+                    is_dir=True,
+                ))
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Permission denied")
+
+    parent = str(target.parent) if target != target.parent else None
+
+    return BrowseDirResponse(
+        current=str(target),
+        parent=parent,
+        entries=entries,
+    )
+
 
 class SetupRequest(BaseModel):
     auth_password: str

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -715,6 +715,12 @@ export const api = {
         plant_stages: { stage: number; name: string; xp_required: number }[];
         streak_milestones: number[];
       }>('GET', '/config/gamification'),
+    browseDirs: (path: string = '/vault') =>
+      req<{
+        current: string;
+        parent: string | null;
+        entries: { name: string; path: string; is_dir: boolean }[];
+      }>('GET', `/config/browse-dirs?path=${encodeURIComponent(path)}`),
   },
   stats: {
     system: () =>

--- a/frontend/src/lib/components/DirectoryBrowser.svelte
+++ b/frontend/src/lib/components/DirectoryBrowser.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { createEventDispatcher } from 'svelte';
+  import { Folder, ChevronRight, ArrowUp, Check, X, Loader2 } from 'lucide-svelte';
+  import { api } from '$lib/api';
+  import { logger } from '$lib/utils/logger';
+
+  export let open = false;
+  /** Title shown at the top of the modal. */
+  export let title = 'Seleccionar carpeta';
+  /** Starting path when the modal opens (e.g. "/vault"). */
+  export let startPath = '/vault';
+  /**
+   * If set, the selected path is made relative to this base before being
+   * dispatched. Used for `daily_notes_folder` (relative to the vault root).
+   * If null, the absolute path is dispatched as-is.
+   */
+  export let relativeTo: string | null = null;
+
+  const dispatch = createEventDispatcher<{ select: string; cancel: void }>();
+
+  let currentPath = '';
+  let parentPath: string | null = null;
+  let entries: { name: string; path: string; is_dir: boolean }[] = [];
+  let loading = false;
+  let error = '';
+
+  async function loadDir(path: string) {
+    loading = true;
+    error = '';
+    try {
+      const res = await api.config.browseDirs(path);
+      currentPath = res.current;
+      parentPath = res.parent;
+      entries = res.entries;
+    } catch (e: any) {
+      error = e.message || 'Error al leer el directorio';
+      entries = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  $: if (open && currentPath === '') {
+    loadDir(startPath);
+  }
+
+  function navigate(path: string) {
+    loadDir(path);
+  }
+
+  function goUp() {
+    if (parentPath) loadDir(parentPath);
+  }
+
+  function selectHere() {
+    let result = currentPath;
+    if (relativeTo && result.startsWith(relativeTo)) {
+      result = result.slice(relativeTo.length).replace(/^\/+/, '');
+    }
+    dispatch('select', result);
+    close();
+  }
+
+  function close() {
+    dispatch('cancel');
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') close();
+  }
+
+  onMount(() => {
+    window.addEventListener('keydown', onKeydown);
+  });
+  onDestroy(() => {
+    window.removeEventListener('keydown', onKeydown);
+  });
+
+  // Reset state when modal closes so it re-opens fresh next time.
+  $: if (!open) {
+    currentPath = '';
+    entries = [];
+    error = '';
+  }
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div class="fp-backdrop" onclick={close}>
+    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+    <div class="fp-modal" onclick={(e) => e.stopPropagation()}>
+      <div class="fp-header">
+        <span class="fp-title mono">{title}</span>
+        <button class="fp-close" onclick={close} aria-label="Cerrar">
+          <X size={14} />
+        </button>
+      </div>
+
+      <!-- Breadcrumb / current path -->
+      <div class="fp-path-bar">
+        <button class="fp-up-btn" onclick={goUp} disabled={!parentPath} title="Subir">
+          <ArrowUp size={13} />
+        </button>
+        <span class="fp-path mono" title={currentPath}>{currentPath}</span>
+      </div>
+
+      <!-- Directory listing -->
+      <div class="fp-list">
+        {#if loading}
+          <div class="fp-empty">
+            <Loader2 size={18} class="fp-spin" />
+          </div>
+        {:else if error}
+          <div class="fp-empty fp-error">{error}</div>
+        {:else if entries.length === 0}
+          <div class="fp-empty">Sin subcarpetas.</div>
+        {:else}
+          {#each entries as entry (entry.path)}
+            <button
+              class="fp-item"
+              onclick={() => navigate(entry.path)}
+              ondblclick={selectHere}
+            >
+              <Folder size={15} />
+              <span class="fp-item-name">{entry.name}</span>
+              <ChevronRight size={13} class="fp-chevron" />
+            </button>
+          {/each}
+        {/if}
+      </div>
+
+      <!-- Actions -->
+      <div class="fp-actions">
+        <button class="fp-btn fp-cancel" onclick={close}>Cancelar</button>
+        <button class="fp-btn fp-select" onclick={selectHere}>
+          <Check size={13} />
+          Seleccionar esta carpeta
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .fp-backdrop {
+    position: fixed; inset: 0; z-index: 1000;
+    background: rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(3px);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .fp-modal {
+    background: var(--bg, #1a1a2e);
+    border: 1px solid var(--border, #333);
+    border-radius: 10px;
+    width: 480px; max-width: 90vw;
+    max-height: 70vh; display: flex; flex-direction: column;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  }
+  .fp-header {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 12px 16px; border-bottom: 1px solid var(--border-light, #222);
+  }
+  .fp-title { font-size: 13px; font-weight: 600; color: var(--text-primary); }
+  .fp-close {
+    background: none; border: none; cursor: pointer;
+    color: var(--text-muted); padding: 4px; border-radius: 4px;
+  }
+  .fp-close:hover { background: var(--elevated); color: var(--text-primary); }
+
+  .fp-path-bar {
+    display: flex; align-items: center; gap: 8px;
+    padding: 8px 12px; border-bottom: 1px solid var(--border-light, #222);
+  }
+  .fp-up-btn {
+    background: var(--elevated); border: 1px solid var(--border);
+    border-radius: 4px; padding: 4px 6px; cursor: pointer;
+    color: var(--text-secondary); display: flex; align-items: center;
+  }
+  .fp-up-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+  .fp-up-btn:not(:disabled):hover { color: var(--text-primary); }
+  .fp-path {
+    font-size: 11px; color: var(--text-muted);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1;
+  }
+
+  .fp-list {
+    flex: 1; overflow-y: auto; padding: 4px 0;
+    min-height: 180px; max-height: 320px;
+  }
+  .fp-item {
+    display: flex; align-items: center; gap: 8px;
+    width: 100%; padding: 8px 16px;
+    background: none; border: none; cursor: pointer;
+    color: var(--text-primary); font-size: 13px; text-align: left;
+  }
+  .fp-item:hover { background: var(--elevated); }
+  .fp-item-name { flex: 1; }
+  .fp-chevron { color: var(--text-muted); opacity: 0.4; }
+
+  .fp-empty {
+    padding: 32px; text-align: center; color: var(--text-muted);
+    font-size: 13px; display: flex; align-items: center; justify-content: center;
+  }
+  .fp-error { color: var(--danger, #e74c3c); }
+  .fp-spin { animation: fp-spin 1s linear infinite; }
+  @keyframes fp-spin { to { transform: rotate(360deg); } }
+
+  .fp-actions {
+    display: flex; justify-content: flex-end; gap: 8px;
+    padding: 10px 16px; border-top: 1px solid var(--border-light, #222);
+  }
+  .fp-btn {
+    display: flex; align-items: center; gap: 6px;
+    padding: 6px 14px; border-radius: 6px; font-size: 12px;
+    cursor: pointer; border: 1px solid var(--border);
+  }
+  .fp-cancel {
+    background: var(--elevated); color: var(--text-secondary);
+  }
+  .fp-cancel:hover { color: var(--text-primary); }
+  .fp-select {
+    background: var(--accent, #6366f1); color: white;
+    border-color: var(--accent);
+  }
+  .fp-select:hover { opacity: 0.9; }
+</style>

--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -24,6 +24,8 @@
   import { locale as localeStore, setLocale } from '$lib/stores/locale';
   import { t } from 'svelte-i18n';
   import { mapToSupportedLocale, SUPPORTED_LOCALES, type SupportedLocale } from '$lib/i18n';
+  import DirectoryBrowser from '$lib/components/DirectoryBrowser.svelte';
+  import { FolderOpen } from 'lucide-svelte';
 
   export let open = false;
 
@@ -51,6 +53,13 @@
   let stravaName = '';
   let gmailConnected = false;
   let gmailEmail = '';
+
+  // Folder picker state
+  let folderPickerOpen = false;
+  let folderPickerTitle = '';
+  let folderPickerStart = '/vault';
+  let folderPickerRelativeTo: string | null = null;
+  let folderPickerTarget: 'vault' | 'daily' = 'vault';
 
   let systemConfig = {
     gemini_api_key: '',
@@ -216,6 +225,31 @@
     await checkGithubStatus();
     showNotification('GitHub desconectado', 'info');
     window.dispatchEvent(new CustomEvent('joidy:github-disconnected'));
+  }
+
+  function openVaultPicker() {
+    folderPickerTarget = 'vault';
+    folderPickerTitle = 'Directorio del Vault';
+    folderPickerStart = systemConfig.obsidian_vault_path || '/vault';
+    folderPickerRelativeTo = null;
+    folderPickerOpen = true;
+  }
+
+  function openDailyNotesPicker() {
+    folderPickerTarget = 'daily';
+    folderPickerTitle = 'Carpeta de notas diarias';
+    folderPickerStart = '/vault';
+    folderPickerRelativeTo = '/vault';
+    folderPickerOpen = true;
+  }
+
+  function onFolderSelect(path: string) {
+    if (folderPickerTarget === 'vault') {
+      systemConfig.obsidian_vault_path = path;
+    } else {
+      systemConfig.daily_notes_folder = path;
+    }
+    folderPickerOpen = false;
   }
 
   async function openGoogleCalendarLink() {
@@ -655,6 +689,14 @@
                 placeholder="/Documentos/ObsidianVault"
                 bind:value={systemConfig.obsidian_vault_path}
               />
+              <button
+                class="folder-picker-btn"
+                onclick={openVaultPicker}
+                title="Explorar carpetas"
+                aria-label="Explorar carpetas"
+              >
+                <FolderOpen size={14} />
+              </button>
             </div>
           </div>
           <div class="row" style="flex-direction: column; align-items: stretch; gap: 8px;">
@@ -674,6 +716,14 @@
                 placeholder="Ejemplo/Daily"
                 bind:value={systemConfig.daily_notes_folder}
               />
+              <button
+                class="folder-picker-btn"
+                onclick={openDailyNotesPicker}
+                title="Explorar carpetas del vault"
+                aria-label="Explorar carpetas del vault"
+              >
+                <FolderOpen size={14} />
+              </button>
             </div>
           </div>
           <div class="row">
@@ -882,6 +932,15 @@
     </div>
   </div>
 {/if}
+
+<DirectoryBrowser
+  open={folderPickerOpen}
+  title={folderPickerTitle}
+  startPath={folderPickerStart}
+  relativeTo={folderPickerRelativeTo}
+  on:select={(e) => onFolderSelect(e.detail)}
+  on:cancel={() => (folderPickerOpen = false)}
+/>
 
 <style>
   .backdrop {
@@ -1209,6 +1268,17 @@
 
   .input-wrapper:focus-within {
     border-color: var(--text-muted);
+  }
+
+  .folder-picker-btn {
+    display: flex; align-items: center; justify-content: center;
+    background: none; border: none; cursor: pointer;
+    color: var(--text-muted); padding: 4px; border-radius: 4px;
+    flex-shrink: 0;
+  }
+  .folder-picker-btn:hover {
+    color: var(--accent);
+    background: var(--border);
   }
 
   .color-rm {


### PR DESCRIPTION
## Summary
- Replaces manual path typing with a file-explorer-like modal for selecting the Obsidian vault directory and the daily-notes folder in Settings.
- **Backend**: new `GET /config/browse-dirs` endpoint that lists subdirectories of a given path (defaults to `/vault`). Returns current path, parent path, and sorted directory entries. Hidden directories excluded.
- **Frontend**: new `DirectoryBrowser.svelte` modal that navigates directories via the browse-dirs endpoint. Each path input in Settings now has a `FolderOpen` button that opens the picker.
  - Vault path: absolute path is used as-is.
  - Daily notes folder: path is made relative to `/vault`.
- The text input remains alongside the picker for manual entry.

#### Test plan
- [ ] Open Settings → Obsidian Vault section
- [ ] Click the FolderOpen button next to "Directorio del Vault" → modal opens showing directories
- [ ] Navigate into folders by clicking them; go up with the arrow button
- [ ] Click "Seleccionar esta carpeta" → the path is filled in the input
- [ ] Click the FolderOpen button next to "Carpeta de notas diarias" → modal opens at /vault
- [ ] Navigate and select a subfolder → the relative path (e.g. "Objetivos/Daily") is filled
- [ ] Save config → paths persist correctly
- [ ] `npm run check` passes (0 errors)

Generated with [Devin](https://devin.ai)