### PR TITLE
fix(frontend): fixed height for streak icon/emoji picker container

### DIFF
--- a/frontend/src/lib/components/StreakCreateModal.svelte
+++ b/frontend/src/lib/components/StreakCreateModal.svelte
@@ -278,7 +278,7 @@
             </div>
 
             {#if !useIcon}
-              <div class="field">
+              <div class="field icon-picker-field">
                 <div class="emoji-grid">
                   {#each EMOJIS as e}
                     <button class="emoji-btn" class:selected={emoji === e} onclick={() => emoji = e}>{e}</button>
@@ -286,7 +286,7 @@
                 </div>
               </div>
             {:else}
-              <div class="field">
+              <div class="field icon-picker-field">
                 <LazyIconPicker selected={icon} color={color} onSelect={(ic) => icon = ic} />
               </div>
             {/if}
@@ -521,13 +521,27 @@
   }
   .icon-type-btn.selected { border-color: var(--text-primary); color: var(--text-primary); }
 
+  /* Icon picker field — fixed height container so switching between
+     emoji and icon modes does not resize the modal. */
+  .icon-picker-field {
+    height: 260px;
+    min-height: 260px;
+    max-height: 260px;
+    overflow: hidden;
+  }
+  .icon-picker-field > :global(*) {
+    height: 100%;
+    min-height: 0;
+    max-height: 100%;
+    overflow: hidden;
+  }
+
   /* Emoji grid */
   .emoji-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(36px, 1fr));
     gap: 4px;
-    min-height: 220px;
-    max-height: 300px;
+    height: 100%;
     overflow-y: auto;
     padding: 4px;
     align-content: start;


### PR DESCRIPTION
## Summary
- When switching between emoji and icon modes in the streak create/edit modal, the picker container changed height — the emoji grid had `min-height: 220px` while the `IconPicker` had no fixed height, causing the modal to expand/contract vertically.
- Fix: wrap both pickers in a `.icon-picker-field` container with a fixed height of `260px`. Both the emoji grid and the IconPicker fill this container with `height: 100%` and scroll internally if needed.

#### Test plan
- [ ] Open Streaks → New Streak
- [ ] Switch between "Emoji" and "Icono" tabs — verify the container height does not change
- [ ] Verify the emoji grid scrolls within the fixed container
- [ ] Verify the icon picker (with search box) fits within the fixed container and the grid scrolls
- [ ] `npm run check` passes (0 errors)

Generated with [Devin](https://devin.ai)