### PR TITLE
feat: add system power management (hibernate/shutdown) with CLI and web controls

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -31,6 +31,7 @@ from routers import (
     skills,
     stats,
     sync,
+    system,
     tags,
     upload,
     vault,
@@ -211,6 +212,7 @@ app.include_router(stats.router, dependencies=[Depends(get_current_user)])
 app.include_router(analytics.router, dependencies=[Depends(get_current_user)])
 app.include_router(sync.router, dependencies=[Depends(get_current_user)])
 app.include_router(upload.router, dependencies=[Depends(get_current_user)])
+app.include_router(system.router, dependencies=[Depends(get_current_user)])
 
 # Ensure the upload directory exists before serving it. This is best-effort:
 # uploads are a non-critical feature, so an unwritable path (read-only mount,

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -18,3 +18,4 @@ pywebpush==2.3.0
 cryptography==50.0.0
 pytest==9.0.3
 pytest-cov==7.1.0
+aiodocker==0.23.0

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -1,0 +1,197 @@
+"""System power management router.
+
+Provides endpoints to check service status and hibernate/wake/shutdown
+the Docker stack from the web UI. Uses aiodocker to communicate with
+the Docker Engine API via the mounted Docker socket.
+"""
+
+import logging
+import os
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from services.auth_service import get_current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/system/power", tags=["system-power"])
+
+# Services that are stopped during hibernation (heavy compute).
+# api, frontend, and postgres stay running so the web UI remains accessible.
+HIBERNATE_SERVICES = ["joidy-ai-service-1", "joidy-worker-1"]
+
+# All Joidy services (for full shutdown). The api itself is excluded because
+# stopping it from within itself would prevent sending the response.
+ALL_SERVICES = [
+    "joidy-ai-service-1",
+    "joidy-worker-1",
+    "joidy-frontend-1",
+    # postgres is kept running so data isn't lost; user can stop it via CLI.
+]
+
+_docker_client = None
+
+
+async def get_docker():
+    """Lazily create and cache the aiodocker client."""
+    global _docker_client
+    if _docker_client is None:
+        try:
+            import aiodocker
+
+            sock_path = os.environ.get("DOCKER_SOCK_PATH", "/var/run/docker.sock")
+            _docker_client = aiodocker.Docker(url=f"unix://{sock_path}")
+        except Exception as exc:
+            logger.warning("Docker socket not accessible: %s", exc)
+            return None
+    return _docker_client
+
+
+class ServiceStatus(BaseModel):
+    name: str
+    status: Literal["running", "stopped", "unknown"]
+    healthy: bool | None = None
+
+
+class PowerStatusResponse(BaseModel):
+    docker_available: bool
+    services: list[ServiceStatus]
+    hibernating: bool
+
+
+class PowerActionResponse(BaseModel):
+    status: str
+    message: str
+    affected: list[str] = []
+
+
+@router.get("/status", response_model=PowerStatusResponse)
+async def get_power_status(_=Depends(get_current_user)):
+    """Get the status of all Joidy services."""
+    docker = await get_docker()
+    if docker is None:
+        return PowerStatusResponse(
+            docker_available=False,
+            services=[],
+            hibernating=False,
+        )
+
+    try:
+        containers = await docker.containers.list(all=True)
+    except Exception as exc:
+        logger.error("Failed to list containers: %s", exc)
+        return PowerStatusResponse(
+            docker_available=False,
+            services=[],
+            hibernating=False,
+        )
+
+    joidy_containers = [c for c in containers if c["Names"][0].lstrip("/") in ALL_SERVICES + ["joidy-postgres-1"]]
+
+    services: list[ServiceStatus] = []
+    hibernating = False
+
+    for c in joidy_containers:
+        name = c["Names"][0].lstrip("/")
+        state = c.get("State", "unknown")
+        status = "running" if state == "running" else "stopped"
+        healthy = None
+        if status == "running":
+            health = c.get("Health", {})
+            if health:
+                healthy = health.get("Status") == "healthy"
+
+        services.append(ServiceStatus(name=name, status=status, healthy=healthy))
+
+        if name in HIBERNATE_SERVICES and status == "stopped":
+            hibernating = True
+
+    return PowerStatusResponse(
+        docker_available=True,
+        services=services,
+        hibernating=hibernating,
+    )
+
+
+@router.post("/sleep", response_model=PowerActionResponse)
+async def hibernate_services(_=Depends(get_current_user)):
+    """Stop heavy services (ai-service, worker) to save resources.
+    api, frontend, and postgres remain running."""
+    docker = await get_docker()
+    if docker is None:
+        raise HTTPException(status_code=503, detail="Docker socket not available. Use the CLI instead.")
+
+    affected: list[str] = []
+    for name in HIBERNATE_SERVICES:
+        try:
+            container = await docker.containers.get(name)
+            info = await container.show()
+            if info.get("State", {}).get("Running"):
+                await container.stop()
+                affected.append(name)
+                logger.info("Stopped container %s for hibernation", name)
+        except Exception as exc:
+            logger.warning("Failed to stop %s: %s", name, exc)
+
+    return PowerActionResponse(
+        status="ok",
+        message=f"Hibernated {len(affected)} service(s). Use Wake or 'joidy wake' to restart them.",
+        affected=affected,
+    )
+
+
+@router.post("/wake", response_model=PowerActionResponse)
+async def wake_services(_=Depends(get_current_user)):
+    """Restart heavy services (ai-service, worker) from hibernation."""
+    docker = await get_docker()
+    if docker is None:
+        raise HTTPException(status_code=503, detail="Docker socket not available. Use the CLI instead.")
+
+    affected: list[str] = []
+    for name in HIBERNATE_SERVICES:
+        try:
+            container = await docker.containers.get(name)
+            info = await container.show()
+            if not info.get("State", {}).get("Running"):
+                await container.start()
+                affected.append(name)
+                logger.info("Started container %s from hibernation", name)
+        except Exception as exc:
+            logger.warning("Failed to start %s: %s", name, exc)
+
+    return PowerActionResponse(
+        status="ok",
+        message=f"Woke {len(affected)} service(s).",
+        affected=affected,
+    )
+
+
+@router.post("/shutdown", response_model=PowerActionResponse)
+async def shutdown_services(_=Depends(get_current_user)):
+    """Stop all services except postgres and the api itself.
+    The user must use the CLI ('joidy up') to restart everything."""
+    docker = await get_docker()
+    if docker is None:
+        raise HTTPException(status_code=503, detail="Docker socket not available. Use the CLI instead.")
+
+    affected: list[str] = []
+    # Stop in reverse dependency order: frontend → ai-service → worker
+    stop_order = ["joidy-frontend-1", "joidy-ai-service-1", "joidy-worker-1"]
+    for name in stop_order:
+        try:
+            container = await docker.containers.get(name)
+            info = await container.show()
+            if info.get("State", {}).get("Running"):
+                await container.stop()
+                affected.append(name)
+                logger.info("Stopped container %s for shutdown", name)
+        except Exception as exc:
+            logger.warning("Failed to stop %s: %s", name, exc)
+
+    return PowerActionResponse(
+        status="ok",
+        message="Shutdown complete. Run 'joidy up' in your terminal to restart all services.",
+        affected=affected,
+    )

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -18,18 +18,16 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/system/power", tags=["system-power"])
 
-# Services that are stopped during hibernation (heavy compute).
-# api, frontend, and postgres stay running so the web UI remains accessible.
-HIBERNATE_SERVICES = ["joidy-ai-service-1", "joidy-worker-1"]
+# Docker Compose service names (from the `com.docker.compose.service` label).
+# These are independent of the project name / directory name.
+HIBERNATE_SERVICES = {"ai-service", "worker"}
 
-# All Joidy services (for full shutdown). The api itself is excluded because
-# stopping it from within itself would prevent sending the response.
-ALL_SERVICES = [
-    "joidy-ai-service-1",
-    "joidy-worker-1",
-    "joidy-frontend-1",
-    # postgres is kept running so data isn't lost; user can stop it via CLI.
-]
+# All Joidy services to show in the status list (by compose service name).
+ALL_SERVICES = {"ai-service", "worker", "frontend", "api", "postgres"}
+
+# Services to stop during full shutdown (in order).
+# postgres and api are kept so the response can be sent and data isn't lost.
+SHUTDOWN_SERVICES = ["frontend", "ai-service", "worker"]
 
 _docker_client = None
 
@@ -67,6 +65,51 @@ class PowerActionResponse(BaseModel):
     affected: list[str] = []
 
 
+def _get_compose_service(container: dict) -> str | None:
+    """Extract the Docker Compose service name from container labels."""
+    labels = container.get("Labels") or {}
+    if isinstance(labels, dict):
+        return labels.get("com.docker.compose.service")
+    # Docker API returns labels as a list of "key=value" strings in some versions
+    if isinstance(labels, list):
+        for label in labels:
+            if isinstance(label, str) and label.startswith("com.docker.compose.service="):
+                return label.split("=", 1)[1]
+    return None
+
+
+def _get_container_name(container: dict) -> str:
+    """Get the container name without the leading slash."""
+    names = container.get("Names") or []
+    if names:
+        return names[0].lstrip("/")
+    return container.get("Id", "unknown")[:12]
+
+
+def _parse_health(container: dict) -> bool | None:
+    """Parse health status from the Docker API list response.
+
+    Returns True (healthy), False (unhealthy), or None (no healthcheck).
+    """
+    health = container.get("Health")
+    if health and isinstance(health, dict):
+        status = health.get("Status")
+        if status == "healthy":
+            return True
+        if status == "unhealthy":
+            return False
+        # "none" or other values → no healthcheck configured
+        return None
+
+    # Fallback: parse the Status string (e.g., "Up 2 hours (healthy)")
+    status_str = container.get("Status", "")
+    if "(healthy)" in status_str:
+        return True
+    if "(unhealthy)" in status_str:
+        return False
+    return None
+
+
 @router.get("/status", response_model=PowerStatusResponse)
 async def get_power_status(_=Depends(get_current_user)):
     """Get the status of all Joidy services."""
@@ -88,24 +131,28 @@ async def get_power_status(_=Depends(get_current_user)):
             hibernating=False,
         )
 
-    joidy_containers = [c for c in containers if c["Names"][0].lstrip("/") in ALL_SERVICES + ["joidy-postgres-1"]]
+    # Filter to Joidy containers by compose service label
+    joidy_containers = []
+    for c in containers:
+        svc = _get_compose_service(c)
+        if svc and svc in ALL_SERVICES:
+            joidy_containers.append((svc, c))
+
+    # Sort by a fixed order for consistent display
+    service_order = ["postgres", "api", "ai-service", "worker", "frontend"]
+    joidy_containers.sort(key=lambda pair: service_order.index(pair[0]) if pair[0] in service_order else 99)
 
     services: list[ServiceStatus] = []
     hibernating = False
 
-    for c in joidy_containers:
-        name = c["Names"][0].lstrip("/")
+    for svc_name, c in joidy_containers:
         state = c.get("State", "unknown")
         status = "running" if state == "running" else "stopped"
-        healthy = None
-        if status == "running":
-            health = c.get("Health", {})
-            if health:
-                healthy = health.get("Status") == "healthy"
+        healthy = _parse_health(c) if status == "running" else None
 
-        services.append(ServiceStatus(name=name, status=status, healthy=healthy))
+        services.append(ServiceStatus(name=svc_name, status=status, healthy=healthy))
 
-        if name in HIBERNATE_SERVICES and status == "stopped":
+        if svc_name in HIBERNATE_SERVICES and status == "stopped":
             hibernating = True
 
     return PowerStatusResponse(
@@ -124,16 +171,20 @@ async def hibernate_services(_=Depends(get_current_user)):
         raise HTTPException(status_code=503, detail="Docker socket not available. Use the CLI instead.")
 
     affected: list[str] = []
-    for name in HIBERNATE_SERVICES:
+    for c in await docker.containers.list(all=True):
+        svc = _get_compose_service(c)
+        if svc not in HIBERNATE_SERVICES:
+            continue
         try:
-            container = await docker.containers.get(name)
+            container_name = _get_container_name(c)
+            container = await docker.containers.get(container_name)
             info = await container.show()
             if info.get("State", {}).get("Running"):
                 await container.stop()
-                affected.append(name)
-                logger.info("Stopped container %s for hibernation", name)
+                affected.append(svc)
+                logger.info("Stopped container %s for hibernation", container_name)
         except Exception as exc:
-            logger.warning("Failed to stop %s: %s", name, exc)
+            logger.warning("Failed to stop %s: %s", svc, exc)
 
     return PowerActionResponse(
         status="ok",
@@ -150,16 +201,20 @@ async def wake_services(_=Depends(get_current_user)):
         raise HTTPException(status_code=503, detail="Docker socket not available. Use the CLI instead.")
 
     affected: list[str] = []
-    for name in HIBERNATE_SERVICES:
+    for c in await docker.containers.list(all=True):
+        svc = _get_compose_service(c)
+        if svc not in HIBERNATE_SERVICES:
+            continue
         try:
-            container = await docker.containers.get(name)
+            container_name = _get_container_name(c)
+            container = await docker.containers.get(container_name)
             info = await container.show()
             if not info.get("State", {}).get("Running"):
                 await container.start()
-                affected.append(name)
-                logger.info("Started container %s from hibernation", name)
+                affected.append(svc)
+                logger.info("Started container %s from hibernation", container_name)
         except Exception as exc:
-            logger.warning("Failed to start %s: %s", name, exc)
+            logger.warning("Failed to start %s: %s", svc, exc)
 
     return PowerActionResponse(
         status="ok",
@@ -176,19 +231,27 @@ async def shutdown_services(_=Depends(get_current_user)):
     if docker is None:
         raise HTTPException(status_code=503, detail="Docker socket not available. Use the CLI instead.")
 
+    # Build a map of compose service name → container name
+    svc_to_container_name: dict[str, str] = {}
+    for c in await docker.containers.list(all=True):
+        svc = _get_compose_service(c)
+        if svc and svc in SHUTDOWN_SERVICES:
+            svc_to_container_name[svc] = _get_container_name(c)
+
     affected: list[str] = []
-    # Stop in reverse dependency order: frontend → ai-service → worker
-    stop_order = ["joidy-frontend-1", "joidy-ai-service-1", "joidy-worker-1"]
-    for name in stop_order:
+    for svc_name in SHUTDOWN_SERVICES:
+        container_name = svc_to_container_name.get(svc_name)
+        if not container_name:
+            continue
         try:
-            container = await docker.containers.get(name)
+            container = await docker.containers.get(container_name)
             info = await container.show()
             if info.get("State", {}).get("Running"):
                 await container.stop()
-                affected.append(name)
-                logger.info("Stopped container %s for shutdown", name)
+                affected.append(svc_name)
+                logger.info("Stopped container %s for shutdown", container_name)
         except Exception as exc:
-            logger.warning("Failed to stop %s: %s", name, exc)
+            logger.warning("Failed to stop %s: %s", svc_name, exc)
 
     return PowerActionResponse(
         status="ok",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,11 @@ services:
       - ./data/uploads:/data/uploads
       - ./.env:/app/.env
       - ${OBSIDIAN_VAULT_PATH:-./data/vault}:/vault
+      # Docker socket for power management (sleep/wake/shutdown from web UI).
+      # On Linux: ensure the container user can access the socket
+      #   (set DOCKER_GID in .env to your host's docker group GID, or use 0 for root).
+      # On Windows Docker Desktop: the socket is accessible by default.
+      - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-joidy}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-joidy}
       - AI_SERVICE_URL=http://ai-service:8002
@@ -31,6 +36,11 @@ services:
       - UPLOAD_DIR=/data/uploads
       - OBSIDIAN_VAULT_PATH=/vault
       - VAULT_PATH=/vault
+      - DOCKER_SOCK_PATH=/var/run/docker.sock
+    # Add the host's docker group so the app user can access the Docker socket.
+    # Set DOCKER_GID in .env (find it with `getent group docker | cut -d: -f3` on Linux).
+    group_add:
+      - "${DOCKER_GID:-0}"
     depends_on:
       postgres:
         condition: service_healthy

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -837,4 +837,21 @@ export const api = {
         server_time: string;
       }>('GET', '/sync/status'),
   },
+
+  system: {
+    power: {
+      status: () =>
+        req<{
+          docker_available: boolean;
+          services: { name: string; status: string; healthy: boolean | null }[];
+          hibernating: boolean;
+        }>('GET', '/system/power/status'),
+      sleep: () =>
+        req<{ status: string; message: string; affected: string[] }>('POST', '/system/power/sleep'),
+      wake: () =>
+        req<{ status: string; message: string; affected: string[] }>('POST', '/system/power/wake'),
+      shutdown: () =>
+        req<{ status: string; message: string; affected: string[] }>('POST', '/system/power/shutdown'),
+    },
+  },
 };

--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -59,6 +59,7 @@
   let powerActionLoading: 'sleep' | 'wake' | 'shutdown' | null = null;
   let powerMessage = '';
   let powerError = '';
+  let powerStatusAttempted = false;
 
   let systemConfig = {
     gemini_api_key: '',
@@ -82,13 +83,14 @@
     loadConfig();
   }
 
-  $: if (open && !powerStatus && !powerLoading) {
+  $: if (open && !powerStatusAttempted && !powerLoading) {
     refreshPowerStatus();
   }
 
   async function refreshPowerStatus() {
     powerLoading = true;
     powerError = '';
+    powerStatusAttempted = true;
     try {
       powerStatus = await api.system.power.status();
     } catch (e: any) {
@@ -147,11 +149,11 @@
 
   function serviceLabel(name: string): string {
     const labels: Record<string, string> = {
-      'joidy-postgres-1': 'PostgreSQL',
-      'joidy-api-1': 'API',
-      'joidy-ai-service-1': 'AI Service',
-      'joidy-worker-1': 'Worker',
-      'joidy-frontend-1': 'Frontend',
+      'postgres': 'PostgreSQL',
+      'api': 'API',
+      'ai-service': 'AI Service',
+      'worker': 'Worker',
+      'frontend': 'Frontend',
     };
     return labels[name] ?? name;
   }

--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -24,6 +24,7 @@
   import { locale as localeStore, setLocale } from '$lib/stores/locale';
   import { t } from 'svelte-i18n';
   import { mapToSupportedLocale, SUPPORTED_LOCALES, type SupportedLocale } from '$lib/i18n';
+  import { Power, Moon, Sun, PowerOff, RefreshCw, CheckCircle, XCircle, Loader2 } from 'lucide-svelte';
 
   export let open = false;
 
@@ -52,6 +53,13 @@
   let gmailConnected = false;
   let gmailEmail = '';
 
+  // Power management state
+  let powerStatus: { docker_available: boolean; services: { name: string; status: string; healthy: boolean | null }[]; hibernating: boolean } | null = null;
+  let powerLoading = false;
+  let powerActionLoading: 'sleep' | 'wake' | 'shutdown' | null = null;
+  let powerMessage = '';
+  let powerError = '';
+
   let systemConfig = {
     gemini_api_key: '',
     obsidian_vault_path: '',
@@ -72,6 +80,80 @@
 
   $: if (open && !configLoaded) {
     loadConfig();
+  }
+
+  $: if (open && !powerStatus && !powerLoading) {
+    refreshPowerStatus();
+  }
+
+  async function refreshPowerStatus() {
+    powerLoading = true;
+    powerError = '';
+    try {
+      powerStatus = await api.system.power.status();
+    } catch (e: any) {
+      powerError = e?.message || 'Failed to load power status';
+      powerStatus = null;
+    } finally {
+      powerLoading = false;
+    }
+  }
+
+  async function doHibernate() {
+    powerActionLoading = 'sleep';
+    powerMessage = '';
+    powerError = '';
+    try {
+      const res = await api.system.power.sleep();
+      powerMessage = res.message;
+      await refreshPowerStatus();
+    } catch (e: any) {
+      powerError = e?.message || 'Hibernate failed';
+    } finally {
+      powerActionLoading = null;
+    }
+  }
+
+  async function doWake() {
+    powerActionLoading = 'wake';
+    powerMessage = '';
+    powerError = '';
+    try {
+      const res = await api.system.power.wake();
+      powerMessage = res.message;
+      await refreshPowerStatus();
+    } catch (e: any) {
+      powerError = e?.message || 'Wake failed';
+    } finally {
+      powerActionLoading = null;
+    }
+  }
+
+  async function doShutdown() {
+    if (!confirm($t('power.shutdownConfirm'))) return;
+    powerActionLoading = 'shutdown';
+    powerMessage = '';
+    powerError = '';
+    try {
+      const res = await api.system.power.shutdown();
+      powerMessage = res.message;
+      await refreshPowerStatus();
+    } catch (e: any) {
+      powerError = e?.message || 'Shutdown failed';
+    } finally {
+      powerActionLoading = null;
+    }
+  }
+
+  function serviceLabel(name: string): string {
+    const labels: Record<string, string> = {
+      'joidy-postgres-1': 'PostgreSQL',
+      'joidy-api-1': 'API',
+      'joidy-ai-service-1': 'AI Service',
+      'joidy-worker-1': 'Worker',
+      'joidy-frontend-1': 'Frontend',
+    };
+    return labels[name] ?? name;
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -833,6 +915,78 @@
           </div>
         </section>
 
+        <!-- Power & System -->
+        <section class="section">
+          <div class="section-title" style="color: var(--xp, var(--accent));">
+            <Power size={12} /> {$t('power.title')}
+          </div>
+
+          {#if powerLoading}
+            <div class="row"><span class="hint"><Loader2 size={13} class="spin" /> {$t('power.refreshing')}</span></div>
+          {:else if powerStatus && !powerStatus.docker_available}
+            <p class="hint">{$t('power.dockerUnavailable')}</p>
+          {:else if powerStatus}
+            <div class="power-services">
+              {#each powerStatus.services as svc (svc.name)}
+                <div class="power-service-row">
+                  <span class="power-service-name">{serviceLabel(svc.name)}</span>
+                  <span class="power-service-badge" class:running={svc.status === 'running'} class:stopped={svc.status !== 'running'}>
+                    {#if svc.status === 'running'}
+                      {#if svc.healthy === false}
+                        <XCircle size={11} /> {$t('power.unhealthy')}
+                      {:else}
+                        <CheckCircle size={11} /> {$t('power.running')}
+                      {/if}
+                    {:else}
+                      <XCircle size={11} /> {$t('power.stopped')}
+                    {/if}
+                  </span>
+                </div>
+              {/each}
+            </div>
+
+            {#if powerStatus.hibernating}
+              <p class="hint" style="color: var(--accent);">{$t('power.hibernating')}</p>
+            {:else if powerStatus.services.every(s => s.status === 'running')}
+              <p class="hint">{$t('power.allRunning')}</p>
+            {/if}
+
+            <div class="power-actions">
+              {#if powerStatus.hibernating}
+                <button class="power-btn wake-btn" onclick={doWake} disabled={powerActionLoading !== null}>
+                  {#if powerActionLoading === 'wake'}<Loader2 size={13} class="spin" />{:else}<Sun size={13} />{/if}
+                  {$t('power.wake')}
+                </button>
+              {:else}
+                <button class="power-btn sleep-btn" onclick={doHibernate} disabled={powerActionLoading !== null}>
+                  {#if powerActionLoading === 'sleep'}<Loader2 size={13} class="spin" />{:else}<Moon size={13} />{/if}
+                  {$t('power.hibernate')}
+                </button>
+              {/if}
+              <button class="power-btn shutdown-btn" onclick={doShutdown} disabled={powerActionLoading !== null}>
+                {#if powerActionLoading === 'shutdown'}<Loader2 size={13} class="spin" />{:else}<PowerOff size={13} />{/if}
+                {$t('power.shutdown')}
+              </button>
+              <button class="power-btn refresh-btn" onclick={refreshPowerStatus} disabled={powerLoading}>
+                <RefreshCw size={13} />
+                {$t('power.refresh')}
+              </button>
+            </div>
+
+            <p class="hint">{$t('power.hibernateHint')}</p>
+            <p class="hint" style="color: var(--danger, #e74c3c);">{$t('power.shutdownHint')}</p>
+
+            {#if powerMessage}
+              <p class="hint" style="color: var(--accent);">{powerMessage}</p>
+            {/if}
+            {#if powerError}
+              <p class="hint" style="color: var(--danger, #e74c3c);">{$t('power.actionFailed')}: {powerError}</p>
+            {/if}
+          {:else}
+            <p class="hint">{$t('power.dockerUnavailable')}</p>
+          {/if}
+        </section>
+
         <!-- Desarrollador -->
         <section class="section">
           <div class="section-title" style="color: var(--xp, var(--accent));">
@@ -1324,5 +1478,78 @@
     .panel {
       width: 100%;
     }
+  }
+
+  /* ── Power Management ── */
+  .power-services {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 8px;
+  }
+  .power-service-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 4px 8px;
+    border-radius: 4px;
+    background: var(--surface-2, rgba(128, 128, 128, 0.08));
+    font-size: 12px;
+  }
+  .power-service-name {
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+  .power-service-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    padding: 2px 6px;
+    border-radius: 3px;
+  }
+  .power-service-badge.running {
+    color: var(--success, #2ecc71);
+    background: rgba(46, 204, 113, 0.1);
+  }
+  .power-service-badge.stopped {
+    color: var(--text-secondary);
+    background: rgba(128, 128, 128, 0.1);
+  }
+  .power-actions {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin: 8px 0;
+  }
+  .power-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    background: var(--surface-2, rgba(128, 128, 128, 0.06));
+    color: var(--text-primary);
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .power-btn:hover:not(:disabled) {
+    border-color: var(--accent);
+    background: var(--surface-3, rgba(128, 128, 128, 0.12));
+  }
+  .power-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .sleep-btn:hover:not(:disabled) { border-color: var(--accent, #3498db); }
+  .wake-btn:hover:not(:disabled) { border-color: var(--success, #2ecc71); }
+  .shutdown-btn:hover:not(:disabled) { border-color: var(--danger, #e74c3c); color: var(--danger, #e74c3c); }
+  .spin {
+    animation: spin 1s linear infinite;
+  }
+  @keyframes spin {
+    to { transform: rotate(360deg); }
   }
 </style>

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -81,6 +81,27 @@
     "language": "Language",
     "languageHint": "The interface language"
   },
+  "power": {
+    "title": "Power & System",
+    "status": "Service Status",
+    "hibernate": "Hibernate",
+    "wake": "Wake",
+    "shutdown": "Shutdown",
+    "hibernateHint": "Stop AI service and worker to save resources. API, frontend, and database stay running.",
+    "shutdownHint": "Stop all services. You will need to run 'joidy up' in your terminal to restart.",
+    "shutdownConfirm": "Are you sure you want to shut down all services? You will need the CLI to restart.",
+    "dockerUnavailable": "Docker socket not available. Use the CLI ('joidy' command) to manage services.",
+    "running": "Running",
+    "stopped": "Stopped",
+    "healthy": "Healthy",
+    "unhealthy": "Unhealthy",
+    "refreshing": "Refreshing...",
+    "refresh": "Refresh",
+    "hibernating": "Hibernating",
+    "allRunning": "All services running",
+    "actionDone": "Done",
+    "actionFailed": "Failed"
+  },
   "quickCapture": {
     "placeholder": "Capture a quick idea...",
     "defaultTitle": "Quick note",

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -81,6 +81,27 @@
     "language": "Idioma",
     "languageHint": "El idioma de la interfaz"
   },
+  "power": {
+    "title": "Energía y Sistema",
+    "status": "Estado de Servicios",
+    "hibernate": "Hibernar",
+    "wake": "Despertar",
+    "shutdown": "Apagar",
+    "hibernateHint": "Detiene el servicio de IA y el worker para ahorrar recursos. La API, el frontend y la base de datos siguen funcionando.",
+    "shutdownHint": "Detiene todos los servicios. Necesitarás ejecutar 'joidy up' en tu terminal para reiniciar.",
+    "shutdownConfirm": "¿Seguro que quieres apagar todos los servicios? Necesitarás la CLI para reiniciar.",
+    "dockerUnavailable": "Socket de Docker no disponible. Usa la CLI (comando 'joidy') para gestionar los servicios.",
+    "running": "Activo",
+    "stopped": "Detenido",
+    "healthy": "Saludable",
+    "unhealthy": "No saludable",
+    "refreshing": "Actualizando...",
+    "refresh": "Actualizar",
+    "hibernating": "Hibernando",
+    "allRunning": "Todos los servicios activos",
+    "actionDone": "Listo",
+    "actionFailed": "Falló"
+  },
   "quickCapture": {
     "placeholder": "Captura una idea rápida...",
     "defaultTitle": "Nota rápida",

--- a/scripts/install-autostart.ps1
+++ b/scripts/install-autostart.ps1
@@ -1,0 +1,72 @@
+# install-autostart.ps1 — Set up Windows Task Scheduler for Joidy auto-start on logon.
+#
+# Usage:
+#   .\scripts\install-autostart.ps1          # Install auto-start
+#   .\scripts\install-autostart.ps1 -Remove  # Remove auto-start
+
+param(
+  [switch]$Remove = $false
+)
+
+$TaskName = "Joidy"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectDir = Split-Path -Parent $ScriptDir
+$StartupScript = Join-Path $ScriptDir "joidy_startup.sh"
+
+if ($Remove) {
+  Write-Host "Removing Joidy auto-start task..."
+  $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+  if ($task) {
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+    Write-Host "✓ Joidy auto-start task removed."
+  } else {
+    Write-Host "⚠ No Joidy auto-start task found."
+  }
+  exit 0
+}
+
+Write-Host "Setting up Joidy auto-start via Windows Task Scheduler..."
+
+# Check if running on Windows
+if ($PSVersionTable.Platform -ne "Win32NT" -and -not $env:OS.Contains("Windows")) {
+  Write-Host "⚠ This script is for Windows. For Linux, use install-autostart.sh"
+  exit 1
+}
+
+# Find docker compose startup command
+$DockerComposeCmd = "docker compose up -d"
+
+# Create the scheduled task action
+$Action = New-ScheduledTaskAction `
+  -Execute "powershell.exe" `
+  -Argument "-NoProfile -WindowStyle Hidden -Command `"Set-Location '$ProjectDir'; docker compose up -d`""
+
+# Trigger at user logon
+$Trigger = New-ScheduledTaskTrigger -AtLogOn
+
+# Settings: don't start if already running, allow start on battery
+$Settings = New-ScheduledTaskSettingsSet `
+  -DontStartIfOnBatteries:$false `
+  -AllowStartIfOnBatteries `
+  -StartWhenAvailable
+
+# Register the task
+Register-ScheduledTask `
+  -TaskName $TaskName `
+  -Action $Action `
+  -Trigger $Trigger `
+  -Settings $Settings `
+  -Description "Start Joidy Docker services on logon" `
+  -Force
+
+Write-Host ""
+Write-Host "✓ Joidy auto-start task installed."
+Write-Host ""
+Write-Host "The services will start automatically when you log in."
+Write-Host ""
+Write-Host "Manual commands:"
+Write-Host "  Start-ScheduledTask -TaskName Joidy    # Start now"
+Write-Host "  Stop-ScheduledTask -TaskName Joidy     # Stop now"
+Write-Host "  Get-ScheduledTask -TaskName Joidy      # Check status"
+Write-Host ""
+Write-Host "To remove auto-start: .\scripts\install-autostart.ps1 -Remove"

--- a/scripts/install-autostart.sh
+++ b/scripts/install-autostart.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# install-autostart.sh — Set up systemd user service for Joidy auto-start on Linux.
+#
+# Usage:
+#   bash scripts/install-autostart.sh          # Install auto-start
+#   bash scripts/install-autostart.sh --remove # Remove auto-start
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SERVICE_NAME="joidy"
+SERVICE_FILE="$HOME/.config/systemd/user/${SERVICE_NAME}.service"
+
+if [ "$1" = "--remove" ]; then
+  echo "Removing Joidy auto-start service..."
+  systemctl --user stop "${SERVICE_NAME}.service" 2>/dev/null || true
+  systemctl --user disable "${SERVICE_NAME}.service" 2>/dev/null || true
+  rm -f "$SERVICE_FILE"
+  systemctl --user daemon-reload
+  echo "✓ Joidy auto-start removed."
+  exit 0
+fi
+
+echo "Setting up Joidy auto-start via systemd user service..."
+
+# Create systemd user directory if it doesn't exist
+mkdir -p "$HOME/.config/systemd/user"
+
+# Write the service file
+cat > "$SERVICE_FILE" <<EOF
+[Unit]
+Description=Joidy — Personal Growth Dashboard
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=${PROJECT_DIR}
+ExecStart=${PROJECT_DIR}/scripts/joidy_startup.sh
+RemainAfterExit=yes
+ExecStop=${PROJECT_DIR}/scripts/joidy.sh down
+
+[Install]
+WantedBy=default.target
+EOF
+
+# Reload systemd and enable the service
+systemctl --user daemon-reload
+systemctl --user enable "${SERVICE_NAME}.service"
+
+echo ""
+echo "✓ Joidy auto-start service installed."
+echo ""
+echo "The service will start automatically when you log in."
+echo ""
+echo "Manual commands:"
+echo "  systemctl --user start joidy    # Start now"
+echo "  systemctl --user stop joidy     # Stop now"
+echo "  systemctl --user status joidy   # Check status"
+echo "  systemctl --user disable joidy  # Disable auto-start"
+echo ""
+echo "To remove auto-start: bash scripts/install-autostart.sh --remove"

--- a/scripts/joidy.ps1
+++ b/scripts/joidy.ps1
@@ -1,0 +1,132 @@
+# joidy — CLI for managing the Joidy Docker stack (Windows PowerShell)
+#
+# Installation:
+#   Copy scripts/joidy.ps1 to a folder in your PATH (e.g., $HOME\bin)
+#   Or add the scripts folder to your PATH:
+#     [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$PWD\scripts", "User")
+#
+# Usage:
+#   .\joidy.ps1 up       Start all services (detached)
+#   .\joidy.ps1 down     Stop all services
+#   .\joidy.ps1 sleep    Stop heavy services (ai-service, worker)
+#   .\joidy.ps1 wake     Restart heavy services from hibernation
+#   .\joidy.ps1 restart  Restart all services
+#   .\joidy.ps1 status   Show service status
+#   .\joidy.ps1 logs     Tail logs (all services)
+#   .\joidy.ps1 logs api Tail logs for a specific service
+#   .\joidy.ps1 help     Show this help message
+
+param(
+  [Parameter(Position = 0)]
+  [string]$Command = "help",
+
+  [Parameter(Position = 1)]
+  [string]$Service = ""
+)
+
+# Resolve project directory from script location
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectDir = Split-Path -Parent $ScriptDir
+
+Set-Location $ProjectDir
+
+$HIBERNATE_SERVICES = @("ai-service", "worker")
+
+function Write-Status($msg) { Write-Host "[$(Get-Date -Format 'HH:mm:ss')] $msg" -ForegroundColor Blue }
+function Write-Ok($msg)     { Write-Host "✓ $msg" -ForegroundColor Green }
+function Write-Warn($msg)   { Write-Host "⚠ $msg" -ForegroundColor Yellow }
+function Write-Err($msg)    { Write-Host "✗ $msg" -ForegroundColor Red }
+
+function Invoke-Up {
+  Write-Status "Starting Joidy services..."
+  docker compose up -d
+  Write-Status "Waiting for services to stabilize..."
+  Start-Sleep -Seconds 5
+  Invoke-Status
+}
+
+function Invoke-Down {
+  Write-Status "Stopping all Joidy services..."
+  docker compose down
+  Write-Ok "All services stopped."
+}
+
+function Invoke-Sleep {
+  Write-Status "Hibernating heavy services (ai-service, worker)..."
+  foreach ($svc in $HIBERNATE_SERVICES) {
+    $running = docker compose ps --status running $svc 2>$null
+    if ($running -match $svc) {
+      docker compose stop $svc
+      Write-Ok "Stopped $svc"
+    } else {
+      Write-Warn "$svc is already stopped"
+    }
+  }
+  Write-Host ""
+  Write-Ok "Hibernation complete. API, frontend, and database are still running."
+  Write-Host "  Use 'joidy wake' to restart heavy services."
+}
+
+function Invoke-Wake {
+  Write-Status "Waking heavy services from hibernation..."
+  foreach ($svc in $HIBERNATE_SERVICES) {
+    $stopped = docker compose ps --status stopped $svc 2>$null
+    if ($stopped -match $svc) {
+      docker compose start $svc
+      Write-Ok "Started $svc"
+    } else {
+      Write-Warn "$svc is already running"
+    }
+  }
+  Write-Host ""
+  Write-Ok "Wake complete."
+}
+
+function Invoke-Restart {
+  Write-Status "Restarting all Joidy services..."
+  docker compose restart
+  Write-Ok "All services restarted."
+}
+
+function Invoke-Status {
+  Write-Status "Joidy service status:"
+  Write-Host ""
+  docker compose ps
+}
+
+function Invoke-Logs {
+  if ($Service) {
+    docker compose logs -f $Service
+  } else {
+    docker compose logs -f
+  }
+}
+
+function Show-Help {
+  Write-Host "joidy — Manage the Joidy Docker stack"
+  Write-Host ""
+  Write-Host "Usage:"
+  Write-Host "  joidy up         Start all services (detached)"
+  Write-Host "  joidy down       Stop all services"
+  Write-Host "  joidy sleep      Stop heavy services (ai-service, worker) — hibernation"
+  Write-Host "  joidy wake       Restart heavy services from hibernation"
+  Write-Host "  joidy restart    Restart all services"
+  Write-Host "  joidy status     Show service status"
+  Write-Host "  joidy logs       Tail logs (all services)"
+  Write-Host "  joidy logs api   Tail logs for a specific service"
+  Write-Host "  joidy help       Show this help message"
+  Write-Host ""
+  Write-Host "The project directory is auto-detected from the script location."
+}
+
+switch ($Command) {
+  "up"      { Invoke-Up }
+  "down"    { Invoke-Down }
+  "sleep"   { Invoke-Sleep }
+  "wake"    { Invoke-Wake }
+  "restart" { Invoke-Restart }
+  "status"  { Invoke-Status }
+  "logs"    { Invoke-Logs }
+  "help"    { Show-Help }
+  default   { Write-Err "Unknown command: $Command"; Write-Host ""; Show-Help; exit 1 }
+}

--- a/scripts/joidy.sh
+++ b/scripts/joidy.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# joidy — CLI for managing the Joidy Docker stack.
+#
+# Installation (Linux/macOS):
+#   chmod +x scripts/joidy.sh
+#   ln -sf "$(pwd)/scripts/joidy.sh" ~/.local/bin/joidy
+#
+# Usage:
+#   joidy up       Start all services (detached)
+#   joidy down     Stop all services
+#   joidy sleep    Stop heavy services (ai-service, worker)
+#   joidy wake     Restart heavy services from hibernation
+#   joidy restart  Restart all services
+#   joidy status   Show service status
+#   joidy logs     Tail logs (all services)
+#   joidy logs api Tail logs for a specific service
+#   joidy help     Show this help message
+
+set -e
+
+# Resolve project directory from script location
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_DIR"
+
+# Services that are stopped during hibernation
+HIBERNATE_SERVICES="ai-service worker"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_status() {
+  echo -e "${BLUE}[$(date +%H:%M:%S)]${NC} $1"
+}
+
+print_ok() {
+  echo -e "${GREEN}✓${NC} $1"
+}
+
+print_warn() {
+  echo -e "${YELLOW}⚠${NC} $1"
+}
+
+print_err() {
+  echo -e "${RED}✗${NC} $1"
+}
+
+cmd_up() {
+  print_status "Starting Joidy services..."
+  docker compose up -d
+  print_status "Waiting for services to stabilize..."
+  sleep 5
+  cmd_status
+}
+
+cmd_down() {
+  print_status "Stopping all Joidy services..."
+  docker compose down
+  print_ok "All services stopped."
+}
+
+cmd_sleep() {
+  print_status "Hibernating heavy services (ai-service, worker)..."
+  for svc in $HIBERNATE_SERVICES; do
+    if docker compose ps --status running "$svc" 2>/dev/null | grep -q "$svc"; then
+      docker compose stop "$svc"
+      print_ok "Stopped $svc"
+    else
+      print_warn "$svc is already stopped"
+    fi
+  done
+  echo ""
+  print_ok "Hibernation complete. API, frontend, and database are still running."
+  echo "  Use 'joidy wake' to restart heavy services."
+}
+
+cmd_wake() {
+  print_status "Waking heavy services from hibernation..."
+  for svc in $HIBERNATE_SERVICES; do
+    if docker compose ps --status stopped "$svc" 2>/dev/null | grep -q "$svc"; then
+      docker compose start "$svc"
+      print_ok "Started $svc"
+    else
+      print_warn "$svc is already running"
+    fi
+  done
+  echo ""
+  print_ok "Wake complete."
+}
+
+cmd_restart() {
+  print_status "Restarting all Joidy services..."
+  docker compose restart
+  print_ok "All services restarted."
+}
+
+cmd_status() {
+  print_status "Joidy service status:"
+  echo ""
+  docker compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || docker compose ps
+}
+
+cmd_logs() {
+  local svc="${1:-}"
+  if [ -n "$svc" ]; then
+    docker compose logs -f "$svc"
+  else
+    docker compose logs -f
+  fi
+}
+
+cmd_help() {
+  cat <<'HELP'
+joidy — Manage the Joidy Docker stack
+
+Usage:
+  joidy up         Start all services (detached)
+  joidy down       Stop all services
+  joidy sleep      Stop heavy services (ai-service, worker) — hibernation
+  joidy wake       Restart heavy services from hibernation
+  joidy restart    Restart all services
+  joidy status     Show service status
+  joidy logs       Tail logs (all services)
+  joidy logs api   Tail logs for a specific service
+  joidy help       Show this help message
+
+The project directory is auto-detected from the script location.
+HELP
+}
+
+# Main
+case "${1:-help}" in
+  up)       cmd_up ;;
+  down)     cmd_down ;;
+  sleep)    cmd_sleep ;;
+  wake)     cmd_wake ;;
+  restart)  cmd_restart ;;
+  status)   cmd_status ;;
+  logs)     cmd_logs "${2:-}" ;;
+  help|--help|-h) cmd_help ;;
+  *)
+    print_err "Unknown command: $1"
+    echo ""
+    cmd_help
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

- **CLI** (`scripts/joidy.sh` / `scripts/joidy.ps1`): cross-platform commands `up`, `down`, `sleep`, `wake`, `restart`, `status`, `logs`
- **Auto-start** (`scripts/install-autostart.sh` / `.ps1`): systemd user service (Linux) + Task Scheduler (Windows), both with `--remove` option
- **Backend** (`api/routers/system.py`): 4 endpoints for power status/sleep/wake/shutdown using `aiodocker` + Docker socket
- **Frontend** (SettingsPanel): "Power & System" section with service status indicators, hibernate/wake/shutdown buttons, and i18n (en/es)
- **Docker socket** mounted in `docker-compose.yml` with configurable `DOCKER_GID`

### Hibernation mode
- **Sleep**: stops `ai-service` + `worker` only — API, frontend, and postgres keep running so the web UI stays accessible
- **Wake**: restarts the stopped services
- **Shutdown**: stops frontend + ai-service + worker (postgres + api remain so the response can be sent). User must run `joidy up` to restart.

Closes #727

#### Test plan

- [ ] `joidy up` starts all services
- [ ] `joidy sleep` stops ai-service + worker, api/frontend/postgres stay up
- [ ] `joidy wake` restarts ai-service + worker
- [ ] `joidy down` stops everything
- [ ] `joidy status` shows correct service states
- [ ] `joidy logs` / `joidy logs api` tails logs
- [ ] Settings panel shows service status with health badges
- [ ] Hibernate button from web UI stops heavy services
- [ ] Wake button from web UI restarts heavy services
- [ ] Shutdown button from web UI stops services (with confirmation)
- [ ] `install-autostart.sh` creates systemd service that starts on login
- [ ] `install-autostart.ps1` creates Task Scheduler task on Windows
- [ ] `npm run check` passes with 0 errors
- [ ] `python -m compileall api/` passes

Generated with [Devin](https://devin.ai)