### PR TITLE
feat(doctor): detect root-owned frontend/.svelte-kit before make dev (#781)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,24 @@ doctor: ## Verify all prerequisites are met
 		echo "$(YELLOW)⚠$(NC) data/db directory not found"; \
 	fi; \
 	echo ""; \
+	if [ -d "frontend/.svelte-kit" ]; then \
+		if [ -e "frontend/.svelte-kit/env.d.ts" ] && [ ! -w "frontend/.svelte-kit/env.d.ts" ]; then \
+			echo "$(YELLOW)⚠$(NC) frontend/.svelte-kit/env.d.ts is not writable (likely root-owned)"; \
+			echo "  The frontend dev container (uid 1000) will crash on start with EACCES"; \
+			echo "  Run: sudo make fix-permissions"; \
+			EXIT_CODE=1; \
+		elif [ ! -w "frontend/.svelte-kit" ]; then \
+			echo "$(YELLOW)⚠$(NC) frontend/.svelte-kit is not writable (likely root-owned)"; \
+			echo "  The frontend dev container (uid 1000) will crash on start with EACCES"; \
+			echo "  Run: sudo make fix-permissions"; \
+			EXIT_CODE=1; \
+		else \
+			echo "$(GREEN)✓$(NC) frontend/.svelte-kit is writable"; \
+		fi; \
+	else \
+		echo "$(GREEN)✓$(NC) frontend/.svelte-kit will be generated on first start"; \
+	fi; \
+	echo ""; \
 	if [ $$EXIT_CODE -eq 0 ]; then \
 		echo "$(GREEN)All checks passed! Run 'make dev' to start.$(NC)"; \
 	else \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,6 +13,17 @@ services:
       - VITE_API_URL=http://localhost:${API_PORT:-8000}
       - VITE_INTERNAL_API_URL=http://api:8000
     command: npm run dev -- --host 0.0.0.0 --port 3000
+    # The dev container runs as uid 1000 (node). When frontend/.svelte-kit is
+    # root-owned (e.g. after `sudo make fix-permissions`), svelte-kit sync
+    # crashes on EACCES before Vite starts. The healthcheck surfaces that
+    # crash-loop as "unhealthy" in `docker compose ps` so it is visible
+    # instead of a silently dead UI.
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
 
   api:
     build:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -293,6 +293,51 @@ npm run check
 
 ---
 
+### 3.4 Frontend container crash-loop / dead UI (`.svelte-kit` EACCES)
+
+**Síntoma:**
+- `make dev` arranca pero la UI en `http://localhost:3000` no carga (carga infinita o
+  conexión rechazada).
+- `docker compose ps` muestra el contenedor `frontend` en `unhealthy` (con el
+  healthcheck de `docker-compose.dev.yml`).
+- Los logs del frontend muestran un error de permisos al hacer `svelte-kit sync`:
+  ```
+  ERROR EACCES: permission denied, open '/app/.svelte-kit/env.d.ts'
+  ```
+- Nada parece roto si solo se revisa `make dev` (el contenedor reinicia en bucle).
+
+**Causa:** El contenedor de desarrollo del frontend corre como el usuario `node`
+(uid 1000). `frontend/.svelte-kit` es host-compilado por `svelte-kit` y, si se
+generó (o se tocó) con `sudo` —p. ej. tras `sudo make fix-permissions`—, queda
+propiedad de `root`. En el próximo arranque, `svelte-kit sync` no puede
+reescribir `env.d.ts` y Vite nunca llega a levantar.
+
+**Solución:**
+
+1. Comprobar la propiedad de `.svelte-kit`:
+   ```bash
+   ls -la frontend/.svelte-kit | head
+   ```
+
+2. Devolverle la propiedad a tu usuario (el healthcheck se apagará solo):
+   ```bash
+   sudo chown -R "$(id -u):$(id -g)" frontend/.svelte-kit
+   ```
+
+3. Reiniciar el frontend:
+   ```bash
+   docker compose restart frontend
+   ```
+
+4. Verificar:
+   ```bash
+   docker compose ps
+   docker compose logs frontend
+   ```
+
+**Prevención:** `make doctor` ya detecta `.svelte-kit` con permisos ridículos
+(propiedad de root / no escribible) antes de levantar la pila.
+
 ---
 
 ## 4. Problemas del Worker


### PR DESCRIPTION
## Summary

After `sudo make fix-permissions` (or any root-owned `frontend/.svelte-kit`), the frontend dev container (uid 1000) crashes on startup with `EACCES: permission denied, open '/app/.svelte-kit/env.d.ts'`. The UI never loads, the container restart-loops, and nothing in `make dev` output hints at the cause. This PR surfaces the problem before the stack starts.

- **`make doctor`**: new check on `frontend/.svelte-kit` and `frontend/.svelte-kit/env.d.ts` writability. Warns with the exact fix (`sudo make fix-permissions`) and sets a failing exit code when not writable; prints `✓` when writable or not yet generated.
- **`docker-compose.dev.yml`**: HTTP healthcheck for the `frontend` dev service (`node` + `fetch` against `http://localhost:3000`). A Vite crash-loop now shows as `unhealthy` in `docker compose ps` instead of a silently dead UI.
- **`docs/troubleshooting.md`**: new section 3.4 covering symptom, cause (`ls -la` to confirm), fix (`sudo chown -R \$(id -u):\$(id -g) frontend/.svelte-kit`), and prevention via `make doctor`.

## Context

Closes #781. Detected during a local `make dev` where the frontend container restart-looped after a root-owned `.svelte-kit` and the failure was invisible until inspecting logs.

## Test plan

- [x] `make doctor` recipe runs clean standalone and prints `✓ frontend/.svelte-kit is writable` when healthy
- [x] `docker-compose.dev.yml` parses (healthcheck present, `docker compose config` YAML-valid)
- [x] Markdown renders; no code logic touched in `frontend/`
- [ ] CI green on this branch (compileall + frontend check + Docker build)

Generated with [opencode](https://opencode.ai)