### PR TITLE
fix(frontend): allow emoji grid to scroll within fixed-height container

### DIFF
--- a/frontend/src/lib/components/StreakCreateModal.svelte
+++ b/frontend/src/lib/components/StreakCreateModal.svelte
@@ -533,7 +533,6 @@
     height: 100%;
     min-height: 0;
     max-height: 100%;
-    overflow: hidden;
   }
 
   /* Emoji grid */


### PR DESCRIPTION
## Summary
- Follow-up to #719. The `overflow: hidden` applied to all direct children of `.icon-picker-field` via `:global(*)` prevented the `.emoji-grid` from scrolling, so only the first ~6 rows of emojis were visible and the rest were clipped.
- Removed `overflow: hidden` from the `:global(*)` rule. Each child manages its own scrolling — the `.emoji-grid` has `overflow-y: auto` and the `IconPicker` has its own internal scroll.

#### Test plan
- [ ] Open Streaks → New Streak → Emoji tab
- [ ] Verify all emojis are accessible by scrolling within the fixed 260px container
- [ ] Switch to Icon tab — verify icon picker still works and container height is unchanged
- [ ] `npm run check` passes (0 errors)

Generated with [Devin](https://devin.ai)