### PR TITLE
docs: complete docs/index.md table of contents (#758)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,8 @@ Joidy es un sistema personal de gestión del conocimiento que integra:
 
 ## Índice de Documentación
 
+### Documentación Principal
+
 | # | Documento | Descripción |
 |---|-----------|-------------|
 | 1 | [Arquitectura](architecture.md) | Visión general del sistema, servicios, base de datos y comunicación |
@@ -38,6 +40,23 @@ Joidy es un sistema personal de gestión del conocimiento que integra:
 | 8 | [Gamificación](gamification.md) | XP, niveles, rachas, planta, milestones |
 | 9 | [Desarrollo](development.md) | Guía para desarrolladores |
 | 10 | [Troubleshooting](troubleshooting.md) | Errores comunes y soluciones |
+
+### Guías y Referencias
+
+| # | Documento | Descripción |
+|---|-----------|-------------|
+| 11 | [Accesibilidad](A11Y.md) | Criterios WCAG 2.1 AA, patrones a11y aplicados en el frontend |
+| 12 | [Internacionalización](I18N.md) | Estado actual del i18n y estrategia para multi-idioma |
+| 13 | [Guía de Estilo](STYLE_GUIDE.md) | Convenciones de código para frontend y backend |
+| 14 | [Monitoring](MONITORING.md) | Métricas Prometheus, endpoint `/metrics`, Grafana |
+| 15 | [Comunidad](COMMUNITY.md) | Canales de participación, contribuciones, código de conducta |
+| 16 | [Real-Time & Security](realtime-security.md) | WebSockets, error handling, rate limiting, seguridad |
+
+### Architecture Decision Records
+
+| # | Documento | Descripción |
+|---|-----------|-------------|
+| 17 | [ADRs](adr/README.md) | Índice de Architecture Decision Records (0001–0006) |
 
 ---
 


### PR DESCRIPTION
## Summary

`docs/index.md` listed only 10 documents but `docs/` contains several more files not indexed. This PR adds rows for every missing `docs/*.md` file and an ADR entry, organized into three groups.

### Changes

Added 7 missing entries, organized into two new sections:

**Guías y Referencias** (new section):
| # | Document | Description |
|---|----------|-------------|
| 11 | A11Y.md | WCAG 2.1 AA criteria, a11y patterns in frontend |
| 12 | I18N.md | Current i18n state and multi-language strategy |
| 13 | STYLE_GUIDE.md | Code conventions for frontend and backend |
| 14 | MONITORING.md | Prometheus metrics, `/metrics` endpoint, Grafana |
| 15 | COMMUNITY.md | Participation channels, contributions, code of conduct |
| 16 | realtime-security.md | WebSockets, error handling, rate limiting, security |

**Architecture Decision Records** (new section):
| # | Document | Description |
|---|----------|-------------|
| 17 | adr/README.md | ADR index (0001–0006) |

The existing 10 rows are preserved under "Documentación Principal".

Closes #758

#### Test plan
- [x] Every `docs/*.md` file (excluding `index.md` and `ARCHITECTURE_DECISIONS.md` which is legacy) has a row in `docs/index.md`
- [x] ADRs are linked via `adr/README.md`
- [x] `ls docs/*.md` count (16 excluding index.md + ARCHITECTURE_DECISIONS.md) + 1 ADR = 17 doc rows in the index

Generated with [Devin](https://devin.ai)