### PR TITLE
fix(frontend): balance goal creation modal columns and fix internal scroll (#764)

### DIFF
--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -1550,6 +1550,18 @@
                   {/each}
                 </div>
               </div>
+              <div class="form-field">
+                <label class="label">{$t('goalsPage.measurementType')}</label>
+                <select class="input w-full" bind:value={newMeasurement}>
+                  <option value="COUNT">{$t('goalsPage.countNumeric')}</option>
+                  <option value="BOOLEAN">{$t('goalsPage.booleanDone')}</option>
+                  <option value="PERCENT">{$t('goalsPage.percent')}</option>
+                </select>
+              </div>
+              <div class="form-field">
+                <label class="label">{$t('goalsPage.targetGoal')}</label>
+                <input class="input w-full" type="number" bind:value={newTargetValue} min="1" disabled={newMeasurement === 'BOOLEAN'} />
+              </div>
             </div>
 
             <!-- Column 2: Appearance -->
@@ -1615,18 +1627,6 @@
             <!-- Column 3: Advanced -->
             <div class="ng-col">
               <span class="ng-col-title">{$t('goalsPage.advanced')}</span>
-              <div class="form-field">
-                <label class="label">{$t('goalsPage.measurementType')}</label>
-                <select class="input w-full" bind:value={newMeasurement}>
-                  <option value="COUNT">{$t('goalsPage.countNumeric')}</option>
-                  <option value="BOOLEAN">{$t('goalsPage.booleanDone')}</option>
-                  <option value="PERCENT">{$t('goalsPage.percent')}</option>
-                </select>
-              </div>
-              <div class="form-field">
-                <label class="label">{$t('goalsPage.targetGoal')}</label>
-                <input class="input w-full" type="number" bind:value={newTargetValue} min="1" disabled={newMeasurement === 'BOOLEAN'} />
-              </div>
               <div class="form-field">
                 <label class="label">{$t('goalsPage.limitDays')} <span class="optional">{$t('goalsPage.limitDaysOptional')}</span></label>
                 <input class="input w-full" type="number" bind:value={newMaxAssignmentDays} min="1" placeholder={$t('goalsPage.unlimited')} />
@@ -2099,6 +2099,7 @@
     flex-direction: column;
     gap: var(--s4);
     min-height: 0;
+    overscroll-behavior: contain;
   }
 
   .ng-bottom-preview {


### PR DESCRIPTION
## Summary

Redistributes fields across the 3 columns of the goal creation modal to balance heights and eliminate the internal scroll on standard desktop viewports.

### Problem

The 3-column layout (Basics / Appearance / Advanced) was heavily unbalanced:

| Column | Before | After |
|--------|--------|-------|
| **Básico** | 3 fields (Title, Description, Frequency) | 5 fields (+ Measurement type, Target) |
| **Apariencia** | 2 fields (Icon/Emoji, Color) | 2 fields (unchanged) |
| **Avanzado** | 6 fields (Measurement, Target, Limit days, Fail policy, Linked note, Tag sync) | 4 fields (Limit days, Fail policy, Linked note, Tag sync) |

The Advanced column was 3x taller than Appearance, causing visual imbalance and triggering internal scroll on the modal body.

### Change

Moved **Measurement type** and **Target** from Advanced to Basics — they are essential to goal definition, not "advanced" configuration. The new 5/2/4 distribution balances column heights so the modal fits on a single page without internal scroll at standard desktop viewport (≥900px height).

Also added `overscroll-behavior: contain` to the modal body to prevent scroll chaining when internal scroll does occur (small viewports).

Closes #764

#### Test plan
- [x] `npm run check` — 0 errors (139 pre-existing warnings, unchanged)
- [ ] Open goal creation modal — 3 columns have roughly equal height
- [ ] No internal scroll at standard desktop viewport (≥900px height)
- [ ] All 11 fields remain present and functional
- [ ] Responsive stacking at ≤900px still works
- [ ] CI green

Generated with [Devin](https://devin.ai)