### PR TITLE
fix: resolve power management runtime bugs (aiodocker API, project filter, CLI wake)

### DIFF
--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -29,7 +29,12 @@ ALL_SERVICES = {"ai-service", "worker", "frontend", "api", "postgres"}
 # postgres and api are kept so the response can be sent and data isn't lost.
 SHUTDOWN_SERVICES = ["frontend", "ai-service", "worker"]
 
+# The compose project name is auto-detected from the container labels at
+# runtime (see _get_compose_project). We only manage containers that belong
+# to the same compose project as the API container itself.
+
 _docker_client = None
+_project_name: str | None = None
 
 
 async def get_docker():
@@ -65,9 +70,53 @@ class PowerActionResponse(BaseModel):
     affected: list[str] = []
 
 
-def _get_compose_service(container: dict) -> str | None:
+def _container_dict(container) -> dict:
+    """Get the raw dict from a DockerContainer or pass through if already a dict."""
+    if isinstance(container, dict):
+        return container
+    # aiodocker's DockerContainer stores the raw API response in _container
+    return getattr(container, "_container", container)
+
+
+def _get_compose_project(container) -> str | None:
+    """Extract the Docker Compose project name from container labels."""
+    data = _container_dict(container)
+    labels = data.get("Labels") or {}
+    if isinstance(labels, dict):
+        return labels.get("com.docker.compose.project")
+    return None
+
+
+async def _detect_project_name(docker) -> str | None:
+    """Detect the compose project name from the current (API) container.
+
+    We find the API container by looking for the service name "api"
+    that is currently running. This avoids managing containers from
+    other compose projects on the same host.
+    """
+    global _project_name
+    if _project_name is not None:
+        return _project_name
+    try:
+        containers = await docker.containers.list(all=True)
+        for c in containers:
+            data = _container_dict(c)
+            labels = data.get("Labels") or {}
+            if isinstance(labels, dict):
+                svc = labels.get("com.docker.compose.service")
+                state = data.get("State")
+                if svc == "api" and state == "running":
+                    _project_name = labels.get("com.docker.compose.project")
+                    return _project_name
+    except Exception:
+        pass
+    return None
+
+
+def _get_compose_service(container) -> str | None:
     """Extract the Docker Compose service name from container labels."""
-    labels = container.get("Labels") or {}
+    data = _container_dict(container)
+    labels = data.get("Labels") or {}
     if isinstance(labels, dict):
         return labels.get("com.docker.compose.service")
     # Docker API returns labels as a list of "key=value" strings in some versions
@@ -78,20 +127,22 @@ def _get_compose_service(container: dict) -> str | None:
     return None
 
 
-def _get_container_name(container: dict) -> str:
+def _get_container_name(container) -> str:
     """Get the container name without the leading slash."""
-    names = container.get("Names") or []
+    data = _container_dict(container)
+    names = data.get("Names") or []
     if names:
         return names[0].lstrip("/")
-    return container.get("Id", "unknown")[:12]
+    return data.get("Id", "unknown")[:12]
 
 
-def _parse_health(container: dict) -> bool | None:
+def _parse_health(container) -> bool | None:
     """Parse health status from the Docker API list response.
 
     Returns True (healthy), False (unhealthy), or None (no healthcheck).
     """
-    health = container.get("Health")
+    data = _container_dict(container)
+    health = data.get("Health")
     if health and isinstance(health, dict):
         status = health.get("Status")
         if status == "healthy":
@@ -102,7 +153,7 @@ def _parse_health(container: dict) -> bool | None:
         return None
 
     # Fallback: parse the Status string (e.g., "Up 2 hours (healthy)")
-    status_str = container.get("Status", "")
+    status_str = data.get("Status", "")
     if "(healthy)" in status_str:
         return True
     if "(unhealthy)" in status_str:
@@ -131,12 +182,21 @@ async def get_power_status(_=Depends(get_current_user)):
             hibernating=False,
         )
 
-    # Filter to Joidy containers by compose service label
+    # Detect the compose project name from the running API container
+    project = await _detect_project_name(docker)
+
+    # Filter to Joidy containers by compose service label AND project name
     joidy_containers = []
     for c in containers:
         svc = _get_compose_service(c)
-        if svc and svc in ALL_SERVICES:
-            joidy_containers.append((svc, c))
+        if not svc or svc not in ALL_SERVICES:
+            continue
+        # Only include containers from the same compose project
+        if project:
+            c_project = _get_compose_project(c)
+            if c_project != project:
+                continue
+        joidy_containers.append((svc, c))
 
     # Sort by a fixed order for consistent display
     service_order = ["postgres", "api", "ai-service", "worker", "frontend"]
@@ -146,7 +206,8 @@ async def get_power_status(_=Depends(get_current_user)):
     hibernating = False
 
     for svc_name, c in joidy_containers:
-        state = c.get("State", "unknown")
+        data = _container_dict(c)
+        state = data.get("State", "unknown")
         status = "running" if state == "running" else "stopped"
         healthy = _parse_health(c) if status == "running" else None
 
@@ -162,6 +223,28 @@ async def get_power_status(_=Depends(get_current_user)):
     )
 
 
+async def _get_project_containers(docker, service_filter: set[str] | None = None):
+    """List containers belonging to the current compose project.
+
+    Returns a list of (service_name, container) tuples.
+    """
+    project = await _detect_project_name(docker)
+    containers = await docker.containers.list(all=True)
+    result = []
+    for c in containers:
+        svc = _get_compose_service(c)
+        if not svc:
+            continue
+        if service_filter and svc not in service_filter:
+            continue
+        if project:
+            c_project = _get_compose_project(c)
+            if c_project != project:
+                continue
+        result.append((svc, c))
+    return result
+
+
 @router.post("/sleep", response_model=PowerActionResponse)
 async def hibernate_services(_=Depends(get_current_user)):
     """Stop heavy services (ai-service, worker) to save resources.
@@ -171,10 +254,7 @@ async def hibernate_services(_=Depends(get_current_user)):
         raise HTTPException(status_code=503, detail="Docker socket not available. Use the CLI instead.")
 
     affected: list[str] = []
-    for c in await docker.containers.list(all=True):
-        svc = _get_compose_service(c)
-        if svc not in HIBERNATE_SERVICES:
-            continue
+    for svc, c in await _get_project_containers(docker, HIBERNATE_SERVICES):
         try:
             container_name = _get_container_name(c)
             container = await docker.containers.get(container_name)
@@ -201,10 +281,7 @@ async def wake_services(_=Depends(get_current_user)):
         raise HTTPException(status_code=503, detail="Docker socket not available. Use the CLI instead.")
 
     affected: list[str] = []
-    for c in await docker.containers.list(all=True):
-        svc = _get_compose_service(c)
-        if svc not in HIBERNATE_SERVICES:
-            continue
+    for svc, c in await _get_project_containers(docker, HIBERNATE_SERVICES):
         try:
             container_name = _get_container_name(c)
             container = await docker.containers.get(container_name)
@@ -233,10 +310,8 @@ async def shutdown_services(_=Depends(get_current_user)):
 
     # Build a map of compose service name → container name
     svc_to_container_name: dict[str, str] = {}
-    for c in await docker.containers.list(all=True):
-        svc = _get_compose_service(c)
-        if svc and svc in SHUTDOWN_SERVICES:
-            svc_to_container_name[svc] = _get_container_name(c)
+    for svc, c in await _get_project_containers(docker, set(SHUTDOWN_SERVICES)):
+        svc_to_container_name[svc] = _get_container_name(c)
 
     affected: list[str] = []
     for svc_name in SHUTDOWN_SERVICES:

--- a/scripts/install-autostart.ps1
+++ b/scripts/install-autostart.ps1
@@ -11,7 +11,6 @@ param(
 $TaskName = "Joidy"
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ProjectDir = Split-Path -Parent $ScriptDir
-$StartupScript = Join-Path $ScriptDir "joidy_startup.sh"
 
 if ($Remove) {
   Write-Host "Removing Joidy auto-start task..."
@@ -28,13 +27,11 @@ if ($Remove) {
 Write-Host "Setting up Joidy auto-start via Windows Task Scheduler..."
 
 # Check if running on Windows
-if ($PSVersionTable.Platform -ne "Win32NT" -and -not $env:OS.Contains("Windows")) {
+$osEnv = $env:OS
+if ($PSVersionTable.Platform -ne "Win32NT" -and (-not $osEnv -or -not $osEnv.Contains("Windows"))) {
   Write-Host "⚠ This script is for Windows. For Linux, use install-autostart.sh"
   exit 1
 }
-
-# Find docker compose startup command
-$DockerComposeCmd = "docker compose up -d"
 
 # Create the scheduled task action
 $Action = New-ScheduledTaskAction `

--- a/scripts/joidy.ps1
+++ b/scripts/joidy.ps1
@@ -54,7 +54,7 @@ function Invoke-Down {
 function Invoke-Sleep {
   Write-Status "Hibernating heavy services (ai-service, worker)..."
   foreach ($svc in $HIBERNATE_SERVICES) {
-    $running = docker compose ps --status running $svc 2>$null
+    $running = docker compose ps $svc 2>$null
     if ($running -match $svc) {
       docker compose stop $svc
       Write-Ok "Stopped $svc"
@@ -70,12 +70,17 @@ function Invoke-Sleep {
 function Invoke-Wake {
   Write-Status "Waking heavy services from hibernation..."
   foreach ($svc in $HIBERNATE_SERVICES) {
-    $stopped = docker compose ps --status stopped $svc 2>$null
-    if ($stopped -match $svc) {
-      docker compose start $svc
-      Write-Ok "Started $svc"
+    $all = docker compose ps -a $svc 2>$null
+    if ($all -match $svc) {
+      $running = docker compose ps $svc 2>$null
+      if ($running -match $svc) {
+        Write-Warn "$svc is already running"
+      } else {
+        docker compose start $svc
+        Write-Ok "Started $svc"
+      }
     } else {
-      Write-Warn "$svc is already running"
+      Write-Warn "$svc container not found"
     }
   }
   Write-Host ""

--- a/scripts/joidy.sh
+++ b/scripts/joidy.sh
@@ -67,7 +67,8 @@ cmd_down() {
 cmd_sleep() {
   print_status "Hibernating heavy services (ai-service, worker)..."
   for svc in $HIBERNATE_SERVICES; do
-    if docker compose ps --status running "$svc" 2>/dev/null | grep -q "$svc"; then
+    # Check if the service is running by looking at docker compose ps output
+    if docker compose ps "$svc" 2>/dev/null | grep -q "$svc"; then
       docker compose stop "$svc"
       print_ok "Stopped $svc"
     else
@@ -82,11 +83,16 @@ cmd_sleep() {
 cmd_wake() {
   print_status "Waking heavy services from hibernation..."
   for svc in $HIBERNATE_SERVICES; do
-    if docker compose ps --status stopped "$svc" 2>/dev/null | grep -q "$svc"; then
-      docker compose start "$svc"
-      print_ok "Started $svc"
+    # Check if the service is NOT running (use -a to include stopped containers)
+    if docker compose ps -a "$svc" 2>/dev/null | grep -q "$svc"; then
+      if docker compose ps "$svc" 2>/dev/null | grep -q "$svc"; then
+        print_warn "$svc is already running"
+      else
+        docker compose start "$svc"
+        print_ok "Started $svc"
+      fi
     else
-      print_warn "$svc is already running"
+      print_warn "$svc container not found"
     fi
   done
   echo ""


### PR DESCRIPTION
## Summary

- **aiodocker API fix**: DockerContainer objects are not plain dicts — `container.get()` and `"key" in container` caused `AttributeError`/`KeyError`. Added `_container_dict()` helper to extract the raw API dict.
- **Project filtering**: Status/sleep/wake/shutdown now filter containers by the current compose project name (auto-detected from the running API container's labels), preventing duplicate entries from other projects on the same host.
- **CLI wake fix**: `docker compose ps --status stopped` doesn't work in Compose v2. Changed to compare `ps -a` (all) vs `ps` (running only) in both `joidy.sh` and `joidy.ps1`.
- **Dead code cleanup**: Removed unused variables in `install-autostart.ps1`; fixed null-safe platform check.

### Test results (Linux)

| Test | Result |
|------|--------|
| `joidy.sh status` | ✅ Shows 5 services correctly |
| `joidy.sh sleep` | ✅ Stops ai-service + worker, others stay up |
| `joidy.sh wake` | ✅ Starts stopped ai-service + worker |
| `joidy.sh up` | ✅ Starts all services |
| `GET /system/power/status` | ✅ Returns 5 services, no duplicates, correct health |
| `POST /system/power/sleep` | ✅ Hibernates 2 services, `hibernating: true` |
| `POST /system/power/wake` | ✅ Wakes 2 services, `hibernating: false` |
| `POST /system/power/shutdown` | ✅ Stops frontend+ai+worker, api+postgres stay |
| `install-autostart.sh` install/remove | ✅ systemd service created and removed |
| `npm run check` | ✅ 0 errors |
| `python -m compileall` | ✅ Passes |

Closes #730

#### Test plan

- [ ] CI passes (all 5 checks)
- [ ] `joidy.sh status` shows correct services
- [ ] `joidy.sh sleep` + `joidy.sh wake` cycle works
- [ ] API `/system/power/status` returns only current-project containers
- [ ] API `/system/power/sleep` stops only current-project services
- [ ] API `/system/power/wake` starts only current-project services
- [ ] API `/system/power/shutdown` stops only current-project services
- [ ] `joidy.ps1` wake logic matches `joidy.sh` (theoretical review)
- [ ] `install-autostart.ps1` has no dead variables

Generated with [Devin](https://devin.ai)