### PR TITLE
docs: fix QUICKSTART.md step 6 — point to Settings integrations (#757)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -101,7 +101,7 @@ graph LR
 2. Si es la primera vez, elige contraseña maestra o accede con la configurada en `.env`.
 3. Crea una nota desde `/notes`.
 4. Crea una racha desde `/streaks`.
-5. Explora el dashboard y las integraciones en `/integraciones`.
+5. Abre Ajustes y configura tus integraciones en la sección "Integraciones".
 
 ## 7. Desarrollo sin Docker (no recomendado)
 


### PR DESCRIPTION
## Summary

`QUICKSTART.md` step 6 told users to explore integrations at the `/integraciones` route, which does not exist. The frontend routes are: `ai`, `goals`, `graph`, `notes`, `skills`, `streaks`, `offline`. The integrations UI lives inside `SettingsPanel.svelte` (the "Integraciones" section), not on a dedicated route.

### Change

Updated step 5 of "Primeros pasos en la app":
- **Before**: `Explora el dashboard y las integraciones en /integraciones.`
- **After**: `Abre Ajustes y configura tus integraciones en la sección "Integraciones".`

Verified no other docs reference the non-existent `/integraciones` route (`grep -rn '/integraciones' docs/ QUICKSTART.md README.md` returns 0 matches).

Closes #757

#### Test plan
- [x] `QUICKSTART.md` step 6 no longer references `/integraciones`
- [x] Step 6 points to Settings → Integraciones section
- [x] `grep -rn 'integraciones' docs/ QUICKSTART.md README.md` returns no route references

Generated with [Devin](https://devin.ai)