### PR TITLE
refactor(frontend): fold goal description into markdown editor content

### DIFF
--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -515,17 +515,6 @@
     }
   }
 
-  // ── Edit goal modal state ──
-  let editingGoal = $state<Goal | null>(null);
-  let editTitle = $state('');
-  let editDescription = $state('');
-  let editTargetValue = $state(1);
-  let editFailConfig = $state<Goal['fail_config']>('STATIC');
-  let editMeasurement = $state<Goal['measurement_type']>('COUNT');
-  let editColor = $state(DEFAULT_GOAL_COLOR);
-  let editMaxAssignmentDays = $state<number | null>(null);
-  let editSaving = $state(false);
-
   // ── Analytics expandable state ──
   let showPerformanceChart = $state(true);
 
@@ -1064,28 +1053,6 @@
     ];
   });
 
-  async function saveEdit() {
-    if (!editingGoal) return;
-    editSaving = true;
-    try {
-      const result = await api.goals.update(editingGoal.id, {
-        title: editTitle,
-        description: editDescription,
-        target_value: editTargetValue,
-        fail_config: editFailConfig,
-        measurement_type: editMeasurement,
-        color: editColor,
-        max_assignment_days: editMaxAssignmentDays,
-      });
-      goals = goals.map((g) => (g.id === editingGoal!.id ? result : g));
-      editingGoal = null;
-    } catch (e) {
-      logger.error('Error al editar:', e);
-    } finally {
-      editSaving = false;
-    }
-  }
-
   function getGoalColor(goal: Goal): string {
     const colorMap: Record<string, string> = {
       DAILY: 'var(--today)',
@@ -1119,7 +1086,6 @@
         return;
       }
       showAddForm = false;
-      editingGoal = null;
     }
   }}
 />
@@ -2550,76 +2516,6 @@
         </div>
       </div>
     </div>
-  {/if}
-
-  {#if editingGoal}
-    <ModalDialog
-      open={true}
-      title={$t('goalsPage.editGoalModal')}
-      size="md"
-      onClose={() => (editingGoal = null)}
-    >
-      <div class="form-field">
-        <label class="label">{$t('goalsPage.title')}</label>
-        <input class="input w-full" bind:value={editTitle} />
-      </div>
-      <div class="form-field">
-        <label class="label">{$t('goalsPage.description')}</label>
-        <textarea class="input w-full" bind:value={editDescription} rows="2"></textarea>
-      </div>
-      <div class="form-row">
-        <div class="form-field" style="flex:1;">
-          <label class="label">{$t('goalsPage.measurement')}</label>
-          <select class="input w-full" bind:value={editMeasurement}>
-            <option value="COUNT">{$t('goalsPage.countNumeric')}</option>
-            <option value="BOOLEAN">{$t('goalsPage.booleanDone')}</option>
-            <option value="PERCENT">{$t('goalsPage.percent')}</option>
-          </select>
-        </div>
-        <div class="form-field" style="width:120px;">
-          <label class="label">{$t('goalsPage.target')}</label>
-          <input class="input w-full" type="number" bind:value={editTargetValue} min="1" />
-        </div>
-        <div class="form-field" style="width:100px;">
-          <label class="label">{$t('goalsPage.limitDaysLabel')}</label>
-          <input
-            class="input w-full"
-            type="number"
-            bind:value={editMaxAssignmentDays}
-            min="1"
-            placeholder="∞"
-          />
-        </div>
-      </div>
-      <div class="form-row">
-        <div class="form-field" style="flex:1;">
-          <label class="label">{$t('goalsPage.failRule')}</label>
-          <select class="input w-full" bind:value={editFailConfig}>
-            <option value="STATIC">{$t('goalsPage.staticReset')}</option>
-            <option value="ROLLOVER">{$t('goalsPage.rolloverNext')}</option>
-            <option value="SNOWBALL">{$t('goalsPage.snowballSum')}</option>
-          </select>
-        </div>
-        <div class="form-field" style="width:80px;">
-          <label class="label">{$t('goalsPage.color')}</label>
-          <div class="color-custom" style="background: {editColor}; width:36px; height:36px;">
-            <input type="color" bind:value={editColor} class="color-picker" />
-          </div>
-        </div>
-      </div>
-      <div class="form-actions">
-        <button
-          class="btn btn-primary"
-          onclick={saveEdit}
-          disabled={editSaving || !editTitle.trim()}
-        >
-          {editSaving ? 'Guardando...' : 'Guardar cambios'}
-        </button>
-        <button class="btn btn-ghost" onclick={() => (editingGoal = null)}
-          >{$t('goalsPage.cancel')}</button
-        >
-      </div>
-    </ModalDialog>
   {/if}
 
   {#if pendingGoals.length > 0}

--- a/frontend/src/routes/goals/[id]/+page.svelte
+++ b/frontend/src/routes/goals/[id]/+page.svelte
@@ -47,7 +47,6 @@
   let showSettings = false;
   let settingsSection: 'basics' | 'appearance' | 'advanced' = 'basics';
   let editTitle = '';
-  let editDescription = '';
   let editTemporality: Goal['temporality'] = 'DAILY';
   let editMeasurement: Goal['measurement_type'] = 'COUNT';
   let editTargetValue = 1;
@@ -98,7 +97,6 @@
   function openSettings() {
     if (!goal) return;
     editTitle = goal.title || '';
-    editDescription = goal.description || '';
     editTemporality = goal.temporality || 'DAILY';
     editMeasurement = goal.measurement_type || 'COUNT';
     editTargetValue = goal.target_value || 1;
@@ -129,7 +127,6 @@
     try {
       const result = await api.goals.update(goalId, {
         title: editTitle.trim(),
-        description: editDescription,
         temporality: editTemporality,
         measurement_type: editMeasurement,
         target_value: editTargetValue,


### PR DESCRIPTION
## Summary

- Removes the standalone `description` textarea from the goal edit UI — the description now lives solely as the markdown content authored in `GoalEditor` (`handleSave()` already persists `description = content` via `api.goals.saveContent`, and `getContent` falls back to `goal.description`, so no data loss).
- `goals/+page.svelte`: removed the **unreachable** edit-goal modal (nothing in the codebase ever assigned `editingGoal` a non-null value), its `saveEdit()` handler, and the dead `edit*` state variables — 104 lines of dead code gone.
- `goals/[id]/+page.svelte`: removed `editDescription` from the settings panel state; `saveSettings()` no longer sends a separate `description` (optional in `GoalUpdate`, so existing values are never clobbered).
- `GoalCard` description preview continues to work — it reads from goal content/description as before.

Closes #789

#### Test plan
- [x] `cd frontend && npm run check` — 0 errors, 132 warnings (baseline on `development`: 139; 7 fewer after dead-code removal)
- [ ] Open a goal detail page, edit markdown content in the editor, save — description persists
- [ ] Open goal settings panel — no description textarea; saving settings preserves existing description/content
- [ ] Goal cards with existing descriptions still show the preview

Generated with [Devin](https://devin.ai)