### PR TITLE
fix(frontend): streak Glass theme preview renders liquid-glass effect (#784)

### DIFF
--- a/frontend/src/lib/components/StreakCreateModal.svelte
+++ b/frontend/src/lib/components/StreakCreateModal.svelte
@@ -273,6 +273,7 @@
               class:theme-glass={theme === 'glass'}
               class:theme-sketch={theme === 'sketch'}
               style={previewStyle}
+              use:liquidGlass={{ enabled: theme === 'glass' }}
             >
               <div class="preview-icon">
                 {#if useIcon && icon}


### PR DESCRIPTION
## Summary
- `liquidGlass` was imported in `StreakCreateModal.svelte` but never attached to the `.preview-card`.
- Added `use:liquidGlass={{ enabled: theme === 'glass' }}` to the preview card, matching `StreakListItem`'s live rendering.
- The preview card already has `position: relative; overflow: hidden; isolation: isolate` so the glass layers (zIndex 0) sit behind the content (z-index 1).

Closes #784

#### Test plan
- [ ] Open streak create/edit modal, select the **Glass** theme — preview shows the animated aurora + frosted glass effect.
- [ ] Switch away from Glass — layers unmount cleanly (no leftover DOM).
- [ ] Other 7 themes (solid/gradient/glow/minimal/lcd/neon/sketch) unaffected.
- [ ] `cd frontend && npm run check` — 0 errors.

Generated with [Devin](https://devin.ai)