### PR TITLE
fix(frontend): make production image permission-safe and self-contained

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -4,7 +4,8 @@
 data/
 node_modules/
 frontend/node_modules/
-frontend/.svelte-kit/
+build/
+.svelte-kit/
 __pycache__/
 *.pyc
 *.pyo

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,11 +2,11 @@ FROM node:22-slim AS base
 WORKDIR /app
 
 FROM base AS deps
-COPY package.json ./
-RUN npm install
+COPY package.json package-lock.json ./
+RUN npm ci
+RUN chown -R node:node /app
 
 FROM deps AS development
-RUN chown -R node:node /app/node_modules
 COPY --chown=node:node . .
 USER node
 EXPOSE 3000
@@ -15,15 +15,20 @@ CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
 FROM deps AS build
 ARG VITE_API_URL=http://localhost:8000
 ENV VITE_API_URL=$VITE_API_URL
-COPY . .
+ENV NODE_OPTIONS=--max-old-space-size=4096
+
+COPY --chown=node:node . .
+
+USER node
 RUN npm run build
 
 FROM base AS production
 COPY --from=build --chown=node:node /app/build ./build
 COPY --from=build --chown=node:node /app/package.json .
 COPY --from=build --chown=node:node /app/package-lock.json .
-RUN npm install --omit=dev --ignore-scripts
+RUN chown node:node /app
 USER node
+RUN npm ci --omit=dev --ignore-scripts
 ENV NODE_ENV=production
 EXPOSE 3000
 CMD ["node", "build"]


### PR DESCRIPTION
Fixes #796

## Problem

The published production image `d4mag3/joidy-frontend:latest` contains `/app/.svelte-kit` with root-owned files. On startup the container (running as `node`, UID 1000) hits `EACCES` writing into `.svelte-kit`, causing a restart/crash loop that requires `make fix-permissions` on the host. Production should never depend on that.

## Changes

**`frontend/.dockerignore`**
- `frontend/.svelte-kit/` → `.svelte-kit/`. The build context is `frontend/`, so the old pattern never matched and the host `.svelte-kit` leaked into the image.
- Added `build/` to keep local build artifacts out of the context.

**`frontend/Dockerfile`**
- `deps`: use `package-lock.json` + `npm ci` for reproducible installs; `chown -R node:node /app` before building.
- `build`: run as `USER node`, `NODE_OPTIONS=--max-old-space-size=4096`, `COPY --chown=node:node . .`.
- `production`: `chown node:node /app`, `USER node`, `npm ci --omit=dev --ignore-scripts` (adapter-node externalizes production `dependencies`, so the final image needs `node_modules` at runtime). No `.svelte-kit` in the final image.

## Validation

- `docker build --no-cache --target production -t joidy-frontend-test ./frontend` ✅
- Final image: `/app/build`, `/app/package.json`, `/app/package-lock.json`, `/app/node_modules` — **no** `/app/.svelte-kit`.
- `id` → `uid=1000(node) gid=1000(node)`; all `/app` owned by `node`.
- Booted from the clean image with **no** `make fix-permissions`/host chown: `Status=running Restarts=0`, serves HTTP 200, other routes 200, zero 500s in logs.
- `npm run check` → 0 errors; `npm run test:run` → 161 passed.

## Notes for merge/publish

`publish.yml` builds `./frontend` with buildx using the default target — `production` is the last stage, so the next release will automatically publish the fixed `d4mag3/joidy-frontend:latest`. To fully discard old layers, rebuild without cache.