### PR TITLE
fix(frontend): hide Google Calendar & Tasks integration behind dev mode

### DIFF
--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -760,29 +760,30 @@
               </div>
               <button class="link-btn">Enlazar</button>
             </div>
-          {/if}
-          <div class="row">
-            <div class="row-label">
-              <span>Google Calendar & Tasks</span>
-              {#if googleConnected}<span class="badge badge-on" style="margin-left:4px"
-                  >Conectado</span
-                >{/if}
+            <div class="row">
+              <div class="row-label">
+                <span>Google Calendar & Tasks</span>
+                {#if googleConnected}<span class="badge badge-on" style="margin-left:4px"
+                    >Conectado</span
+                  >{/if}
+              </div>
+              {#if googleConnecting}
+                <span class="mono" style="font-size:12px; color: var(--text-muted);"
+                  >Conectando…</span
+                >
+              {:else if googleConnected}
+                <button
+                  class="link-btn"
+                  onclick={disconnectGoogle}
+                  style="background:var(--border); color:var(--text-secondary);">Desconectar</button
+                >
+              {:else}
+                <button class="link-btn" onclick={startGoogleAuth}>Enlazar</button>
+              {/if}
             </div>
-            {#if googleConnecting}
-              <span class="mono" style="font-size:12px; color: var(--text-muted);">Conectando…</span
-              >
-            {:else if googleConnected}
-              <button
-                class="link-btn"
-                onclick={disconnectGoogle}
-                style="background:var(--border); color:var(--text-secondary);">Desconectar</button
-              >
-            {:else}
-              <button class="link-btn" onclick={startGoogleAuth}>Enlazar</button>
+            {#if googleError}
+              <p class="hint" style="color:var(--danger)">{googleError}</p>
             {/if}
-          </div>
-          {#if googleError}
-            <p class="hint" style="color:var(--danger)">{googleError}</p>
           {/if}
         </section>
 


### PR DESCRIPTION
## Summary

- Wrap the Google Calendar & Tasks integration section in `{#if $devMode}` to match the pattern already used for Contacts, Strava, Gmail, and Spotify
- With dev mode OFF, only GitHub (fully functional integration) is shown in Settings → Integrations
- With dev mode ON, all experimental integrations are visible (including Google Calendar & Tasks)
- The Google OAuth flow remains accessible for developers/testers when dev mode is enabled

## Rationale

The Google Calendar & Tasks integration is only a scaffold (issue #2 is closed but only partially implemented). Showing it to end users without dev mode creates a broken/confusing experience — the "Enlazar" button starts an OAuth flow that doesn't complete real synchronization.

Closes #851

#### Test plan

- [ ] `npm run check` passes (0 errors)
- [ ] With dev mode OFF: Settings → Integrations shows only GitHub
- [ ] With dev mode ON: Settings → Integrations shows GitHub + all experimental integrations (Contacts, Strava, Gmail, Spotify, Google Calendar & Tasks, IA)
- [ ] Google OAuth flow still works when dev mode is ON
- [ ] No layout regression in the Integrations section

Generated with [Devin](https://devin.ai)