### PR TITLE
fix(frontend): add missing color picker styles in streak modal

### DIFF
--- a/frontend/src/lib/components/StreakCreateModal.svelte
+++ b/frontend/src/lib/components/StreakCreateModal.svelte
@@ -641,6 +641,30 @@
   .theme-btn:hover { border-color: var(--text-muted); }
   .theme-btn.selected { border-color: var(--text-primary); color: var(--text-primary); }
 
+  /* Color picker */
+  .color-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(32px, 1fr));
+    gap: 6px;
+    padding: 4px;
+  }
+  .color-btn {
+    width: 32px; height: 32px;
+    border: 2px solid transparent;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.15s;
+    padding: 0;
+  }
+  .color-btn:hover {
+    transform: scale(1.1);
+    border-color: var(--text-muted);
+  }
+  .color-btn.selected {
+    border-color: var(--text-primary);
+    box-shadow: 0 0 0 1px var(--bg), 0 0 0 3px var(--text-primary);
+  }
+
   /* Footer */
   .modal-footer {
     display: flex; justify-content: flex-end; gap: 10px;


### PR DESCRIPTION
## Summary
- The `.color-grid` and `.color-btn` classes in `StreakCreateModal.svelte` had no CSS rules — the 12 color preset buttons rendered as tiny unstyled default browser buttons that were barely visible and unusable.
- Added proper styles: 32x32px buttons with 6px rounded corners, grid layout with `auto-fill` columns, hover scale effect, and a selected state with a ring border.

#### Test plan
- [ ] Open Streaks → New Streak
- [ ] Verify the color section shows 12 properly sized color buttons in a grid
- [ ] Click a color — verify it gets a selection ring
- [ ] Hover a color — verify the scale-up effect
- [ ] Verify the selected color updates the preview card
- [ ] `npm run check` passes (0 errors)

Generated with [Devin](https://devin.ai)