### PR TITLE
fix(notes): mostrar carpetas vacías del vault en el árbol de notas

### DIFF
--- a/api/routers/folders.py
+++ b/api/routers/folders.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -6,6 +7,9 @@ from config import settings
 from services.auth_service import get_current_user
 
 router = APIRouter(prefix="/folders", tags=["folders"])
+
+# Characters forbidden in Obsidian folder names (mirrors note sanitization).
+_INVALID_NAME_CHARS = re.compile(r'[\\/:*?"<>|]')
 
 
 class FolderCreate(BaseModel):
@@ -21,6 +25,48 @@ def _get_safe_path(vault: str, requested: str) -> str:
     return full_path
 
 
+def _validate_folder_name(path: str) -> None:
+    """Basic validation for a vault-relative folder path."""
+    for part in path.split("/"):
+        if not part or part in (".", ".."):
+            raise HTTPException(status_code=400, detail="Invalid folder name")
+        if _INVALID_NAME_CHARS.search(part):
+            raise HTTPException(status_code=400, detail="Invalid folder name")
+        if len(part) > 255:
+            raise HTTPException(status_code=400, detail="Folder name too long")
+
+
+def _list_vault_folders(vault: str) -> list[str]:
+    """Recursively list vault directories as vault-relative posix paths.
+
+    Prunes hidden dirs (".obsidian", ".git", …) and the internal "_joidy/"
+    directory from traversal so they never reach the tree.
+    """
+    base = os.path.realpath(vault)
+    folders: list[str] = []
+    for root, dirs, _files in os.walk(base):
+        dirs[:] = [d for d in dirs if not d.startswith(".") and d != "_joidy"]
+        rel = os.path.relpath(root, base)
+        for d in dirs:
+            rel_dir = d if rel == "." else os.path.join(rel, d)
+            folders.append(rel_dir.replace(os.sep, "/"))
+    folders.sort()
+    return folders
+
+
+@router.get("/")
+def list_folders(user: dict = Depends(get_current_user)):
+    vault = settings.obsidian_vault_path
+    if not vault:
+        raise HTTPException(status_code=400, detail="OBSIDIAN_VAULT_PATH not set")
+
+    try:
+        folders = _list_vault_folders(vault)
+        return {"folders": folders}
+    except Exception:
+        raise HTTPException(status_code=500, detail="Failed to list folders")
+
+
 @router.post("/")
 def create_folder(
     folder: FolderCreate,
@@ -30,6 +76,7 @@ def create_folder(
     if not vault:
         raise HTTPException(status_code=400, detail="OBSIDIAN_VAULT_PATH not set")
 
+    _validate_folder_name(folder.path)
     full_path = _get_safe_path(vault, folder.path)
     if os.path.exists(full_path):
         raise HTTPException(status_code=400, detail="Folder already exists")

--- a/api/tests/test_folders.py
+++ b/api/tests/test_folders.py
@@ -57,6 +57,63 @@ def test_create_folder_no_vault_path(client, monkeypatch):
     assert "OBSIDIAN_VAULT_PATH" in resp.json()["detail"]
 
 
+def test_create_folder_invalid_name(client, monkeypatch, tmp_path):
+    vault = str(tmp_path / "vault")
+    os.makedirs(vault, exist_ok=True)
+    monkeypatch.setattr(settings, "obsidian_vault_path", vault)
+
+    for bad in ["bad\\name", "bad:name", "bad*name", "../escape", ".", "..", "a//b"]:
+        resp = client.post("/folders/", json={"path": bad})
+        assert resp.status_code == 400, f"expected 400 for {bad!r}"
+        assert resp.json()["detail"] == "Invalid folder name"
+
+
+def test_create_folder_name_too_long(client, monkeypatch, tmp_path):
+    vault = str(tmp_path / "vault")
+    os.makedirs(vault, exist_ok=True)
+    monkeypatch.setattr(settings, "obsidian_vault_path", vault)
+
+    resp = client.post("/folders/", json={"path": "a" * 256})
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Folder name too long"
+
+
+def test_list_folders_requires_auth(client_no_auth):
+    resp = client_no_auth.get("/folders/")
+    assert resp.status_code == 401
+
+
+def test_list_folders_empty(client, monkeypatch, tmp_path):
+    vault = str(tmp_path / "vault")
+    os.makedirs(vault, exist_ok=True)
+    monkeypatch.setattr(settings, "obsidian_vault_path", vault)
+
+    resp = client.get("/folders/")
+    assert resp.status_code == 200
+    assert resp.json() == {"folders": []}
+
+
+def test_list_folders_returns_nested_and_skips_internal(client, monkeypatch, tmp_path):
+    vault = str(tmp_path / "vault")
+    os.makedirs(os.path.join(vault, "Proyectos", "Sub"), exist_ok=True)
+    os.makedirs(os.path.join(vault, "Notas"), exist_ok=True)
+    os.makedirs(os.path.join(vault, "_joidy", "daily"), exist_ok=True)
+    os.makedirs(os.path.join(vault, ".obsidian"), exist_ok=True)
+    monkeypatch.setattr(settings, "obsidian_vault_path", vault)
+
+    resp = client.get("/folders/")
+    assert resp.status_code == 200
+    assert resp.json()["folders"] == ["Notas", "Proyectos", "Proyectos/Sub"]
+
+
+def test_list_folders_no_vault_path(client, monkeypatch):
+    monkeypatch.setattr(settings, "obsidian_vault_path", "")
+
+    resp = client.get("/folders/")
+    assert resp.status_code == 400
+    assert "OBSIDIAN_VAULT_PATH" in resp.json()["detail"]
+
+
 def test_delete_folder_success(client, monkeypatch, tmp_path):
     vault = str(tmp_path / "vault")
     os.makedirs(vault, exist_ok=True)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -773,6 +773,7 @@ export const api = {
   },
 
   folders: {
+    list: () => req<{ folders: string[] }>('GET', '/folders/'),
     create: async (path: string) => {
       return req('POST', '/folders/', { path });
     },

--- a/frontend/src/lib/utils/fileTree.ts
+++ b/frontend/src/lib/utils/fileTree.ts
@@ -161,7 +161,8 @@ export function buildTree(
   showTrash = false, 
   showHidden = false, 
   sortMode: SortMode = 'az',
-  folderMeta: FolderMetaMap = {}
+  folderMeta: FolderMetaMap = {},
+  vaultFolders: string[] = []
 ): TreeNode[] {
   const root: Record<string, RawNode> = {};
 
@@ -197,6 +198,24 @@ export function buildTree(
       const key = '✦ joidy';
       if (!root[key]) root[key] = { type: 'folder', name: '✦ joidy', children: {} };
       root[key].children[note.title] = { type: 'file', name: note.title, note, children: {} };
+    }
+  }
+
+  // Seed real vault folders (e.g. freshly created empty folders) so they show up
+  // even when no note lives inside them yet. Only merge, never overwrite.
+  if (!search) {
+    for (const path of vaultFolders) {
+      const parts = path.split('/').filter(Boolean);
+      if (!parts.length) continue;
+      if (!showTrash && parts.some(p => p === '.trash')) continue;
+      if (!showHidden && parts.some(p => p !== '.trash' && p.startsWith('.'))) continue;
+      let node = root;
+      for (const seg of parts) {
+        if (!node[seg]) {
+          node[seg] = { type: 'folder', name: seg, children: {} };
+        }
+        node = node[seg].children;
+      }
     }
   }
 

--- a/frontend/src/routes/notes/+page.svelte
+++ b/frontend/src/routes/notes/+page.svelte
@@ -71,6 +71,7 @@
   import { loadUserSettings, patchUserSettings } from '$lib/utils/userSettings';
   import { captureSnapshot, getSnapshot } from '$lib/stores/pageSnapshots';
   import { api, type Note } from '$lib/api';
+  import { logger } from '$lib/utils/logger';
   import { DEFAULT_GOAL_COLOR } from '$lib/utils/goalColors';
   import { t } from 'svelte-i18n';
 
@@ -85,6 +86,14 @@
   let dailyNotesConfigured = false;
   let deleteConfirm = false;
   let totalNotes = 0;
+
+  // Real vault folders (from GET /folders/) merged into the tree so empty
+  // folders created on disk actually show up.
+  let vaultFolders: string[] = [];
+  let vaultPath = '';
+  // When opening a "new note in folder", holds the folder path so the note is
+  // saved with a source_path inside it instead of the virtual "✦ joidy" folder.
+  let newNoteFolderPath: string | null = null;
 
   // Folder customization
   let editingFolder: string | null = null;
@@ -158,8 +167,9 @@
 
   function handleNewNoteInFolder() {
     if (!ctxMenu) return;
+    const path = ctxMenu.node.path;
     ctxMenu = null;
-    openNew();
+    openNew(path);
   }
 
   function handleDeleteFolder() {
@@ -172,7 +182,16 @@
       const ids = $notes
         .filter((n) => n.source_path && n.source_path.includes(path))
         .map((n) => n.id);
-      Promise.all(ids.map((id) => deleteNote(id))).then(() => loadNotes());
+      Promise.all(ids.map((id) => deleteNote(id)))
+        .then(async () => {
+          try {
+            await api.folders.delete(path);
+          } catch (e) {
+            logger.warn('[notes] Failed to delete folder on disk:', e);
+          }
+          await refreshTree();
+        })
+        .catch((e) => logger.error('[notes] Failed to delete folder notes:', e));
     }
   }
 
@@ -387,9 +406,29 @@
     $showTrash,
     $showHiddenFiles,
     sortMode,
-    $folderMetaStore
+    $folderMetaStore,
+    vaultFolders
   );
   $: flatNodes = flattenTree(tree, collapsed);
+
+  async function loadFolders() {
+    try {
+      const res = await api.folders.list();
+      vaultFolders = res.folders;
+    } catch (e) {
+      logger.warn('[notes] Failed to load vault folders:', e);
+    }
+  }
+
+  async function refreshTree() {
+    try {
+      const [ns, fs] = await Promise.all([api.notes.list(), api.folders.list()]);
+      notes.set(ns);
+      vaultFolders = fs.folders;
+    } catch (e) {
+      logger.error('[notes] Failed to refresh tree:', e);
+    }
+  }
   let historyStack: number[] = [];
   let historyIndex = -1;
   let isNavigatingHistory = false;
@@ -514,6 +553,7 @@
     // Kick off note loading (loads from cache synchronously inside loadNotes,
     // then fetches from API asynchronously).
     loadNotes();
+    loadFolders();
 
     // Wait one tick for Svelte to render the cached notes into the DOM.
     await tick();
@@ -535,6 +575,7 @@
     api.config
       .get()
       .then((config) => {
+        vaultPath = (config.obsidian_vault_path || '').trim();
         dailyNotesConfigured = Boolean(
           config.obsidian_vault_path?.trim() && config.daily_notes_folder?.trim()
         );
@@ -649,12 +690,13 @@
     ensureNoteEditor();
   }
 
-  function openNew() {
+  function openNew(folderPath?: string) {
     selectedNote = null;
     showEditor = true;
     editingNew = true;
     isMomentary = false;
     dailySourcePath = null;
+    newNoteFolderPath = folderPath ?? null;
     dailyInitialTitle = '';
     aiSuggestions.set([]);
     ensureNoteEditor();
@@ -666,6 +708,7 @@
     editingNew = true;
     isMomentary = true;
     dailySourcePath = null;
+    newNoteFolderPath = null;
     dailyInitialTitle = '';
     ensureNoteEditor();
   }
@@ -704,6 +747,7 @@
     isMomentary = false; // Usually daily notes are real
     dailyInitialTitle = today;
     dailySourcePath = buildDailySourcePath(vaultPath, dailyFolder, `${today}.md`);
+    newNoteFolderPath = null;
     aiSuggestions.set([]);
     ensureNoteEditor();
   }
@@ -712,6 +756,7 @@
     showEditor = false;
     selectedNote = null;
     dailySourcePath = null;
+    newNoteFolderPath = null;
     dailyInitialTitle = '';
     goto('/notes');
   }
@@ -724,7 +769,11 @@
     }
     if (editingNew) {
       if (dailyInitialTitle && !dailySourcePath) return;
-      const n = await createNote(title, content, tags, dailySourcePath);
+      let sp = dailySourcePath;
+      if (!sp && newNoteFolderPath && title.trim()) {
+        sp = buildDailySourcePath(vaultPath || '/vault', newNoteFolderPath, `${title.trim()}.md`);
+      }
+      const n = await createNote(title, content, tags, sp);
       if (n) {
         selectedNote = n;
         editingNew = false;
@@ -773,7 +822,7 @@
           class="icon-btn"
           title={$t('notesPage.createNote')}
           aria-label={$t('notesPage.createNote')}
-          onclick={openNew}><FilePen size={13} /></button
+          onclick={() => openNew()}><FilePen size={13} /></button
         >
         <button
           class="icon-btn"
@@ -1280,9 +1329,7 @@
                 await api.folders.create(targetPath);
                 updateFolderMeta(targetPath, { icon: newFolderIcon, color: newFolderColor });
                 creatingFolder = false;
-                // Refresh tree
-                const ns = await api.notes.list();
-                notes.set(ns);
+                await refreshTree();
               } catch (e) {
                 alert((e as any).message || 'Error al crear carpeta');
               }
@@ -1466,7 +1513,7 @@
               <DynamicIcon name="PenTool" size={13} /> Acciones Rápidas
             </div>
             <div class="dash-action-buttons">
-              <button class="dash-btn primary-dash-btn" onclick={openNew}>
+              <button class="dash-btn primary-dash-btn" onclick={() => openNew()}>
                 <FilePen size={16} /> Crear nota nueva
               </button>
               <button


### PR DESCRIPTION
Closes #806

## Problema

Las carpetas se creaban en disco pero nunca aparecían en el árbol lateral: el árbol se construía solo desde los `source_path` de las notas, y una carpeta vacía no genera nodo. Reintentar el mismo nombre daba "Folder already exists", pareciendo que la creación fallaba.

## Cambios

- **api/routers/folders.py**: nuevo `GET /folders/` que lista las carpetas reales del vault (excluye ocultas y `_joidy/`); validación de nombres en `POST /folders/`.
- **api/tests/test_folders.py**: +7 tests (listado, filtros, auth, validación de nombres).
- **frontend/src/lib/api.ts**: `api.folders.list()`.
- **frontend/src/lib/utils/fileTree.ts**: `buildTree` acepta `vaultFolders` y los siembra sin pisar nodos existentes.
- **frontend/src/routes/notes/+page.svelte**:
  - carga y refresca carpetas del vault (onMount, tras crear/borrar);
  - "Nueva nota aquí" guarda la nota con `source_path` dentro de la carpeta;
  - borrar carpeta ahora también elimina el directorio vía `api.folders.delete`.

## Verificación

- `pytest tests/test_folders.py`: **14 passed**.
- Suite API: **481 passed, 2 failed** (pre-existentes en `test_routers_upload.py`, fallan igual en el commit base).
- `npm run check`: **0 errores**.
- Prueba manual e2e: crear/listar/borrar carpeta OK; duplicado → 400; nombre inválido → 400.