### PR TITLE
fix(frontend): eliminate notes list scroll flicker on page load

### DIFF
--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -384,6 +384,17 @@
     });
   }
 
+  // Restore scroll position as soon as the scroll container is available
+  // and prefs are loaded — avoids the flash at scrollTop=0 before the
+  // saved position is applied.
+  let scrollRestored = false;
+  $: if (notesPrefsReady && listScrollEl && !scrollRestored) {
+    scrollRestored = true;
+    const snap = getSnapshot('/notes');
+    const snapScroll = snap?.scrollPositions;
+    listScrollEl.scrollTop = snapScroll?.['notes-list'] ?? (viewMode === 'tree' ? treeScrollTop : listScrollTop);
+  }
+
   onMount(async () => {
     try {
       const config = await api.config.get();
@@ -442,11 +453,6 @@
       } else if (typeof saved?.selectedNoteId === 'number') {
         const n = $notes.find(note => note.id === saved.selectedNoteId);
         if (n) openNote(n);
-      }
-      await tick();
-      if (listScrollEl) {
-        const snapScroll = snap?.scrollPositions;
-        listScrollEl.scrollTop = snapScroll?.['notes-list'] ?? (viewMode === 'tree' ? treeScrollTop : listScrollTop);
       }
     });
 


### PR DESCRIPTION
## Summary
- The notes page showed the list at `scrollTop=0` for a moment before jumping to the saved scroll position, causing a visible flicker/jump.
- Root cause: scroll restoration was done inside a `requestAnimationFrame` callback that ran after two `await tick()` calls — by then the list was already painted at the default position.
- Fix: moved scroll restoration to a reactive block that fires as soon as `notesPrefsReady` is `true` and the scroll container (`listScrollEl`) is bound, which happens before the list content is painted. A `scrollRestored` flag ensures it only runs once.
- Removed the duplicate scroll restoration from the late rAF callback.

#### Test plan
- [ ] Open Notes page, scroll down, navigate away
- [ ] Navigate back to Notes — the list should appear directly at the saved scroll position with no flash/jump
- [ ] Switch between tree and list view — scroll position is maintained
- [ ] `npm run check` passes (0 errors)

Generated with [Devin](https://devin.ai)