### PR TITLE
docs: update integrations status table in AGENTS.md (#756)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,12 +63,12 @@ Port overrides: `FRONTEND_PORT`, `API_PORT`, `AI_SERVICE_PORT`, `WORKER_PORT`.
 |-------------|---------|----------|-------|
 | **Gemini AI** | ✅ `ai-service` | ⚠️ Placeholder UI | #41 |
 | **GitHub** | ✅ `auth/github` | ✅ Unified integrations page | #120 |
-| **Gmail** | ❌ None | ❌ None | #42 |
-| **Contacts** | ❌ None | ❌ None | #43 |
-| **Strava** | ❌ None | ❌ None | #44 |
-| **Spotify** | ❌ None | ❌ None | #45 |
-| **G Calendar**| ❌ None | ❌ None | #2 |
-| **G Tasks** | ❌ None | ❌ None | #2 |
+| **Google Calendar** | ⚠️ `integrations/google` scaffold | ⚠️ Partial | #2 |
+| **Google Tasks** | ⚠️ `integrations/google` scaffold | ⚠️ Partial | #2 |
+| **Gmail** | ❌ None (Google OAuth scaffold only) | ❌ None | #42 |
+| **Contacts** | ❌ None (Google OAuth scaffold only) | ❌ None | #43 |
+| **Strava** | ⚠️ `integrations/strava` scaffold | ❌ None | #44 |
+| **Spotify** | ⚠️ `integrations/spotify` scaffold | ❌ None | #45 |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Updates the integrations status table in `AGENTS.md` to reflect the actual scaffold state of backend code, replacing the outdated `❌ None` markers with a three-state indicator (`✅` / `⚠️ scaffold` / `❌ none`).

### Changes

| Integration | Before | After |
|-------------|--------|-------|
| Google Calendar | ❌ None | ⚠️ `integrations/google` scaffold |
| Google Tasks | ❌ None | ⚠️ `integrations/google` scaffold |
| Strava | ❌ None | ⚠️ `integrations/strava` scaffold |
| Spotify | ❌ None | ⚠️ `integrations/spotify` scaffold |
| Gmail | ❌ None | ❌ None (Google OAuth scaffold only) |
| Contacts | ❌ None | ❌ None (Google OAuth scaffold only) |

The table now accurately reflects that `api/routers/integrations/google.py`, `spotify.py`, and `strava.py` (plus their service stubs) exist as scaffold code, while Gmail and Contacts have no dedicated backend beyond the shared Google OAuth token management.

Closes #756

#### Test plan
- [x] `AGENTS.md` integrations table matches actual files in `api/routers/integrations/` and `api/services/`
- [x] No integration is listed as `❌ None` backend when its router+service files exist
- [x] Gmail and Contacts correctly show `❌ None` (no dedicated router/service)

Generated with [Devin](https://devin.ai)