### PR TITLE
fix(api): serialize alembic migrations across uvicorn workers via pg_advisory_lock

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -54,6 +54,18 @@ def init_db():
 from models import *  # noqa: E402,F401
 
 
+# Stable advisory-lock key used to serialize Alembic migrations across
+# uvicorn workers on cold start (#816). With ``--workers N`` every worker
+# runs the FastAPI lifespan concurrently, and each one used to call
+# ``alembic upgrade head`` at the same time — the loser of the race crashed
+# its child process, flap-looping the container until migrations settled.
+# ``pg_advisory_lock`` is session-scoped and blocks until the holder
+# releases it, so the second worker simply waits for the first to finish,
+# then re-runs ``upgrade head`` which is a no-op (already at head).
+# 0x4A4F494459 = ASCII "JOIDY"; suffix disambiguates from future locks.
+_ALEMBIC_ADVISORY_LOCK_KEY = 0x4A4F494459000001
+
+
 def _run_migrations() -> None:
     alembic_ini = Path(__file__).resolve().parent / "alembic.ini"
     if not alembic_ini.exists():
@@ -64,8 +76,31 @@ def _run_migrations() -> None:
     cfg.set_main_option("script_location", str(Path(__file__).resolve().parent / "alembic"))
     cfg.set_main_option("sqlalchemy.url", settings.database_url)
 
+    # Only PostgreSQL supports advisory locks. The SQLite fallback used by
+    # some unit tests stubs ``init_db`` away entirely (conftest.py), so this
+    # branch is effectively only reached in production against PostgreSQL.
+    use_advisory_lock = engine.dialect.name == "postgresql"
+
     try:
-        command.upgrade(cfg, "head")
+        if use_advisory_lock:
+            # Hold the lock for the whole migration window. ``pg_advisory_lock``
+            # blocks the calling session until the key is available — exactly
+            # what we want: workers serialize instead of racing.
+            with engine.connect() as lock_conn:
+                lock_conn.execute(
+                    text("SELECT pg_advisory_lock(:key)"),
+                    {"key": _ALEMBIC_ADVISORY_LOCK_KEY},
+                )
+                try:
+                    command.upgrade(cfg, "head")
+                finally:
+                    lock_conn.execute(
+                        text("SELECT pg_advisory_unlock(:key)"),
+                        {"key": _ALEMBIC_ADVISORY_LOCK_KEY},
+                    )
+                    lock_conn.commit()
+        else:
+            command.upgrade(cfg, "head")
         logger.info("Database migrations applied successfully")
     except Exception:
         logger.exception("Failed to apply database migrations")

--- a/api/tests/test_migrations.py
+++ b/api/tests/test_migrations.py
@@ -1,0 +1,117 @@
+"""Tests for the Alembic migration serialization logic (#816).
+
+Verifies that ``_run_migrations`` takes a PostgreSQL advisory lock around
+``alembic upgrade head`` so concurrent uvicorn workers serialize instead of
+racing on cold start. The lock path is exercised via mocking so the test
+runs without modifying the live database.
+"""
+
+import sys
+import types
+import unittest
+from unittest import mock
+
+# Stub sqlite_vec before importing app modules (matches conftest pattern).
+if "sqlite_vec" not in sys.modules:
+    _stub = types.ModuleType("sqlite_vec")
+    _stub.load = lambda _conn: None  # type: ignore
+    sys.modules["sqlite_vec"] = _stub
+
+from database import _ALEMBIC_ADVISORY_LOCK_KEY, _run_migrations
+
+
+class _FakeDialect:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _FakeConnection:
+    """Records executed statements in order so tests can assert lock/unlock
+    sequencing around the migration call."""
+
+    def __init__(self, recorder: list):
+        self._recorder = recorder
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, stmt, params=None):
+        # Capture the advisory-lock SQL by stringifying the text() clause.
+        self._recorder.append((str(stmt), params))
+
+    def commit(self):
+        self._recorder.append(("commit", None))
+
+
+class _FakeEngine:
+    def __init__(self, dialect_name: str, recorder: list):
+        self.dialect = _FakeDialect(dialect_name)
+        self._recorder = recorder
+
+    def connect(self):
+        return _FakeConnection(self._recorder)
+
+
+class RunMigrationsTest(unittest.TestCase):
+    def test_advisory_lock_taken_and_released_on_postgresql(self):
+        recorder: list = []
+        fake_engine = _FakeEngine("postgresql", recorder)
+
+        with (
+            mock.patch("database.engine", fake_engine),
+            mock.patch("database.command.upgrade") as upgrade_mock,
+        ):
+            _run_migrations()
+
+        upgrade_mock.assert_called_once()
+        # Expect: lock, unlock, commit (in that order).
+        self.assertEqual(len(recorder), 3)
+        lock_sql, lock_params = recorder[0]
+        unlock_sql, unlock_params = recorder[1]
+        commit_marker = recorder[2]
+        self.assertIn("pg_advisory_lock", lock_sql)
+        self.assertEqual(lock_params, {"key": _ALEMBIC_ADVISORY_LOCK_KEY})
+        self.assertIn("pg_advisory_unlock", unlock_sql)
+        self.assertEqual(unlock_params, {"key": _ALEMBIC_ADVISORY_LOCK_KEY})
+        self.assertEqual(commit_marker, ("commit", None))
+
+    def test_no_advisory_lock_on_non_postgresql(self):
+        recorder: list = []
+        fake_engine = _FakeEngine("sqlite", recorder)
+
+        with (
+            mock.patch("database.engine", fake_engine),
+            mock.patch("database.command.upgrade") as upgrade_mock,
+        ):
+            _run_migrations()
+
+        upgrade_mock.assert_called_once()
+        # No lock/unlock statements should have been issued.
+        self.assertEqual(recorder, [])
+
+    def test_advisory_lock_released_even_if_upgrade_raises(self):
+        recorder: list = []
+        fake_engine = _FakeEngine("postgresql", recorder)
+
+        with (
+            mock.patch("database.engine", fake_engine),
+            mock.patch(
+                "database.command.upgrade",
+                side_effect=RuntimeError("boom"),
+            ),
+            self.assertRaises(RuntimeError),
+        ):
+            _run_migrations()
+
+        # Lock must still be released and committed even on failure —
+        # otherwise a crashed migration would wedge every other worker.
+        self.assertEqual(len(recorder), 3)
+        self.assertIn("pg_advisory_unlock", recorder[1][0])
+        self.assertEqual(recorder[2], ("commit", None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Wrap `alembic upgrade head` in a PostgreSQL session-level advisory lock (`pg_advisory_lock`) so concurrent uvicorn workers serialize instead of racing on cold start (#816).
- The first worker to acquire the lock runs the migrations; others block, then re-run `upgrade head` (a no-op once at head). The lock is released in a `finally` block so a failed migration cannot wedge other workers.
- Only the PostgreSQL path uses the lock; the SQLite fallback is unchanged (and is stubbed out by `conftest.py` during tests anyway).

## Root cause
With `--workers ${WEB_CONCURRENCY:-2}`, every uvicorn worker runs the FastAPI lifespan concurrently, and each one called `alembic upgrade head` at the same time. The loser of the race crashed its child process, flap-looping the API container (unhealthy) until migrations settled — visible as repeated `Running upgrade ...` sequences followed by `Child process failed to start, stopping the parent process`.

## Test plan
- [x] New `tests/test_migrations.py` (3 tests): lock taken+released on PostgreSQL, no lock on non-PostgreSQL, lock released even when `upgrade` raises.
- [x] Full API suite: `486 passed` (no regressions).
- [x] `python -m compileall` clean.
- [x] `ruff check` / `ruff format` clean on the new/modified files.

Closes #816

Generated with [Devin](https://devin.ai)