### PR TITLE
fix(frontend): swap streaks and goals order in sidebar nav (#773)

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -71,8 +71,8 @@
     { href: '/graph', label: $t('nav.graph'), icon: 'Network', status: 'dev' },
     { href: '/skills', label: $t('nav.skills'), icon: 'Zap', status: 'dev' },
     { href: '/ai', label: $t('nav.ai'), icon: 'Brain', status: 'dev' },
-    { href: '/goals', label: $t('nav.goals'), icon: 'Target', status: 'ready' },
     { href: '/streaks', label: $t('nav.streaks'), icon: 'Flame', status: 'ready' },
+    { href: '/goals', label: $t('nav.goals'), icon: 'Target', status: 'ready' },
   ] as { href: string; label: string; icon: string; status: NavItemStatus }[];
 
   // Track page views on route changes (foreground-only, debounced in the store).


### PR DESCRIPTION
## Summary

Swaps the order of Streaks and Goals in the sidebar navigation so Streaks appears above Goals. Streaks are a more frequently accessed daily action (check-in) while goals are a longer-term planning view.

### Change

`navItems` array in `frontend/src/routes/+layout.svelte`:

**Before:** `Home → Notes → Graph → Skills → AI → Goals → Streaks`
**After:** `Home → Notes → Graph → Skills → AI → Streaks → Goals`

Closes #773

#### Test plan
- [x] Streaks appears above Goals in the sidebar
- [x] Both routes still work correctly
- [ ] CI green

Generated with [Devin](https://devin.ai)