### PR TITLE
enhancement(frontend/ux): SettingsPanel save button in-place saved state (#794)

### DIFF
--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -31,8 +31,10 @@
 
   let configLoaded = false;
   let configSaving = false;
+  let configSaved = false;
   let configMessage = '';
   let configRestartNotice = '';
+  let savedTimer: ReturnType<typeof setTimeout> | null = null;
 
   let githubConnected = false;
   let githubUsername = '';
@@ -286,19 +288,26 @@
     configSaving = true;
     configMessage = '';
     configRestartNotice = '';
+    if (savedTimer) {
+      clearTimeout(savedTimer);
+      savedTimer = null;
+    }
     try {
       // No enviamos github_token ni github_username desde el formulario general;
       // esos se manejan con el flujo OAuth dedicado.
       const { github_token, github_username, ...configToSave } = systemConfig;
       const result = await api.config.update(configToSave);
-      configMessage = result.message;
       configuredKeys = Object.entries(configToSave)
         .filter(([k, v]) => v && k !== 'telegram_bot_token' && k !== 'telegram_allowed_user_id')
         .map(([k, v]) => k);
       if (result.requires_restart && result.restart_reason) {
         configRestartNotice = result.restart_reason;
       }
-      setTimeout(() => (configMessage = ''), 3000);
+      configSaved = true;
+      savedTimer = setTimeout(() => {
+        configSaved = false;
+        savedTimer = null;
+      }, 2500);
     } catch (e: any) {
       configMessage = 'Error: ' + (e.message || 'Failed to save');
     } finally {
@@ -862,15 +871,22 @@
       </div>
 
       <div class="panel-footer">
-        <button class="save-config-btn fixed-save" onclick={saveConfig} disabled={configSaving}>
+        <button
+          class="save-config-btn fixed-save"
+          class:saved={configSaved}
+          onclick={saveConfig}
+          disabled={configSaving}
+        >
           {#if configSaving}
             {$t('common.saving')}
+          {:else if configSaved}
+            <DynamicIcon name="CircleCheckBig" size={12} /> {$t('common.saved')}
           {:else}
             <DynamicIcon name="Save" size={12} /> {$t('common.save')}
           {/if}
         </button>
         {#if configMessage}
-          <span class="config-message-footer">{configMessage}</span>
+          <span class="config-message-footer error">{configMessage}</span>
         {/if}
       </div>
       {#if configRestartNotice}
@@ -971,6 +987,9 @@
     font-size: 11px;
     color: var(--text-secondary);
     white-space: nowrap;
+  }
+  .config-message-footer.error {
+    color: var(--error, #ef4444);
   }
 
   .restart-notice {
@@ -1305,6 +1324,9 @@
   .save-config-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+  .save-config-btn.saved {
+    background: var(--success, #22c55e);
   }
 
   .config-message {

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -22,6 +22,7 @@
     "next": "Next",
     "start": "Start",
     "saving": "Saving...",
+    "saved": "Saved",
     "tasks": "tasks",
     "level": "LVL"
   },

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -22,6 +22,7 @@
     "next": "Siguiente",
     "start": "Comenzar",
     "saving": "Guardando...",
+    "saved": "Guardado",
     "tasks": "tareas",
     "level": "NVL"
   },


### PR DESCRIPTION
## Summary
- The save button label now transitions in-place: **Save → Saving... → Saved (green) → Save**, instead of showing the success message in a sibling span.
- Matches the existing `GoalEditor` pattern.
- The side `<span>` is kept **only for error messages** (red).
- Added `common.saved` i18n key (en: "Saved", es: "Guardado").
- `configRestartNotice` block preserved unchanged.

Closes #794

#### Test plan
- [ ] Open Settings, click Save — button shows "Saving..." then "Saved" (green) for ~2.5s, then reverts to "Save".
- [ ] Trigger a save error (e.g. API down) — error message appears in the side span in red.
- [ ] Restart-notice still renders when `requires_restart` is true.
- [ ] `cd frontend && npm run check` — 0 errors.

Generated with [Devin](https://devin.ai)