### PR TITLE
fix: repair make db-health and align stray version strings to 0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ migrate: ## Run Alembic migrations up to head in api container
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm api sh -c "cd /app && alembic -c /app/alembic.ini upgrade head"
 
 db-health: ## Verify migration head and required core tables
-	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm api sh -c "cd /app && alembic -c /app/alembic.ini current && python scripts/verify_db_health.py"
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm api sh -c "cd /app && alembic -c /app/alembic.ini current && PYTHONPATH=/app python scripts/verify_db_health.py"
 
 test-api: ## Run all API unit tests via pytest
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml run --rm api sh -c "cd /app && pytest --cov --cov-report=term-missing"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joidy-frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "engines": {
     "node": ">=22.19.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "joidy"
-version = "0.1.0"
+version = "0.2.0"
 description = "Joidy backend services"
 requires-python = ">=3.12"
 


### PR DESCRIPTION
## Summary

Pre-release housekeeping for the upcoming v0.2.0 release. Two small fixes that were blocking a clean release:

- **`make db-health` was broken**: the `db-health` Makefile target invoked `python scripts/verify_db_health.py` without `PYTHONPATH=/app`, so the script could not import `config` / `database` and failed with `ModuleNotFoundError: No module named 'config'`. Added `PYTHONPATH=/app` (same pattern already used by the `migrate` target's sibling invocations). Verified locally: now reports `DB health OK (engine=postgres:5432/joidy)`.
- **Stray version strings stuck at 0.1.0**: `frontend/package.json` and the root `pyproject.toml` were still on `0.1.0` while the rest of the repo (README badge, `aur/PKGBUILD`, `aur/.SRCINFO`, `docs/index.md`, `docs/api.md`, `docs/architecture.md`, `docs/troubleshooting.md`, `CHANGELOG.md`) is already aligned to `0.2.0`. Bumped both to `0.2.0` so the release is consistent. Neither file is currently covered by `release.yml`'s auto-bump table, so this had to be done manually.

## Context

`development` is 203 commits ahead of `main` and the only existing tag is `v1.0.0-alpha`. The `v0.2.0` section in `CHANGELOG.md` is already populated and ready. Once this PR lands on `development`, the next step is a `development` -> `main` PR, then trigger `release.yml` manually with `version=v0.2.0` and `prerelease=false` (auto-bump must NOT be used: the `v1.0.0-alpha` tag is filtered out by `grep -v '-'`, which would make the workflow emit `v0.1.0` and downgrade the release).

## Test plan

- [x] `make db-health` now succeeds: `a7b8c9d0e1f2 (head)` + `DB health OK (engine=postgres:5432/joidy)`
- [x] `git diff` shows only the 3 intended one-line changes
- [x] No code logic touched; version bumps are metadata-only
- [ ] CI green on this branch (compileall + frontend check + Docker build)

Generated with [Devin](https://devin.ai)