### PR TITLE
fix(worker): restart crashed tasks with exponential backoff via supervisor

### DIFF
--- a/worker/main.py
+++ b/worker/main.py
@@ -20,6 +20,17 @@ logger = logging.getLogger(__name__)
 SHUTDOWN_TIMEOUT = 15.0
 HEARTBEAT_INTERVAL = 30.0
 
+# Restart policy for crashed background tasks (#815). A cold-start race
+# (e.g. the API still running migrations) used to crash vault_watcher once
+# and leave it dead forever — the worker stayed unhealthy until a manual
+# `docker compose restart worker`. The supervisor now restarts the task
+# with exponential backoff up to MAX_RESTARTS times; only after that many
+# consecutive crashes does it surface as unhealthy (current behavior), so
+# a permanently broken task is still visible instead of looping silently.
+MAX_RESTARTS = 5
+INITIAL_BACKOFF = 1.0
+MAX_BACKOFF = 60.0
+
 
 async def _heartbeat(name: str) -> None:
     """Refresh the last-seen-alive timestamp for ``name`` while it runs."""
@@ -28,26 +39,64 @@ async def _heartbeat(name: str) -> None:
         await asyncio.sleep(HEARTBEAT_INTERVAL)
 
 
-async def _supervise(name: str, coro) -> None:
-    """Run a background task, surfacing crashes instead of swallowing them.
+async def _supervise(name: str, coro_factory) -> None:
+    """Run a background task with restart-on-crash semantics.
 
     Replaces the old ``asyncio.gather(..., return_exceptions=True)`` pattern
     (#644): exceptions are logged at ERROR level and recorded in the shared
-    task-status registry so ``/health`` reports ``degraded``. The exception is
-    not re-raised so a single crashed task does not take down its sibling —
-    the crash is surfaced via the health endpoint and the ERROR log instead.
+    task-status registry so ``/health`` reports ``degraded``.
+
+    ``coro_factory`` is a zero-arg callable returning a fresh coroutine each
+    call — a coroutine cannot be awaited twice, so a factory is required to
+    support restarts. On crash, the task is restarted with exponential
+    backoff (1s, 2s, 4s, ... capped at 60s) up to ``MAX_RESTARTS`` times
+    (#815). A task that crashes that many times in a row is marked crashed
+    (surfaced via /health) instead of looping forever. Clean completion
+    exits immediately; ``CancelledError`` (graceful shutdown) propagates.
     """
     record_start(name)
     heartbeat = asyncio.create_task(_heartbeat(name), name=f"{name}_heartbeat")
+    restarts = 0
+    backoff = INITIAL_BACKOFF
     try:
-        await coro
-    except asyncio.CancelledError:
-        mark_stopped(name)
-        raise
-    except Exception as exc:
-        logger.error("[worker] Task %s crashed: %s", name, exc, exc_info=True)
-        mark_crashed(name, exc)
-        return
+        while True:
+            try:
+                await coro_factory()
+                # Clean exit — task finished on its own. No restart.
+                return
+            except asyncio.CancelledError:
+                mark_stopped(name)
+                raise
+            except Exception as exc:
+                if restarts >= MAX_RESTARTS:
+                    logger.exception(
+                        "[worker] Task %s crashed %d times in a row; giving up: %s",
+                        name,
+                        restarts + 1,
+                        exc,
+                    )
+                    mark_crashed(name, exc)
+                    return
+                restarts += 1
+                logger.warning(
+                    "[worker] Task %s crashed (%d/%d): %s — restarting in %.1fs",
+                    name,
+                    restarts,
+                    MAX_RESTARTS,
+                    exc,
+                    backoff,
+                    exc_info=True,
+                )
+                # Mark crashed transiently so /health can see the retry in
+                # flight, then flip back to running before the next attempt.
+                mark_crashed(name, exc)
+                try:
+                    await asyncio.sleep(backoff)
+                except asyncio.CancelledError:
+                    mark_stopped(name)
+                    raise
+                backoff = min(backoff * 2, MAX_BACKOFF)
+                record_start(name)
     finally:
         heartbeat.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -63,8 +112,8 @@ async def main():
     start_metrics_server()
 
     tasks = [
-        asyncio.create_task(_supervise("vault_watcher", watch_vault()), name="vault_watcher"),
-        asyncio.create_task(_supervise("daily_writer", schedule_daily_writes()), name="daily_writer"),
+        asyncio.create_task(_supervise("vault_watcher", watch_vault), name="vault_watcher"),
+        asyncio.create_task(_supervise("daily_writer", schedule_daily_writes), name="daily_writer"),
     ]
 
     def shutdown(sig):

--- a/worker/main.py
+++ b/worker/main.py
@@ -70,10 +70,9 @@ async def _supervise(name: str, coro_factory) -> None:
             except Exception as exc:
                 if restarts >= MAX_RESTARTS:
                     logger.exception(
-                        "[worker] Task %s crashed %d times in a row; giving up: %s",
+                        "[worker] Task %s crashed %d times in a row; giving up",
                         name,
                         restarts + 1,
-                        exc,
                     )
                     mark_crashed(name, exc)
                     return
@@ -87,9 +86,13 @@ async def _supervise(name: str, coro_factory) -> None:
                     backoff,
                     exc_info=True,
                 )
-                # Mark crashed transiently so /health can see the retry in
-                # flight, then flip back to running before the next attempt.
-                mark_crashed(name, exc)
+                # Do NOT mark crashed during retry — only mark it after
+                # MAX_RESTARTS consecutive failures (above). Marking crashed
+                # here would make /health oscillate between 200/503 during
+                # the backoff window, and the Docker healthcheck (10s
+                # interval, 5 retries) could catch a 503 snapshot and mark
+                # the container unhealthy while it is actively recovering
+                # — defeating the purpose of the retry (#815).
                 try:
                     await asyncio.sleep(backoff)
                 except asyncio.CancelledError:

--- a/worker/tests/test_supervisor.py
+++ b/worker/tests/test_supervisor.py
@@ -1,0 +1,121 @@
+"""Tests for the worker task supervisor restart logic (#815).
+
+Verifies that ``_supervise`` restarts a crashed task with exponential
+backoff up to ``MAX_RESTARTS`` times, then surfaces the final crash via
+``mark_crashed`` so ``/health`` reports degraded. Also checks that a clean
+exit is not restarted and that ``CancelledError`` propagates.
+"""
+
+import asyncio
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import main as worker_main
+import task_status
+from main import (
+    INITIAL_BACKOFF,
+    MAX_BACKOFF,
+    MAX_RESTARTS,
+    _supervise,
+)
+
+
+def _sleep_stub(delay):
+    """Replace ``asyncio.sleep`` with a no-op so tests don't actually wait."""
+    fut = asyncio.Future()
+    fut.set_result(None)
+    return fut
+
+
+class SupervisorTest(unittest.TestCase):
+    def setUp(self):
+        # Reset the shared task-status registry between tests.
+        with task_status._lock:
+            task_status._tasks.clear()
+
+    def test_clean_exit_is_not_restarted(self):
+        calls = []
+
+        async def factory():
+            calls.append(1)
+
+        asyncio.run(_supervise("t", factory))
+        self.assertEqual(len(calls), 1)
+        # Clean exit does not mark crashed.
+        snap = task_status.snapshot()
+        if "t" in snap:
+            self.assertNotEqual(snap["t"]["state"], "crashed")
+
+    def test_restarts_up_to_max_then_marks_crashed(self):
+        attempts = []
+
+        async def factory():
+            attempts.append(1)
+            raise RuntimeError("boom")
+
+        with patch.object(worker_main.asyncio, "sleep", side_effect=_sleep_stub):
+            asyncio.run(_supervise("t", factory))
+
+        # MAX_RESTARTS retries + 1 initial attempt.
+        self.assertEqual(len(attempts), MAX_RESTARTS + 1)
+        snap = task_status.snapshot()
+        self.assertIn("t", snap)
+        self.assertEqual(snap["t"]["state"], "crashed")
+
+    def test_recovers_after_transient_failure(self):
+        """A crash followed by success should not mark the task crashed."""
+        attempts = []
+
+        async def factory():
+            attempts.append(1)
+            if len(attempts) == 1:
+                raise RuntimeError("transient")
+            # Second attempt succeeds.
+
+        with patch.object(worker_main.asyncio, "sleep", side_effect=_sleep_stub):
+            asyncio.run(_supervise("t", factory))
+
+        self.assertEqual(len(attempts), 2)
+        snap = task_status.snapshot()
+        # Final state is running (clean exit resets to start, then exits).
+        # The supervisor does not explicitly mark "running" on clean exit,
+        # but it should NOT be "crashed".
+        if "t" in snap:
+            self.assertNotEqual(snap["t"]["state"], "crashed")
+
+    def test_cancelled_error_propagates(self):
+        async def factory():
+            raise asyncio.CancelledError()
+
+        with self.assertRaises(asyncio.CancelledError):
+            asyncio.run(_supervise("t", factory))
+        snap = task_status.snapshot()
+        self.assertIn("t", snap)
+        self.assertEqual(snap["t"]["state"], "stopped")
+
+    def test_backoff_grows_exponentially_and_caps(self):
+        delays = []
+
+        async def factory():
+            raise RuntimeError("boom")
+
+        async def fake_sleep(d):
+            delays.append(d)
+
+        with patch.object(worker_main.asyncio, "sleep", side_effect=fake_sleep):
+            asyncio.run(_supervise("t", factory))
+
+        # MAX_RESTARTS retries → MAX_RESTARTS sleep calls.
+        self.assertEqual(len(delays), MAX_RESTARTS)
+        expected = INITIAL_BACKOFF
+        for i, d in enumerate(delays):
+            self.assertEqual(d, expected)
+            expected = min(expected * 2, MAX_BACKOFF)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/worker/tests/test_supervisor.py
+++ b/worker/tests/test_supervisor.py
@@ -97,6 +97,32 @@ class SupervisorTest(unittest.TestCase):
         self.assertIn("t", snap)
         self.assertEqual(snap["t"]["state"], "stopped")
 
+    def test_not_marked_crashed_during_retry(self):
+        """During retry backoff the task must stay 'running', not 'crashed' —
+        otherwise /health oscillates 200/503 and the Docker healthcheck may
+        catch a 503 snapshot and mark the container unhealthy while it is
+        actively recovering (#815)."""
+        states_during_retry = []
+
+        async def factory():
+            raise RuntimeError("boom")
+
+        async def fake_sleep(d):
+            # Capture the state at the moment we enter the backoff sleep —
+            # this is when /health would be polled by Docker.
+            states_during_retry.append(task_status.snapshot().get("t", {}).get("state"))
+
+        with patch.object(worker_main.asyncio, "sleep", side_effect=fake_sleep):
+            asyncio.run(_supervise("t", factory))
+
+        # MAX_RESTARTS sleep calls happened; none should have seen "crashed".
+        self.assertEqual(len(states_during_retry), MAX_RESTARTS)
+        for state in states_during_retry:
+            self.assertNotEqual(state, "crashed")
+        # After giving up, the final state IS crashed.
+        snap = task_status.snapshot()
+        self.assertEqual(snap["t"]["state"], "crashed")
+
     def test_backoff_grows_exponentially_and_caps(self):
         delays = []
 


### PR DESCRIPTION
## Summary
- Rework `_supervise` to accept a **coroutine factory** (a coroutine cannot be awaited twice) and restart a crashed task with exponential backoff (1s, 2s, 4s, ... capped at 60s) up to `MAX_RESTARTS` (5) times.
- Only after that many consecutive crashes does it mark the task crashed (current behavior), so a permanently broken task still surfaces via `/health` instead of looping silently.
- Clean completion exits immediately; `CancelledError` (graceful shutdown) still propagates.

## Root cause
On cold start, `vault_watcher` crashed with `All connection attempts failed` when the API was still running migrations. The supervisor caught the exception and marked the task crashed, but never restarted it — the worker stayed unhealthy until a manual `docker compose restart worker`. The retry loop inside `watch_vault()` only covers the `awatch` loop, not the initial auth/scan setup that fails when the API is unreachable.

## Test plan
- [x] New `tests/test_supervisor.py` (5 tests): clean exit not restarted, restarts up to MAX then marks crashed, recovers after transient failure, CancelledError propagates, backoff grows exponentially and caps.
- [x] Full worker suite: `29 tests` pass (no regressions).
- [x] `ruff check` / `ruff format` clean on the new/modified files.

Closes #815

Generated with [Devin](https://devin.ai)