### PR TITLE
feat(frontend/ux): GoalCard polish — borderless pin, state below title, square cards

### DIFF
--- a/frontend/src/lib/components/GoalCard.svelte
+++ b/frontend/src/lib/components/GoalCard.svelte
@@ -49,11 +49,11 @@
           {/if}
         </div>
       </div>
-      <div class="goal-state-indicator" class:active={goal.state === 'ACTIVE'} class:completed={goal.state === 'COMPLETED' || goal.is_completed} class:paused={goal.state === 'PAUSED'} class:failed={goal.state === 'FAILED'}>
-        {STATE_LABELS[goal.state] || goal.state}
-      </div>
     </div>
     <div class="card-title">{goal.title}</div>
+    <div class="goal-state-indicator" class:active={goal.state === 'ACTIVE'} class:completed={goal.state === 'COMPLETED' || goal.is_completed} class:paused={goal.state === 'PAUSED'} class:failed={goal.state === 'FAILED'}>
+      {STATE_LABELS[goal.state] || goal.state}
+    </div>
     {#if goal.description}
       <div class="card-description">{goal.description.substring(0, 80)}{goal.description.length > 80 ? '...' : ''}</div>
     {/if}
@@ -130,6 +130,7 @@
     text-align: center;
     position: relative;
     overflow: hidden;
+    aspect-ratio: 1;
   }
 
   .goal-card-main {
@@ -184,12 +185,12 @@
   .pin-btn {
     position: absolute;
     top: 0;
-    right: 0;
+    left: 0;
     width: 24px;
     height: 24px;
     border-radius: 6px;
-    background: var(--surface-hover);
-    border: 1px solid var(--border);
+    background: transparent;
+    border: none;
     color: var(--text-muted);
     display: flex;
     align-items: center;

--- a/frontend/src/lib/components/GoalList.svelte
+++ b/frontend/src/lib/components/GoalList.svelte
@@ -100,7 +100,7 @@
 
   .editor-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
     gap: 20px;
     width: 100%;
   }


### PR DESCRIPTION
## Summary
- **#785**: Pin button moved to **top-left** corner, border removed (transparent background; hover/pinned states still give visual feedback).
- **#786**: State indicator label (e.g. "Activo") moved from the header row (next to the icon) to **below the card title**.
- **#787**: Goal cards are now **fully square** (`aspect-ratio: 1`); `GoalList` grid `minmax` reduced from 320px → 240px for more compact squares.

Closes #785, #786, #787

#### Test plan
- [ ] Pin button appears in the **top-left** corner with no border; hover shows background, pinned shows accent fill.
- [ ] State label ("Activo"/"Completado"/"Pausado"/"Fallido") renders **below the title**, not next to the icon.
- [ ] Goal cards render as **squares** (1:1) on desktop; content fits without clipping.
- [ ] Mobile single-column layout still works.
- [ ] `cd frontend && npm run check` — 0 errors.

Generated with [Devin](https://devin.ai)