### PR TITLE
feat: disable AI service in production + harden API for stable release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,12 @@ TELEGRAM_ALLOWED_USER_ID=
 # Secret key for session signing (generate with: openssl rand -hex 32)
 SECRET_KEY=change_this_to_a_random_secret_key
 APP_ENV=development
+# AI Service: set to false to disable all AI features (embeddings, chat,
+# classification, semantic search). Defaults to false in production
+# (docker-compose.yml) and true in development (docker-compose.dev.yml).
+# To enable AI in production, also start the ai-service container:
+#   docker compose --profile ai up -d
+AI_SERVICE_ENABLED=true
 
 # ── Database (PostgreSQL) ─────────────────────────
 # Required: set a strong password for the database user.

--- a/Makefile
+++ b/Makefile
@@ -64,18 +64,18 @@ setup: ## First-time setup: copy .env, create data directories
 dev: ## Start all services in development mode (with hot reload)
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml up --build
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build
 
 dev-d: ## Start all services in development mode (detached)
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml up --build -d
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build -d
 
 dev-reset: ## Recreate all services in development mode from scratch (one command)
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml down --remove-orphans --volumes
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml up --build -d --force-recreate --remove-orphans --wait
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai down --remove-orphans --volumes
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build -d --force-recreate --remove-orphans --wait
 	@echo "✓ Services recreated. Use 'make logs' to follow output."
 
 prod: ## Start all services in production mode

--- a/api/config.py
+++ b/api/config.py
@@ -6,6 +6,7 @@ class Settings(BaseSettings):
 
     database_url: str = "postgresql://joidy:joidy@postgres:5432/joidy"
     ai_service_url: str = "http://ai-service:8002"
+    ai_service_enabled: bool = True  # Set to false in production to skip AI calls
     worker_url: str = "http://worker:8001"
     secret_key: str = ""
     internal_secret: str = ""  # Shared secret for API → ai-service auth

--- a/api/main.py
+++ b/api/main.py
@@ -39,7 +39,7 @@ from routers import (
 )
 from routers.integrations import github, google, spotify, strava
 from services.auth_service import get_current_user
-from fastapi import Depends
+from fastapi import Depends, HTTPException
 from services.response_cache import get_cache_stats
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -145,6 +145,11 @@ app = FastAPI(
         "- **Graph**: Tag co-occurrence knowledge graph\n"
     ),
     lifespan=lifespan,
+    # Disable auto-docs in production for security (reduces attack surface).
+    # Docs are still available in development via /docs and /redoc.
+    docs_url="/docs" if settings.app_env != "production" else None,
+    redoc_url="/redoc" if settings.app_env != "production" else None,
+    openapi_url="/openapi.json" if settings.app_env != "production" else None,
     openapi_tags=[
         {"name": "notes", "description": "Note CRUD, tags, WikiLinks, and AI embeddings"},
         {"name": "tags", "description": "Tag management and knowledge graph"},
@@ -296,25 +301,27 @@ async def health_ready():
     except Exception as e:
         checks["cache"] = f"error: {str(e)[:50]}"
 
-    # AI service check — short timeout to avoid blocking the health probe
-    # while still detecting real outages (the previous implementation was a
-    # hardcoded "ok" stub that masked a broken ai-service).
-    try:
-        import httpx
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            r = await client.get(f"{settings.ai_service_url}/health")
-            if r.status_code == 200:
-                body = r.json()
-                # Distinguish "alive" from "fully functional": if the ai-service
-                # reports "degraded" (e.g. configured provider not available),
-                # surface that here too.
-                checks["ai_service"] = body.get("status", "ok")
-            else:
-                checks["ai_service"] = f"error: HTTP {r.status_code}"
-    except Exception as e:
-        checks["ai_service"] = f"unavailable: {str(e)[:40]}"
+    # AI service check — skipped entirely when AI_SERVICE_ENABLED=false
+    # (production without AI). Previously this reported "degraded" when the
+    # ai-service was down, which caused Docker healthcheck failures even
+    # though the core app was fully functional.
+    if not settings.ai_service_enabled:
+        checks["ai_service"] = "disabled"
+    else:
+        try:
+            import httpx
+            async with httpx.AsyncClient(timeout=2.0) as client:
+                r = await client.get(f"{settings.ai_service_url}/health")
+                if r.status_code == 200:
+                    body = r.json()
+                    checks["ai_service"] = body.get("status", "ok")
+                else:
+                    checks["ai_service"] = f"error: HTTP {r.status_code}"
+        except Exception as e:
+            checks["ai_service"] = f"unavailable: {str(e)[:40]}"
 
-    all_ok = all(v == "ok" for v in checks.values())
+    # "disabled" is a valid state — only "ok" and "disabled" count as healthy
+    all_ok = all(v in ("ok", "disabled") for v in checks.values())
     return {
         "status": "ready" if all_ok else "degraded",
         "checks": checks,
@@ -329,7 +336,13 @@ def health_cache():
 
 @app.get("/debug", dependencies=[Depends(get_current_user)])
 def debug_info():
-    """Debug endpoint with safe diagnostic information."""
+    """Debug endpoint with safe diagnostic information.
+
+    Disabled in production — exposes internal counts and cache stats that
+    are useful for development but not for a public-facing deployment.
+    """
+    if settings.app_env == "production":
+        raise HTTPException(status_code=404, detail="Not Found")
     import sys
     from datetime import datetime, timezone
 

--- a/api/routers/ai.py
+++ b/api/routers/ai.py
@@ -15,6 +15,16 @@ from datetime import datetime, date, timedelta, timezone
 
 router = APIRouter(prefix="/ai", tags=["ai"])
 
+
+def _ai_disabled_response(endpoint: str) -> dict:
+    """Standard response when AI_SERVICE_ENABLED=false.
+
+    Returns a 200 with a clear 'disabled' status so the frontend can
+    distinguish 'intentionally off' from 'service crashed'.
+    """
+    return {"status": "disabled", "ai_enabled": False, "endpoint": endpoint}
+
+
 class ClassifyRequest(BaseModel):
     note_id: int
     content: str
@@ -22,6 +32,8 @@ class ClassifyRequest(BaseModel):
 
 @router.post("/classify")
 async def classify(req: ClassifyRequest):
+    if not settings.ai_service_enabled:
+        return {**_ai_disabled_response("classify"), "note_id": req.note_id, "suggestions": []}
     async with httpx.AsyncClient(timeout=30.0) as client:
         try:
             headers = {"X-Request-ID": get_correlation_id()}
@@ -39,6 +51,8 @@ async def classify(req: ClassifyRequest):
 
 @router.get("/usage")
 async def usage():
+    if not settings.ai_service_enabled:
+        return {**_ai_disabled_response("usage"), "estimated_cost_usd": 0}
     async with httpx.AsyncClient(timeout=10.0) as client:
         try:
             headers = {"X-Request-ID": get_correlation_id()}
@@ -54,6 +68,8 @@ async def usage():
 @router.post("/cluster")
 async def cluster_notes(eps: float = 0.3, min_samples: int = 3, max_notes: int = 500):
     """Cluster notes by semantic similarity via the ai-service (#393)."""
+    if not settings.ai_service_enabled:
+        return {**_ai_disabled_response("cluster"), "clusters": [], "total_notes": 0}
     async with httpx.AsyncClient(timeout=60.0) as client:
         try:
             headers = {"X-Request-ID": get_correlation_id()}
@@ -80,6 +96,12 @@ async def daily_recap(
     Gathers notes created, XP gained, goals completed, and focus time,
     then asks the ai-service to generate a natural-language summary.
     """
+    if not settings.ai_service_enabled:
+        return {
+            **_ai_disabled_response("daily-recap"),
+            "recap": "El servicio de IA está deshabilitado.",
+            "suggestions": [],
+        }
     if target_date is None:
         target_date = get_local_today().isoformat()
 
@@ -214,6 +236,12 @@ async def chat(
     /chat endpoint. The response is returned without persisting chat history
     on the backend (history lives in the frontend sessionStorage).
     """
+    if not settings.ai_service_enabled:
+        return {
+            **_ai_disabled_response("chat"),
+            "response": "El asistente de IA está deshabilitado en este modo.",
+            "suggestions": [],
+        }
     context = _gather_chat_context(db)
 
     async with httpx.AsyncClient(timeout=60.0) as client:

--- a/api/routers/analytics.py
+++ b/api/routers/analytics.py
@@ -114,6 +114,8 @@ def _activity(db: Session, days: int) -> dict:
 
 async def _ai_usage() -> dict:
     """Fetch monthly AI usage from the ai-service (best-effort)."""
+    if not settings.ai_service_enabled:
+        return {"ai_enabled": False, "estimated_cost_usd": 0, "status": "disabled"}
     async with httpx.AsyncClient(timeout=5.0) as client:
         try:
             headers = {"X-Request-ID": get_correlation_id()}

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -22,6 +22,7 @@ CONFIG_KEYS = {
     "telegram_allowed_user_id": "TELEGRAM_ALLOWED_USER_ID",
     "secret_key": "SECRET_KEY",
     "app_env": "APP_ENV",
+    "ai_service_enabled": "AI_SERVICE_ENABLED",
 }
 
 PUBLIC_KEYS = {
@@ -36,6 +37,7 @@ PUBLIC_KEYS = {
     "telegram_allowed_user_id": False,
     "secret_key": False,
     "app_env": True,
+    "ai_service_enabled": True,
 }
 
 

--- a/api/routers/notes.py
+++ b/api/routers/notes.py
@@ -206,6 +206,8 @@ async def semantic_search(
     Embeds the query via the ai-service, then finds the top-K notes by
     cosine distance (``<=>``) from the stored embeddings.
     """
+    if not settings.ai_service_enabled:
+        raise HTTPException(status_code=503, detail="AI service is disabled")
     if not req.query.strip():
         return {"results": []}
 

--- a/api/services/embedding_service.py
+++ b/api/services/embedding_service.py
@@ -24,6 +24,8 @@ def _session_or_none(db: Session | None) -> Session:
 
 async def _embeddings_available() -> bool:
     """Check (cached) whether the ai-service can produce embeddings."""
+    if not settings.ai_service_enabled:
+        return False
     global _embedding_health_cache
     now = time.monotonic()
     if _embedding_health_cache is not None and now - _embedding_health_cache[1] < _EMBEDDING_HEALTH_TTL:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,6 +37,7 @@ services:
       - ${OBSIDIAN_VAULT_PATH:-./data/vault}:/vault
     environment:
       - APP_ENV=development
+      - AI_SERVICE_ENABLED=true
       - VAULT_PATH=/vault
       - OBSIDIAN_VAULT_PATH=/vault
     # The ./api:/app bind mount shadows the image's pre-chowned /app/data/logs,
@@ -48,6 +49,8 @@ services:
     command: sh -c "mkdir -p /app/data/logs 2>/dev/null || true; exec uvicorn main:app --host 0.0.0.0 --port 8000 --reload --reload-include '*.py' --reload-exclude '__pycache__/*' --reload-exclude '*.pyc'"
 
   ai-service:
+    # Clear the production profile so the AI service always starts in dev.
+    profiles: []
     build:
       context: ./ai-service
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-joidy}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-joidy}
       - AI_SERVICE_URL=http://ai-service:8002
+      - AI_SERVICE_ENABLED=${AI_SERVICE_ENABLED:-false}
       - WORKER_URL=http://worker:8001
       - APP_ENV=${APP_ENV:-production}
       - UPLOAD_DIR=/data/uploads
@@ -66,6 +67,11 @@ services:
 
   ai-service:
     image: ${DOCKER_REGISTRY:-d4mag3}/joidy-ai-service:${IMAGE_TAG:-latest}
+    # In production, the AI service is opt-in via Docker Compose profiles.
+    # It only starts with `docker compose --profile ai up`. In development,
+    # the dev overlay clears this profile so it always starts with `make dev`.
+    # See AGENTS.md § "AI Service" for details.
+    profiles: ["ai"]
     ports:
       - "${AI_SERVICE_PORT:-8002}:8002"
     volumes:
@@ -101,7 +107,6 @@ services:
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER:-joidy}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:-joidy}
       - API_URL=http://api:8000
-      - AI_SERVICE_URL=http://ai-service:8002
       - VAULT_PATH=/vault
       - APP_ENV=${APP_ENV:-production}
       - PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary

- **AI service opt-in in production**: Uses Docker Compose `profiles: ["ai"]` so the ai-service only starts with `docker compose --profile ai up`. Dev overlay clears the profile so it always starts with `make dev`.
- **`AI_SERVICE_ENABLED` flag**: New env var that short-circuits all AI endpoints in the API when `false` — no HTTP calls to the ai-service are attempted, eliminating timeouts and connection errors.
- **Production hardening**: `/docs`, `/redoc`, `/openapi.json`, and `/debug` disabled in production to reduce attack surface.
- **Health check fix**: `/health/ready` reports `"disabled"` instead of `"degraded"` when AI is off, so Docker healthchecks pass cleanly.
- **Cleanup**: Removed unused `AI_SERVICE_URL` from worker in `docker-compose.yml` (worker never calls the ai-service).

## Files changed (11)

| File | Change |
|------|--------|
| `docker-compose.yml` | `profiles: ["ai"]` on ai-service, `AI_SERVICE_ENABLED=false` for api, removed `AI_SERVICE_URL` from worker |
| `docker-compose.dev.yml` | `profiles: []` on ai-service (always starts), `AI_SERVICE_ENABLED=true` for api |
| `Makefile` | `--profile ai` on `dev`/`dev-d`/`dev-reset` commands |
| `api/config.py` | New `ai_service_enabled` setting |
| `api/main.py` | Docs/redoc/openapi disabled in prod, `/debug` disabled in prod, `/health/ready` AI check skip when disabled |
| `api/routers/ai.py` | Short-circuit on all 5 endpoints (`/classify`, `/usage`, `/cluster`, `/daily-recap`, `/chat`) |
| `api/routers/notes.py` | `/search/semantic` returns 503 when AI disabled |
| `api/routers/analytics.py` | `_ai_usage()` returns disabled response |
| `api/routers/config.py` | `AI_SERVICE_ENABLED` added to `CONFIG_KEYS`/`PUBLIC_KEYS` (UI-configurable) |
| `api/services/embedding_service.py` | `_embeddings_available()` returns `False` immediately when disabled |
| `.env.example` | Documented `AI_SERVICE_ENABLED` |

## How to enable AI in production

```bash
# Option 1: env var + profile
AI_SERVICE_ENABLED=true docker compose --profile ai up -d

# Option 2: set in .env, then start with profile
echo "AI_SERVICE_ENABLED=true" >> .env
docker compose --profile ai up -d
```

#### Test plan

- [x] 486 API tests pass (0 failures)
- [x] Production mode: 4 containers healthy, `/health/ready` → `{"status": "ready", "ai_service": "disabled"}`
- [x] Production mode: `/docs`, `/openapi.json` → 404
- [x] Dev mode: 5 containers healthy (ai-service starts), `/docs` → 200
- [x] Dev mode: `/health/ready` → `ai_service: "degraded"` (expected — no GEMINI_API_KEY configured)
- [x] Frontend serves correctly in both modes

Generated with [Devin](https://devin.ai)