### PR TITLE
feat(frontend/ux): goal settings 3-lists-at-once + fold description into note

### DIFF
--- a/frontend/src/routes/goals/[id]/+page.svelte
+++ b/frontend/src/routes/goals/[id]/+page.svelte
@@ -218,137 +218,124 @@
       </div>
 
       <div class="goal-settings-body">
-        <div class="ng-tabs-container">
-          <button class="ng-tab" class:active={settingsSection === 'basics'} onclick={() => settingsSection = 'basics'}>{$t('goalDetail.basics')}</button>
-          <button class="ng-tab" class:active={settingsSection === 'appearance'} onclick={() => settingsSection = 'appearance'}>{$t('goalDetail.appearance')}</button>
-          <button class="ng-tab" class:active={settingsSection === 'advanced'} onclick={() => settingsSection = 'advanced'}>{$t('goalDetail.advanced')}</button>
-        </div>
-
         <div class="ng-content-area">
-          {#if settingsSection === 'basics'}
-            <div class="ng-section-fade settings-basics">
-              <div class="form-field">
-                <label class="label">{$t('goalDetail.goalTitle')}</label>
-                <input class="input w-full" bind:value={editTitle} maxlength="38" />
+          <div class="ng-section-fade settings-basics">
+            <div class="ng-section-heading">{$t('goalDetail.basics')}</div>
+            <div class="form-field">
+              <label class="label">{$t('goalDetail.goalTitle')}</label>
+              <input class="input w-full" bind:value={editTitle} maxlength="38" />
+            </div>
+            <div class="form-field basics-frequency">
+              <label class="label">{$t('goalDetail.frequency')}</label>
+              <div class="ng-freq-grid">
+                {#each TEMPORALITIES as temp}
+                  <button class="ng-freq-btn" class:active={editTemporality === temp} onclick={() => editTemporality = temp}>
+                    {temp === 'DAILY' ? 'Diario' : temp === 'WEEKLY' ? 'Semanal' : temp === 'MONTHLY' ? 'Mensual' : 'Anual'}
+                  </button>
+                {/each}
               </div>
-              <div class="form-field">
-                <label class="label">{$t('goalDetail.description')}</label>
-                <textarea class="input w-full" bind:value={editDescription} rows="2"></textarea>
+            </div>
+          </div>
+
+          <div class="ng-section-fade settings-appearance">
+            <div class="ng-section-heading">{$t('goalDetail.appearance')}</div>
+            <div class="form-field appearance-icon">
+              <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:8px;">
+                <label class="label" style="margin:0;">{$t('goalDetail.failIconEmoji')}</label>
+                <div class="icon-toggle-row">
+                  <button class="icon-type-btn" class:selected={!editUseFailIcon} onclick={() => editUseFailIcon = false}>{$t('goalDetail.emoji')}</button>
+                  <button class="icon-type-btn" class:selected={editUseFailIcon} onclick={() => editUseFailIcon = true}>{$t('goalDetail.icon')}</button>
+                </div>
               </div>
-              <div class="form-field basics-frequency">
-                <label class="label">{$t('goalDetail.frequency')}</label>
-                <div class="ng-freq-grid">
-                  {#each TEMPORALITIES as temp}
-                    <button class="ng-freq-btn" class:active={editTemporality === temp} onclick={() => editTemporality = temp}>
-                      {temp === 'DAILY' ? 'Diario' : temp === 'WEEKLY' ? 'Semanal' : temp === 'MONTHLY' ? 'Mensual' : 'Anual'}
-                    </button>
+              {#if !editUseFailIcon}
+                <div class="emoji-grid ng-large-grid">
+                  {#each EMOJIS as e}
+                    <button class="emoji-btn" class:selected={editFailEmoji === e} onclick={() => editFailEmoji = e}>{e}</button>
                   {/each}
                 </div>
+              {:else}
+                <div class="field ng-large-grid" style="display: flex; flex-direction: column; height: 280px; padding: 8px; border: 1px solid var(--border); border-radius: var(--r); background: var(--surface-hover); overflow: hidden;">
+                  <LazyIconPicker selected={editFailIcon} color={editColor} onSelect={(ic) => editFailIcon = ic} />
+                </div>
+              {/if}
+            </div>
+
+            <div class="form-field appearance-color">
+              <label class="label">{$t('goalDetail.identityColor')}</label>
+              <div class="color-presets ng-expanded-presets">
+                {#each COLOR_PRESETS as c}
+                  <button class="color-dot" class:selected={editColor === c.hex} style="background: {c.hex}; color: {c.hex};" onclick={() => editColor = c.hex}></button>
+                {/each}
+                <div class="color-custom" style="background: {editColor};">
+                  <input type="color" bind:value={editColor} class="color-picker" />
+                </div>
               </div>
             </div>
-          {/if}
+          </div>
 
-          {#if settingsSection === 'appearance'}
-            <div class="ng-section-fade settings-appearance">
-              <div class="form-field appearance-icon">
-                <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:8px;">
-                  <label class="label" style="margin:0;">{$t('goalDetail.failIconEmoji')}</label>
-                  <div class="icon-toggle-row">
-                    <button class="icon-type-btn" class:selected={!editUseFailIcon} onclick={() => editUseFailIcon = false}>{$t('goalDetail.emoji')}</button>
-                    <button class="icon-type-btn" class:selected={editUseFailIcon} onclick={() => editUseFailIcon = true}>{$t('goalDetail.icon')}</button>
-                  </div>
-                </div>
-                {#if !editUseFailIcon}
-                  <div class="emoji-grid ng-large-grid">
-                    {#each EMOJIS as e}
-                      <button class="emoji-btn" class:selected={editFailEmoji === e} onclick={() => editFailEmoji = e}>{e}</button>
-                    {/each}
-                  </div>
-                {:else}
-                  <div class="field ng-large-grid" style="display: flex; flex-direction: column; height: 280px; padding: 8px; border: 1px solid var(--border); border-radius: var(--r); background: var(--surface-hover); overflow: hidden;">
-                    <LazyIconPicker selected={editFailIcon} color={editColor} onSelect={(ic) => editFailIcon = ic} />
-                  </div>
-                {/if}
+          <div class="ng-section-fade settings-advanced">
+            <div class="ng-section-heading">{$t('goalDetail.advanced')}</div>
+            <div class="form-row adv-measure">
+              <div class="form-field" style="flex:1;">
+                <label class="label">{$t('goalDetail.measurementType')}</label>
+                <select class="input w-full" bind:value={editMeasurement}>
+                  <option value="COUNT">{$t('goalDetail.countNumeric')}</option>
+                  <option value="BOOLEAN">{$t('goalDetail.booleanDone')}</option>
+                  <option value="PERCENT">{$t('goalDetail.percent')}</option>
+                </select>
               </div>
+              <div class="form-field" style="width: 140px;">
+                <label class="label">{$t('goalDetail.target')}</label>
+                <input class="input w-full" type="number" bind:value={editTargetValue} min="1" disabled={editMeasurement === 'BOOLEAN'} />
+              </div>
+              <div class="form-field" style="width: 140px;">
+                <label class="label">{$t('goalDetail.limitDays')}</label>
+                <input class="input w-full" type="number" bind:value={editMaxAssignmentDays} min="1" placeholder={$t('goalDetail.unlimited')} />
+              </div>
+            </div>
 
-              <div class="form-field appearance-color">
-                <label class="label">{$t('goalDetail.identityColor')}</label>
-                <div class="color-presets ng-expanded-presets">
-                  {#each COLOR_PRESETS as c}
-                    <button class="color-dot" class:selected={editColor === c.hex} style="background: {c.hex}; color: {c.hex};" onclick={() => editColor = c.hex}></button>
+            <div class="form-field adv-fail">
+              <label class="label">{$t('goalDetail.failPolicy')}</label>
+              <div class="ng-fail-options">
+                <button class="ng-fail-btn" class:active={editFailConfig === 'STATIC'} onclick={() => editFailConfig = 'STATIC'}>
+                  <strong>{$t('goalDetail.static')}</strong>
+                  <span>{$t('goalDetail.staticDesc')}</span>
+                </button>
+                <button class="ng-fail-btn" class:active={editFailConfig === 'ROLLOVER'} onclick={() => editFailConfig = 'ROLLOVER'}>
+                  <strong>{$t('goalDetail.rollover')}</strong>
+                  <span>{$t('goalDetail.rolloverDesc')}</span>
+                </button>
+                <button class="ng-fail-btn" class:active={editFailConfig === 'SNOWBALL'} onclick={() => editFailConfig = 'SNOWBALL'}>
+                  <strong>{$t('goalDetail.snowball')}</strong>
+                  <span>{$t('goalDetail.snowballDesc')}</span>
+                </button>
+              </div>
+            </div>
+
+            <div class="form-row adv-links">
+              <div class="form-field" style="flex:1;">
+                <label class="label">{$t('goalDetail.linkToProject')}</label>
+                <select class="input w-full" bind:value={editNoteId}>
+                  <option value={null}>{$t('goalDetail.noLinkedNote')}</option>
+                  {#each notes as n}
+                    <option value={n.id}>{n.title}</option>
                   {/each}
-                  <div class="color-custom" style="background: {editColor};">
-                    <input type="color" bind:value={editColor} class="color-picker" />
-                  </div>
-                </div>
+                </select>
+              </div>
+              <div class="form-field" style="flex:1;">
+                <label class="label">{$t('goalDetail.tagSync')}</label>
+                <select class="input w-full" bind:value={editTagId}>
+                  <option value={null}>{$t('goalDetail.manualUpdate')}</option>
+                  {#each notes as n}
+                    {@const tagId = tags.find(t => t.name === n.title)?.id}
+                    {#if tagId}
+                      <option value={tagId}>{n.title} (Auto-rastreo)</option>
+                    {/if}
+                  {/each}
+                </select>
               </div>
             </div>
-          {/if}
-
-          {#if settingsSection === 'advanced'}
-            <div class="ng-section-fade settings-advanced">
-              <div class="form-row adv-measure">
-                <div class="form-field" style="flex:1;">
-                  <label class="label">{$t('goalDetail.measurementType')}</label>
-                  <select class="input w-full" bind:value={editMeasurement}>
-                    <option value="COUNT">{$t('goalDetail.countNumeric')}</option>
-                    <option value="BOOLEAN">{$t('goalDetail.booleanDone')}</option>
-                    <option value="PERCENT">{$t('goalDetail.percent')}</option>
-                  </select>
-                </div>
-                <div class="form-field" style="width: 140px;">
-                  <label class="label">{$t('goalDetail.target')}</label>
-                  <input class="input w-full" type="number" bind:value={editTargetValue} min="1" disabled={editMeasurement === 'BOOLEAN'} />
-                </div>
-                <div class="form-field" style="width: 140px;">
-                  <label class="label">{$t('goalDetail.limitDays')}</label>
-                  <input class="input w-full" type="number" bind:value={editMaxAssignmentDays} min="1" placeholder={$t('goalDetail.unlimited')} />
-                </div>
-              </div>
-
-              <div class="form-field adv-fail">
-                <label class="label">{$t('goalDetail.failPolicy')}</label>
-                <div class="ng-fail-options">
-                  <button class="ng-fail-btn" class:active={editFailConfig === 'STATIC'} onclick={() => editFailConfig = 'STATIC'}>
-                    <strong>{$t('goalDetail.static')}</strong>
-                    <span>{$t('goalDetail.staticDesc')}</span>
-                  </button>
-                  <button class="ng-fail-btn" class:active={editFailConfig === 'ROLLOVER'} onclick={() => editFailConfig = 'ROLLOVER'}>
-                    <strong>{$t('goalDetail.rollover')}</strong>
-                    <span>{$t('goalDetail.rolloverDesc')}</span>
-                  </button>
-                  <button class="ng-fail-btn" class:active={editFailConfig === 'SNOWBALL'} onclick={() => editFailConfig = 'SNOWBALL'}>
-                    <strong>{$t('goalDetail.snowball')}</strong>
-                    <span>{$t('goalDetail.snowballDesc')}</span>
-                  </button>
-                </div>
-              </div>
-
-              <div class="form-row adv-links">
-                <div class="form-field" style="flex:1;">
-                  <label class="label">{$t('goalDetail.linkToProject')}</label>
-                  <select class="input w-full" bind:value={editNoteId}>
-                    <option value={null}>{$t('goalDetail.noLinkedNote')}</option>
-                    {#each notes as n}
-                      <option value={n.id}>{n.title}</option>
-                    {/each}
-                  </select>
-                </div>
-                <div class="form-field" style="flex:1;">
-                  <label class="label">{$t('goalDetail.tagSync')}</label>
-                  <select class="input w-full" bind:value={editTagId}>
-                    <option value={null}>{$t('goalDetail.manualUpdate')}</option>
-                    {#each notes as n}
-                      {@const tagId = tags.find(t => t.name === n.title)?.id}
-                      {#if tagId}
-                        <option value={tagId}>{n.title} (Auto-rastreo)</option>
-                      {/if}
-                    {/each}
-                  </select>
-                </div>
-              </div>
-            </div>
-          {/if}
+          </div>
         </div>
 
         <div class="ng-bottom-preview">
@@ -522,37 +509,14 @@
     gap: var(--s3);
   }
 
-  .ng-tabs-container {
-    display: flex;
-    gap: 4px;
-    background: var(--surface-hover);
-    padding: 3px;
-    border-radius: 8px;
-    border: 1px solid var(--border);
-  }
-
-  .ng-tab {
-    flex: 1;
-    padding: 8px;
-    font-size: 11px;
-    font-family: var(--font-mono);
-    font-weight: 600;
-    color: var(--text-disabled);
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    border-radius: 6px;
-    transition: all 0.2s;
-  }
-
-  .ng-tab:hover { color: var(--text-secondary); }
-  .ng-tab.active { background: var(--surface); color: var(--text-primary); box-shadow: 0 2px 8px rgba(0,0,0,0.2); }
-
   .ng-content-area {
     flex: 1;
     min-height: 0;
     display: flex;
     flex-direction: column;
+    gap: var(--s4);
+    overflow-y: auto;
+    padding-right: 4px;
   }
 
   .ng-section-fade {
@@ -560,8 +524,18 @@
     flex-direction: column;
     gap: var(--s4);
     animation: ngFadeIn 0.3s ease;
-    flex: 1;
-    min-height: 0;
+  }
+
+  .ng-section-heading {
+    font-size: 11px;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--border-light);
+    margin-bottom: 4px;
   }
 
   .settings-basics {
@@ -872,11 +846,6 @@
 
     .ng-freq-grid {
       grid-template-columns: 1fr 1fr;
-    }
-
-    .ng-tab {
-      padding: var(--s2);
-      font-size: 10px;
     }
 
     .emoji-grid {


### PR DESCRIPTION
## Summary

### #788 — Show all 3 settings sections at once
- Removed the Basics / Appearance / Advanced **tab switcher**.
- All three sections now render **simultaneously**, each under a labeled heading (`.ng-section-heading`).
- The `.ng-content-area` scrolls vertically when content overflows.
- Removed unused `.ng-tabs-container` / `.ng-tab` styles.

### #789 — Fold description into the markdown note
- Removed the separate **Description** `<textarea>` from the goal settings panel.
- The goal description is now authored inside the goal's markdown editor (`GoalEditor` already had no description field — only the settings panel exposed it).
- The backend `description` field is **still sent** on save (unchanged) for backward compatibility; only the UI stops exposing it separately.

Closes #788, #789

#### Test plan
- [ ] Open a goal detail → settings panel shows **Basics, Appearance, Advanced** all at once, no tabs.
- [ ] Each section has a labeled heading; content scrolls if it overflows.
- [ ] No description textarea in Basics; description is written in the markdown editor below.
- [ ] Save still works (title, frequency, color, measurement, etc. persist).
- [ ] `cd frontend && npm run check` — 0 errors.

Generated with [Devin](https://devin.ai)