### PR TITLE
chore: align version strings to 0.2.0 + automate future bumps (#754)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag (e.g. v0.1.0-alpha.5, v1.0.0). Leave empty to auto-bump.'
+        description: 'Version tag (e.g. v0.2.0, v0.2.1-alpha.1). Leave empty to auto-bump.'
         required: false
         default: ''
       prerelease:
-        description: 'Mark as pre-release (alpha/non-production ready)'
+        description: 'Mark as pre-release (alpha/beta/rc)'
         type: boolean
         required: false
         default: true
@@ -28,31 +28,33 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine version
         id: version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
             VERSION="${{ inputs.version }}"
           else
-            # Auto-bump: find latest alpha tag and increment.
-            # While in alpha, every merge to main produces v1.0.0-alpha.<N>.
-            # The initial release was v1.0.0-alpha (no number); subsequent
-            # releases get a numeric suffix to keep them sortable.
-            LATEST=$(git tag -l 'v1.0.0-alpha*' | sort -V | tail -1)
+            # Auto-bump: find latest semver tag and increment the patch version.
+            # Pre-release tags (alpha/beta/rc) are skipped when looking for
+            # the latest stable release to bump from.
+            LATEST=$(git tag -l 'v[0-9]*' | grep -v '-' | sort -V | tail -1)
             if [ -z "$LATEST" ]; then
-              VERSION="v1.0.0-alpha.1"
-            elif [ "$LATEST" = "v1.0.0-alpha" ]; then
-              VERSION="v1.0.0-alpha.1"
+              VERSION="v0.1.0"
             else
-              N=$(echo "$LATEST" | sed 's/.*alpha\.\([0-9]*\)/\1/')
-              N=$((N + 1))
-              VERSION="v1.0.0-alpha.${N}"
+              # Strip leading 'v' and bump patch
+              BASE="${LATEST#v}"
+              MAJOR=$(echo "$BASE" | cut -d. -f1)
+              MINOR=$(echo "$BASE" | cut -d. -f2)
+              PATCH=$(echo "$BASE" | cut -d. -f3)
+              PATCH=$((PATCH + 1))
+              VERSION="v${MAJOR}.${MINOR}.${PATCH}"
             fi
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          VERSION_CLEAN="${VERSION#v}"
+          echo "version_clean=${VERSION_CLEAN}" >> "$GITHUB_OUTPUT"
           # Auto-detect prerelease: anything with a hyphen suffix (alpha/beta/rc)
           # is a pre-release. Manual dispatch can override via input.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -65,18 +67,65 @@ jobs:
           fi
           echo "prerelease=${PRERELEASE}" >> "$GITHUB_OUTPUT"
 
+      - name: Bump version strings
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          VERSION_CLEAN="${{ steps.version.outputs.version_clean }}"
+          TODAY=$(date +%Y-%m-%d)
+
+          # README badge
+          sed -i "s|badge/JOIDY-v[0-9a-z.\-]*-[0-9A-Fa-f]*|badge/JOIDY-v${VERSION_CLEAN}|" README.md
+
+          # AUR PKGBUILD
+          sed -i "s|^pkgver=.*|pkgver=${VERSION_CLEAN}|" aur/PKGBUILD
+          sed -i "s|archive/v[0-9a-z.\-]*\.tar\.gz|archive/v${VERSION_CLEAN}.tar.gz|" aur/PKGBUILD
+
+          # AUR .SRCINFO
+          sed -i "s|^pkgver = .*|pkgver = ${VERSION_CLEAN}|" aur/.SRCINFO
+          sed -i "s|archive/v[0-9a-z.\-]*\.tar\.gz|archive/v${VERSION_CLEAN}.tar.gz|" aur/.SRCINFO
+
+          # docs metadata (index.md, api.md, architecture.md)
+          for f in docs/index.md docs/api.md docs/architecture.md; do
+            [ -f "$f" ] && sed -i "s|^version: [0-9a-z.\-]*|version: ${VERSION_CLEAN}|" "$f"
+          done
+
+          # docs/troubleshooting.md
+          sed -i "s|^last_updated: .*|last_updated: ${TODAY}|" docs/troubleshooting.md
+          sed -i "s|^version: [0-9a-z.\-]*|version: ${VERSION_CLEAN}|" docs/troubleshooting.md
+
+          # CHANGELOG.md: move [Unreleased] body to new version section
+          # This is handled manually for major releases; for auto-bump
+          # patch releases the [Unreleased] section stays as-is and the
+          # new tag is referenced at the bottom.
+          # Update compare links
+          sed -i "s|\[unreleased\]: .*/compare/v[0-9a-z.\-]*\.\.\.HEAD|[unreleased]: https://github.com/Axel-DaMage/joidy/compare/v${VERSION_CLEAN}...HEAD|" CHANGELOG.md
+
+          # Show what changed
+          git diff --stat
+
+      - name: Commit version bump
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add -A
+          if ! git diff --quiet --cached; then
+            git commit -m "chore: bump version strings to ${VERSION}"
+            git push
+          fi
+
       - name: Create tag and release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           PRERELEASE="${{ steps.version.outputs.prerelease }}"
-          # Tag the commit that triggered the workflow.
+          # Tag the commit with the version bump.
           git tag "$VERSION"
           git push origin "$VERSION"
           ARGS=(--title "Joidy ${VERSION}" --generate-notes --verify-tag)
           if [ "$PRERELEASE" = "true" ]; then
-            PREPEND=$(printf '## ⚠️ Alpha — Non-Production Ready\n\nThis is an **alpha** pre-release. Expect breaking changes, bugs, and incomplete features. Do **not** use in production.\n\n')
+            PREPEND=$(printf '## ⚠️ Pre-Release — Non-Production Ready\n\nThis is a **pre-release**. Expect breaking changes, bugs, and incomplete features. Do **not** use in production.\n\n')
             ARGS+=(--prerelease --notes-prepend "$PREPEND")
           fi
           gh release create "$VERSION" "${ARGS[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- _Nothing yet_
+
+### Changed
+
+- _Nothing yet_
+
+### Fixed
+
+- _Nothing yet_
+
+### Removed
+
+- _Nothing yet_
+
+### Security
+
+- _Nothing yet_
+
+## [0.2.0] - 2026-08-16
+
+### Added
+
 - **Security hardening**: JWT auth enforced on all data/mutation endpoints, API keys/secrets exposure fixed, XSS & input sanitization, CORS & WebSocket auth, ai-service hardening, all containers run as non-root user (#322, #323, #324, #325, #326, #327, #329, #358, #376, #377, #378, #379, #380, #397, #408, #416, #417, #418, #419, #422, #423)
 - **Google Calendar & Tasks OAuth integration** (#2, #374)
 - **WYSIWYG markdown editor** with TipTap (#6, #344)
@@ -123,5 +145,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Responsive base layout and mobile streak actions.
 - CI pipeline: API tests, frontend typecheck, Docker build smoke test.
 
-[unreleased]: https://github.com/Axel-DaMage/joidy/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/Axel-DaMage/joidy/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Axel-DaMage/joidy/releases/tag/v0.2.0
 [0.1.0]: https://github.com/Axel-DaMage/joidy/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/JOIDY-v1.0.0--alpha-8B5CF6?style=for-the-badge" alt="Joidy">
+  <img src="https://img.shields.io/badge/JOIDY-v0.2.0-8B5CF6?style=for-the-badge" alt="Joidy">
 </p>
 
 <p align="center">

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,11 +6,11 @@ Joidy follows [Semantic Versioning 2.0.0](https://semver.org/lang/es/) (`MAJOR.M
 
 | Level | When to bump | Example |
 |-------|--------------|---------|
-| **MAJOR** | Breaking changes in API, storage format, or configuration | `v2.0.0` |
-| **MINOR** | New features, integrations, or non-breaking UI changes | `v1.3.0` |
-| **PATCH** | Bug fixes, docs, security patches, refactorings | `v1.3.1` |
+| **MAJOR** | Breaking changes in API, storage format, or configuration | `v1.0.0` |
+| **MINOR** | New features, integrations, or non-breaking UI changes | `v0.3.0` |
+| **PATCH** | Bug fixes, docs, security patches, refactorings | `v0.2.1` |
 
-Pre-release versions use a suffix: `v1.4.0-alpha.1`, `v1.4.0-beta.2`, `v1.4.0-rc.1`.
+Pre-release versions use a suffix: `v0.3.0-alpha.1`, `v0.3.0-beta.2`, `v0.3.0-rc.1`.
 
 ## Branch strategy
 
@@ -22,17 +22,37 @@ Release branches are not required for this project; tags on `main` are enough.
 
 ## Release steps
 
+### Automated (default)
+
+1. Merge `development` into `main` via PR.
+2. The `.github/workflows/release.yml` workflow triggers automatically on push to `main`.
+3. It auto-determines the next version (patch bump from latest stable tag), bumps all version strings (README badge, AUR `PKGBUILD`/`.SRCINFO`, `docs/*.md` metadata, `CHANGELOG.md` compare links), commits the bump, tags it, and creates the GitHub Release.
+4. The `.github/workflows/publish.yml` triggers on `release: published` and builds Docker images, Homebrew formula, and AUR package.
+
+### Manual (for minor/major releases or pre-releases)
+
 1. Make sure `main` is green (CI passes).
-2. Update `CHANGELOG.md` with the new version.
-3. Create and push a signed tag:
-   ```bash
-   git checkout main
-   git pull
-   git tag -a vX.Y.Z -m "Release vX.Y.Z"
-   git push origin vX.Y.Z
-   ```
-4. The `.github/workflows/release.yml` workflow will create the GitHub Release automatically.
-5. The existing `.github/workflows/publish.yml` triggers on `release: published` and builds Docker images, Homebrew formula, and AUR package.
+2. Update `CHANGELOG.md`: move `[Unreleased]` body to a new `[X.Y.Z] - YYYY-MM-DD` section, add a fresh empty `[Unreleased]`.
+3. Trigger the release workflow manually via `workflow_dispatch` with the desired version tag (e.g. `v0.3.0`, `v0.3.0-alpha.1`).
+4. The workflow bumps version strings, commits, tags, and creates the release.
+5. `publish.yml` handles Docker/Homebrew/AUR publishing automatically.
+
+## Version string automation
+
+The `release.yml` workflow automatically updates version strings in these files when a release is created:
+
+| File | What gets updated |
+|------|-------------------|
+| `README.md` | Badge version (`JOIDY-vX.Y.Z`) |
+| `aur/PKGBUILD` | `pkgver` and `source` URL |
+| `aur/.SRCINFO` | `pkgver` and `source` URL |
+| `docs/index.md` | Metadata `version` |
+| `docs/api.md` | Metadata `version` |
+| `docs/architecture.md` | Metadata `version` |
+| `docs/troubleshooting.md` | `last_updated` and `version` |
+| `CHANGELOG.md` | `[unreleased]` compare link |
+
+For minor/major releases, `CHANGELOG.md` section management (moving `[Unreleased]` to a versioned section) should still be done manually before triggering the release.
 
 ## Changelog format
 
@@ -47,5 +67,5 @@ Release branches are not required for this project; tags on `main` are enough.
 
 ## Release automation
 
-- `release.yml` — creates a GitHub Release and generates notes from merged PRs.
+- `release.yml` — auto-determines version, bumps version strings, creates tag and GitHub Release with generated notes.
 - `publish.yml` — publishes Docker images, Homebrew tap, and AUR package after a release is published.

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -1,11 +1,11 @@
 pkgbase = joidy
 pkgdesc = Personal knowledge management with gamification
-pkgver = 1.0.0
+pkgver = 0.2.0
 pkgrel = 1
 url = https://joidy-web.vercel.app
 arch = any
 license = GPL3
 depends = docker
-source = https://github.com/Axel-DaMage/joidy/archive/v1.0.0.tar.gz
+source = https://github.com/Axel-DaMage/joidy/archive/v0.2.0.tar.gz
 sha256sums = SKIP
 pkgname = joidy

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Joidy App <https://github.com/Axel-DaMage/joidy>
 pkgname=joidy
-pkgver=1.0.0
+pkgver=0.2.0
 _tag=${pkgver}
 pkgrel=1
 pkgdesc="Personal knowledge management with gamification"

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 ```yaml
-version: 0.1.0
+version: 0.2.0
 base_url: http://localhost:8000
 docs_url: http://localhost:8000/docs
 framework: FastAPI

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 ```yaml
 project: Joidy
 type: Sistema de Gestión del Conocimiento con Gamificación
-version: 0.1.0
+version: 0.2.0
 framework: Monorepo Docker
 services: 4
 database: PostgreSQL 16 + pgvector

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 ```yaml
 project: Joidy
 type: Sistema de Gestión del Conocimiento con Gamificación
-version: 0.1.0
+version: 0.2.0
 framework: Monorepo Docker
 docs_version: 2.0
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,8 +3,8 @@
 ## Metadata
 
 ```yaml
-last_updated: 2024
-version: 1.0
+last_updated: 2026-08-16
+version: 0.2.0
 ```
 
 ---


### PR DESCRIPTION
## Summary

Aligns all version strings across the repo to `0.2.0` and adds automated version string bumping to the release workflow so future releases no longer require manual updates.

### Version strings aligned

| File | Before | After |
|------|--------|-------|
| `README.md` badge | `JOIDY-v1.0.0--alpha` | `JOIDY-v0.2.0` |
| `aur/PKGBUILD` `pkgver` | `1.0.0` | `0.2.0` |
| `aur/PKGBUILD` `source` | `v1.0.0.tar.gz` | `v0.2.0.tar.gz` |
| `aur/.SRCINFO` `pkgver` | `1.0.0` | `0.2.0` |
| `aur/.SRCINFO` `source` | `v1.0.0.tar.gz` | `v0.2.0.tar.gz` |
| `docs/index.md` `version` | `0.1.0` | `0.2.0` |
| `docs/api.md` `version` | `0.1.0` | `0.2.0` |
| `docs/architecture.md` `version` | `0.1.0` | `0.2.0` |
| `docs/troubleshooting.md` `last_updated` | `2024` | `2026-08-16` |
| `docs/troubleshooting.md` `version` | `1.0` | `0.2.0` |
| `CHANGELOG.md` | `[Unreleased]` only | `[0.2.0] - 2026-08-16` + fresh `[Unreleased]` + compare links |

### Automation added to `release.yml`

- **Auto-bump** now uses real semver (patch bump from latest stable tag) instead of the old `v1.0.0-alpha.N` scheme
- **New "Bump version strings" step** automatically updates: README badge, AUR `PKGBUILD`/`.SRCINFO`, `docs/*.md` metadata, `docs/troubleshooting.md` `last_updated`, and `CHANGELOG.md` compare links
- Version bump is **committed and pushed** before tagging, so the tag always points at a commit with correct version strings
- `RELEASE.md` updated to document the automated vs manual release flow

Closes #754

#### Test plan
- [x] `grep -rn "1\.0\.0\|v1\.0\.0" README.md aur/ docs/ CHANGELOG.md` returns no stale version strings
- [x] `aur/PKGBUILD` and `aur/.SRCINFO` both use `0.2.0` and `v0.2.0.tar.gz`
- [x] `CHANGELOG.md` has `[0.2.0] - 2026-08-16` followed by an empty `[Unreleased]`
- [x] All `docs/*.md` metadata `version` fields read `0.2.0`
- [x] `docs/troubleshooting.md` `last_updated` is `2026-08-16`
- [x] README badge renders `v0.2.0`
- [x] `release.yml` sed patterns match the current file formats
- [ ] CI green on this PR

Generated with [Devin](https://devin.ai)