### PR TITLE
feat(installer): auto-install joidy CLI into ~/.local/bin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,9 +101,10 @@ jobs:
             echo ""
             echo "package() {"
             echo '  cd "${srcdir}/joidy-${_tag}"'
-            echo '  install -Dm755 bin/joidy "${pkgdir}/usr/bin/joidy"'
+            echo '  install -Dm755 scripts/joidy.sh "${pkgdir}/usr/bin/joidy"'
             echo '  install -Dm644 docker-compose.yml "${pkgdir}/usr/share/joidy/docker-compose.yml"'
             echo '  install -Dm644 .env.example "${pkgdir}/usr/share/joidy/.env.example"'
+            echo '  install -Dm644 /dev/stdin "${pkgdir}/etc/joidy/path" <<<"/usr/share/joidy"'
             echo "}"
           } > PKGBUILD
           {

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ docker compose up -d
 curl -fsSL https://raw.githubusercontent.com/Axel-DaMage/joidy/main/scripts/install.sh | bash
 ```
 
+This clones the repo, copies `.env`, and installs the `joidy` CLI into `~/.local/bin`
+so you can manage the stack from anywhere. After the installer finishes, edit `.env`
+with your credentials and run:
+
+```bash
+joidy up
+```
+
 **Windows (PowerShell):**
 
 ```powershell

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -13,7 +13,8 @@ sha256sums=('SKIP')
 
 package() {
   cd "${srcdir}/joidy-${_tag}"
-  install -Dm755 bin/joidy "${pkgdir}/usr/bin/joidy"
+  install -Dm755 scripts/joidy.sh "${pkgdir}/usr/bin/joidy"
   install -Dm644 docker-compose.yml "${pkgdir}/usr/share/joidy/docker-compose.yml"
   install -Dm644 .env.example "${pkgdir}/usr/share/joidy/.env.example"
+  install -Dm644 /dev/stdin "${pkgdir}/etc/joidy/path" <<<"/usr/share/joidy"
 }

--- a/bin/joidy
+++ b/bin/joidy
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e
-DIR="$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd)"
-cd "$DIR"
-docker compose "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,24 +1,133 @@
 #!/usr/bin/env bash
+# Joidy — one-shot installer for Linux/macOS.
+#
+# Clones the repo, copies .env, and installs the `joidy` CLI as a symlink
+# in ~/.local/bin so the user can run `joidy up` from anywhere.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/Axel-DaMage/joidy/main/scripts/install.sh | bash
+#
+# Environment overrides:
+#   DIR   — install location (default: $HOME/joidy)
+#   BRANCH — git branch/revision to clone (default: main)
 set -e
+
 REPO="https://github.com/Axel-DaMage/joidy.git"
+BRANCH="${BRANCH:-main}"
 DIR="${DIR:-$HOME/joidy}"
 
-if [ -d "$DIR" ]; then
-  echo "Joidy already exists at $DIR"
-  echo "To update: cd $DIR && git pull && docker compose pull && docker compose up -d"
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+ok()    { echo -e "${GREEN}✓${NC} $1"; }
+warn()  { echo -e "${YELLOW}⚠${NC} $1"; }
+err()   { echo -e "${RED}✗${NC} $1" >&2; }
+step()  { echo -e "${BLUE}→${NC} $1"; }
+
+# ─── Prerequisites ────────────────────────────────────────────────
+if ! command -v git &>/dev/null; then
+  err "git is required but not installed."
   exit 1
 fi
+if ! command -v docker &>/dev/null; then
+  warn "Docker is not installed. The CLI will be installed, but you'll need Docker to run Joidy."
+  echo "  Install: https://docs.docker.com/engine/install/"
+fi
 
-echo "Downloading Joidy to $DIR..."
-git clone --depth 1 "$REPO" "$DIR"
+# ─── Clone repo ───────────────────────────────────────────────────
+if [ -d "$DIR" ]; then
+  warn "Joidy already exists at $DIR"
+  echo "  To update: cd $DIR && git pull && docker compose pull && docker compose up -d"
+else
+  step "Downloading Joidy to $DIR..."
+  git clone --depth 1 --branch "$BRANCH" "$REPO" "$DIR"
+  ok "Cloned into $DIR"
+fi
+
 cd "$DIR"
-cp .env.example .env
+
+# ─── .env bootstrap ───────────────────────────────────────────────
+if [ ! -f .env ]; then
+  cp .env.example .env
+  ok "Created .env from .env.example"
+else
+  ok ".env already exists"
+fi
+
+# ─── Install `joidy` CLI into ~/.local/bin ────────────────────────
+LOCAL_BIN="$HOME/.local/bin"
+CONFIG_DIR="$HOME/.config/joidy"
+JOIDY_SCRIPT="$DIR/scripts/joidy.sh"
+
+mkdir -p "$LOCAL_BIN" "$CONFIG_DIR"
+
+# Persist the project path so the CLI survives renames/moves of the symlink.
+echo "$DIR" > "$CONFIG_DIR/path"
+ok "Project path saved to $CONFIG_DIR/path"
+
+# (Re)create the symlink. -f overwrites a stale previous install.
+ln -sf "$JOIDY_SCRIPT" "$LOCAL_BIN/joidy"
+chmod +x "$JOIDY_SCRIPT"
+ok "Installed 'joidy' CLI → $LOCAL_BIN/joidy"
+
+# ─── Ensure ~/.local/bin is in PATH ───────────────────────────────
+ensure_path() {
+  local rc_file="$1"
+  local marker="# Added by Joidy installer"
+  if [ -f "$rc_file" ] && ! grep -q "$marker" "$rc_file"; then
+    printf '\n%s\nexport PATH="$HOME/.local/bin:$PATH"\n' "$marker" >> "$rc_file"
+    ok "Added ~/.local/bin to PATH in $rc_file"
+    return 0
+  fi
+  return 1
+}
+
+PATH_UPDATED=0
+case ":$PATH:" in
+  *":$LOCAL_BIN:"*)
+    ok "~/.local/bin already in PATH"
+    ;;
+  *)
+    # Detect the user's shell rc file.
+    SHELL_NAME="$(basename "${SHELL:-bash}")"
+    case "$SHELL_NAME" in
+      zsh)  ensure_path "$HOME/.zshrc"  && PATH_UPDATED=1 ;;
+      fish) warn "Fish detected. Add ~/.local/bin to fish_user_paths manually:" \
+              && echo "  fish_add_path ~/.local/bin" ;;
+      *)    ensure_path "$HOME/.bashrc" && PATH_UPDATED=1 ;;
+    esac
+    if [ "$PATH_UPDATED" = "0" ]; then
+      warn "Could not auto-update PATH. Add this to your shell rc:"
+      echo '  export PATH="$HOME/.local/bin:$PATH"'
+    fi
+    ;;
+esac
+
+# ─── Done ─────────────────────────────────────────────────────────
 echo ""
-echo "Done!"
+echo -e "${GREEN}╔══════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}║  Joidy installed successfully!               ║${NC}"
+echo -e "${GREEN}╚══════════════════════════════════════════════╝${NC}"
 echo ""
-echo "Next steps:"
-echo "  1. Edit $DIR/.env with your credentials"
-echo "  2. Run: cd $DIR && docker compose up -d"
-echo "  3. Open http://localhost:3000"
+echo -e "${YELLOW}Next steps:${NC}"
+echo "  1. Edit $DIR/.env with your credentials:"
+echo "     - GEMINI_API_KEY:    get free at https://aistudio.google.com/"
+echo "     - OBSIDIAN_VAULT_PATH: absolute path to your Obsidian vault"
+echo "     - SECRET_KEY:        run: openssl rand -hex 32"
 echo ""
-echo "For updates: cd $DIR && git pull && docker compose pull && docker compose up -d"
+if [ "$PATH_UPDATED" = "1" ]; then
+  echo "  2. Reload your shell:"
+  echo "       source ~/.${SHELL_NAME}rc"
+  echo "  3. Start Joidy:"
+else
+  echo "  2. Start Joidy:"
+fi
+echo "       joidy up"
+echo ""
+echo "  Then open http://localhost:3000"
+echo ""
+echo -e "${BLUE}Updates:${NC} cd $DIR && git pull && docker compose pull && docker compose up -d"

--- a/scripts/joidy.sh
+++ b/scripts/joidy.sh
@@ -26,13 +26,15 @@
 set -e
 
 # Resolve project directory.
-# Priority: JOIDY_DIR env var → ~/.config/joidy/path file → script location (../)
+# Priority: JOIDY_DIR env var → ~/.config/joidy/path (user) → /etc/joidy/path (system, e.g. AUR) → script location (../)
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 
 if [ -n "$JOIDY_DIR" ] && [ -d "$JOIDY_DIR" ]; then
   PROJECT_DIR="$JOIDY_DIR"
 elif [ -f "$HOME/.config/joidy/path" ]; then
   PROJECT_DIR="$(cat "$HOME/.config/joidy/path")"
+elif [ -f "/etc/joidy/path" ]; then
+  PROJECT_DIR="$(cat "/etc/joidy/path")"
 else
   PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 fi


### PR DESCRIPTION
## Summary

The curl-piped installer now installs the `joidy` CLI as a symlink in `~/.local/bin` and persists the project path in `~/.config/joidy/path`, so users can run `joidy up` from anywhere after install instead of having to `cd` into the repo and use `docker compose` directly.

### Changes

- **`scripts/install.sh`**: clone + `.env` bootstrap + symlink + PATH management (auto-edits `.bashrc`/`.zshrc` when `~/.local/bin` is missing; prints manual instructions for fish). Idempotent: safe to re-run on existing installs. Verifies prerequisites (`git` required, `docker` warned if missing).
- **`scripts/joidy.sh`**: add `/etc/joidy/path` fallback for system-wide installs (AUR) so the resolver works without the user-level config file.
- **`bin/joidy`**: removed. `scripts/joidy.sh` is now the single source of truth for the CLI.
- **`aur/PKGBUILD`** + **`.github/workflows/publish.yml`**: install `scripts/joidy.sh` into `/usr/bin/joidy` and write `/etc/joidy/path` pointing at `/usr/share/joidy`.
- **`README.md`**: document that the curl installer sets up the CLI and that the next step is `joidy up`.

### Installer flow (after this PR)

```bash
curl -fsSL https://raw.githubusercontent.com/Axel-DaMage/joidy/main/scripts/install.sh | bash
# edit ~/joidy/.env with credentials
joidy up
```

#### Test plan

- [x] `bash -n scripts/install.sh` — syntax OK
- [x] `bash -n scripts/joidy.sh` — syntax OK
- [x] `bash -n aur/PKGBUILD` — syntax OK
- [x] Dry-run installer against local working copy: symlink created at `~/.local/bin/joidy`, path persisted at `~/.config/joidy/path`, `~/.local/bin` detected as already in PATH, output renders correctly with colors
- [x] `joidy help` / `joidy status` still functional via the new symlink
- [ ] CI green on this branch (compileall + frontend check + Docker build)

Generated with [Devin](https://devin.ai)