### PR TITLE
fix(frontend): streak modal dates stacked, rainbow colors, color swatch fix

### DIFF
--- a/frontend/src/lib/components/StreakCreateModal.svelte
+++ b/frontend/src/lib/components/StreakCreateModal.svelte
@@ -41,14 +41,16 @@
 
   // ── Presets ─────────────────────────────────────────────────────────────────
   const COLOR_PRESETS = [
-    { name: 'Gold',      hex: '#c8a96e' },
-    { name: 'Esmeralda', hex: '#10b981' },
-    { name: 'Azul',      hex: '#3b82f6' },
-    { name: 'Violeta',   hex: '#8b5cf6' },
-    { name: 'Rosa',      hex: '#ec4899' },
-    { name: 'Ámbar',     hex: '#f59e0b' },
-    { name: 'Coral',     hex: '#ef4444' },
-    { name: 'Slate',     hex: '#64748b' },
+    { name: 'Rojo',     hex: '#ef4444' },
+    { name: 'Coral',    hex: '#f97316' },
+    { name: 'Ámbar',    hex: '#f59e0b' },
+    { name: 'Lima',     hex: '#84cc16' },
+    { name: 'Esmeralda',hex: '#10b981' },
+    { name: 'Cian',     hex: '#06b6d4' },
+    { name: 'Azul',     hex: '#3b82f6' },
+    { name: 'Violeta',  hex: '#8b5cf6' },
+    { name: 'Rosa',     hex: '#ec4899' },
+    { name: 'Slate',    hex: '#64748b' },
   ];
 
   const EMOJIS = Array.from(new Set([
@@ -224,15 +226,14 @@
               </div>
             {/if}
 
-            <div class="field-row">
-              <div class="field half">
-                <label><Calendar size={11} /> Fecha de inicio</label>
-                <input type="date" bind:value={startDate} disabled={isEdit} />
-              </div>
-              <div class="field half">
-                <label><Target size={11} /> Fecha objetivo <span class="optional">(op.)</span></label>
-                <input type="date" bind:value={targetDate} />
-              </div>
+            <div class="field">
+              <label><Calendar size={11} /> Fecha de inicio</label>
+              <input type="date" bind:value={startDate} disabled={isEdit} />
+            </div>
+
+            <div class="field">
+              <label><Target size={11} /> Fecha objetivo <span class="optional">(op.)</span></label>
+              <input type="date" bind:value={targetDate} />
             </div>
 
             <div class="field-row">
@@ -705,17 +706,31 @@
     margin-top: 8px;
   }
   .color-swatch {
-    width: 32px;
-    height: 32px;
+    width: 36px;
+    height: 36px;
     border: 1px solid var(--border);
     border-radius: 6px;
-    background: none;
     cursor: pointer;
-    padding: 2px;
+    padding: 0;
     flex-shrink: 0;
+    -webkit-appearance: none;
+    appearance: none;
+    background: none;
+  }
+  .color-swatch::-webkit-color-swatch-wrapper {
+    padding: 0;
+  }
+  .color-swatch::-webkit-color-swatch {
+    border: none;
+    border-radius: 5px;
+  }
+  .color-swatch::-moz-color-swatch {
+    border: none;
+    border-radius: 5px;
   }
   .hex-input {
-    flex: 1;
+    width: 90px;
+    flex: none;
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: 4px;


### PR DESCRIPTION
## Summary
- **Dates stacked**: "Fecha de inicio" and "Fecha objetivo" are now stacked vertically instead of side by side in a field-row, fixing the visual misalignment.
- **Rainbow color order**: 10 presets reordered left-to-right following the rainbow: rojo → coral → ámbar → lima → esmeralda → cian → azul → violeta → rosa → slate.
- **Color swatch fix**: the native `<input type="color">` now fills the entire 36x36 box with the user's color (removed padding, used `::-webkit-color-swatch` and `::-moz-color-swatch` with `border: none`).
- **Hex input width**: reduced from `flex: 1` (stretched) to a fixed `90px` so it doesn't take up the full row width.

#### Test plan
- [ ] Open Streaks → New Streak
- [ ] Verify "Fecha de inicio" and "Fecha objetivo" are stacked vertically
- [ ] Verify "Días desde inicio" and "Freezes" are side by side and aligned
- [ ] Verify 10 color presets follow rainbow order left-to-right
- [ ] Verify the manual color swatch is a solid square of the selected color (no inner rectangle)
- [ ] Verify the hex input is compact (not stretched)
- [ ] `npm run check` passes (0 errors)

Generated with [Devin](https://devin.ai)