### PR TITLE
fix(test): playwright config and stale E2E selectors (#776, #777)

### DIFF
--- a/frontend/e2e/goal-editor.spec.ts
+++ b/frontend/e2e/goal-editor.spec.ts
@@ -219,7 +219,7 @@ test.describe('Goal Editor — new goal creation', () => {
     }
   });
 
-  test('new goal modal has 3 tabs', async ({ page }) => {
+  test('new goal modal has 3 columns', async ({ page }) => {
     await authGoto(page, '/goals');
     await page.locator('button.tab:has-text("Inicio")').click();
     await page.waitForTimeout(1000);
@@ -227,9 +227,9 @@ test.describe('Goal Editor — new goal creation', () => {
     if (await newGoalBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
       await newGoalBtn.click();
       await page.waitForTimeout(500);
-      await expect(page.locator('.ng-tab:has-text("Básico")').or(page.locator('.ng-tab:has-text("Basico")'))).toBeVisible({ timeout: 3000 });
-      await expect(page.locator('.ng-tab:has-text("Apariencia")')).toBeVisible();
-      await expect(page.locator('.ng-tab:has-text("Avanzado")')).toBeVisible();
+      await expect(page.locator('.ng-col-title:has-text("Básico")').or(page.locator('.ng-col-title:has-text("Basico")'))).toBeVisible({ timeout: 3000 });
+      await expect(page.locator('.ng-col-title:has-text("Apariencia")')).toBeVisible();
+      await expect(page.locator('.ng-col-title:has-text("Avanzado")')).toBeVisible();
     }
   });
 

--- a/frontend/e2e/goals.spec.ts
+++ b/frontend/e2e/goals.spec.ts
@@ -122,8 +122,8 @@ test.describe('Goals — goal cards', () => {
     const goalCards = page.locator('.goal-card-main');
     const count = await goalCards.count();
     if (count > 0) {
-      // Pin button is a sibling within the goal card container
-      const pinBtn = page.locator('button[aria-label="Fijar objetivo"]').first();
+      // Pin button is a sibling within the goal-editor-card container
+      const pinBtn = page.locator('.goal-editor-card button[aria-label="Fijar objetivo"], .goal-editor-card button[aria-label="Desfijar objetivo"]').first();
       await expect(pinBtn).toBeVisible({ timeout: 3000 });
     }
   });
@@ -143,12 +143,15 @@ test.describe('Goals — goal cards', () => {
   test('pin button toggles goal pin state', async ({ page }) => {
     await authGoto(page, '/goals');
     await page.waitForTimeout(1000);
-    const firstPinBtn = page.locator('button[aria-label="Fijar objetivo"]').first();
-    if (await firstPinBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+    const firstGoalCard = page.locator('.goal-editor-card').first();
+    if (await firstGoalCard.isVisible({ timeout: 2000 }).catch(() => false)) {
+      const firstPinBtn = firstGoalCard.locator('button[aria-label="Fijar objetivo"], button[aria-label="Desfijar objetivo"]').first();
+      await expect(firstPinBtn).toBeVisible({ timeout: 3000 });
       await firstPinBtn.click();
       await page.waitForTimeout(500);
-      // The button should still be visible (toggled state)
-      await expect(firstPinBtn).toBeVisible();
+      // The button should still be visible (toggled state, aria-label may change)
+      const toggledBtn = firstGoalCard.locator('button[aria-label="Fijar objetivo"], button[aria-label="Desfijar objetivo"]').first();
+      await expect(toggledBtn).toBeVisible();
     }
   });
 });

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -24,10 +24,10 @@ test.describe('Smoke — app shell', () => {
     await expect(xp).toBeVisible({ timeout: 5000 });
   });
 
-  test('all 8 nav items are present and clickable', async ({ page }) => {
+  test('all 7 nav items are present and clickable', async ({ page }) => {
     await authGoto(page, '/');
     const nav = page.locator('nav.app-sidebar');
-    const expectedHrefs = ['/', '/notes', '/graph', '/skills', '/ai', '/goals', '/streaks', '/analytics'];
+    const expectedHrefs = ['/', '/notes', '/graph', '/skills', '/ai', '/streaks', '/goals'];
     for (const href of expectedHrefs) {
       const link = nav.locator(`a[href="${href}"]`);
       await expect(link).toBeVisible();
@@ -72,9 +72,8 @@ test.describe('Smoke — navigation between pages', () => {
     { path: '/graph', title: 'Graph' },
     { path: '/skills', title: 'Skills' },
     { path: '/ai', title: 'AI' },
-    { path: '/goals', title: 'Goals' },
     { path: '/streaks', title: 'Streaks' },
-    { path: '/analytics', title: 'Analytics' },
+    { path: '/goals', title: 'Goals' },
   ];
 
   for (const p of pages) {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, devices } from '@playwright/test';
-import globalTeardown from './e2e/helpers/cleanup';
 
 /**
  * Playwright E2E configuration for Joidy frontend.
@@ -45,5 +44,5 @@ export default defineConfig({
         reuseExistingServer: true,
         timeout: 60_000,
       },
-  globalTeardown,
+  globalTeardown: './e2e/helpers/cleanup.ts',
 });


### PR DESCRIPTION
## Summary

Fixes two preexisting testing bugs that blocked E2E execution and caused 4 persistent test failures.

### #776 — playwright.config.ts globalTeardown incompatible with Playwright 1.62+

`globalTeardown` was passed as a function import, but Playwright 1.62+ requires a string path. This blocked **all** E2E test execution:

```
Error: playwright.config.ts: config.globalTeardown must be a string
```

**Fix:** Changed to string path `'./e2e/helpers/cleanup.ts'` and removed the unused import.

### #777 — 3 stale E2E selectors that don't match current UI

1. **Smoke test expected 8 nav items including `/analytics`** — the sidebar only has 7 items (no `/analytics` route). Updated `expectedHrefs` to match the actual `navItems` array (7 items, streaks before goals per #773). Removed the `/analytics` navigation test case.

2. **Goal creation modal test used `.ng-tab` selector** — the creation modal uses `.ng-col-title` for column headers (`.ng-tab` is only in the edit/settings modal). Changed selector and renamed test from "has 3 tabs" to "has 3 columns".

3. **Pin button test searched globally** without scoping to the goal card container, and didn't account for the aria-label changing to "Desfijar objetivo" after pinning. Scoped selector to `.goal-editor-card` and accept both aria-labels (Fijar/Desfijar) for the toggle assertion.

### Test results

Before: 51 passed, 4 failed (of 55 smoke + goals + goal-editor tests)
After: **51 passed, 0 failed**

Global teardown also verified working (cleanup deleted 1 test goal after run).

Closes #776
Closes #777

#### Test plan
- [x] `npm run check` — 0 errors (139 pre-existing warnings, unchanged)
- [x] `npx playwright test e2e/smoke.spec.ts e2e/goals.spec.ts e2e/goal-editor.spec.ts` — 51 passed, 0 failed
- [x] Global teardown executes after tests (cleanup log confirmed)
- [ ] CI green

Generated with [Devin](https://devin.ai)