### PR TITLE
fix(frontend): StreakHeatmap theme-aware empty cells + year view spacing

### DIFF
--- a/frontend/src/lib/components/StreakHeatmap.svelte
+++ b/frontend/src/lib/components/StreakHeatmap.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import StreakIcon from './StreakIcon.svelte';
-  import type { StreakDay } from "$lib/api";
+  import type { StreakDay } from '$lib/api';
   import { t } from 'svelte-i18n';
 
   let {
     history = [],
-    color = "#c8a96e",
+    color = '#c8a96e',
     startDate = null,
     targetDate = null,
     /** ISO date string currently highlighted by the parent */
@@ -26,13 +26,13 @@
     hideTabs?: boolean;
   } = $props();
 
-  type ViewMode = "week" | "month" | "year";
+  type ViewMode = 'week' | 'month' | 'year';
 
   function getInitialView(): ViewMode {
-    if (typeof localStorage === 'undefined') return "year";
+    if (typeof localStorage === 'undefined') return 'year';
     const saved = localStorage.getItem('goals.historyView');
     if (saved === 'week' || saved === 'month' || saved === 'year') return saved;
-    return "year";
+    return 'year';
   }
 
   let view: ViewMode = $state(getInitialView());
@@ -47,8 +47,8 @@
 
   function localIso(date: Date) {
     const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
   }
 
@@ -88,10 +88,20 @@
     return newMap;
   });
 
-  const DAY_NAMES = ["LUN", "MAR", "MIÉ", "JUE", "VIE", "SÁB", "DOM"];
+  const DAY_NAMES = ['LUN', 'MAR', 'MIÉ', 'JUE', 'VIE', 'SÁB', 'DOM'];
   const MONTH_NAMES = [
-    "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio",
-    "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre",
+    'Enero',
+    'Febrero',
+    'Marzo',
+    'Abril',
+    'Mayo',
+    'Junio',
+    'Julio',
+    'Agosto',
+    'Septiembre',
+    'Octubre',
+    'Noviembre',
+    'Diciembre',
   ];
 
   const currentMonthStart = new Date(today.getFullYear(), today.getMonth(), 1);
@@ -161,20 +171,26 @@
   function shiftYearMonth(offset: number) {
     const nextCursor = new Date(yearCursor.getFullYear(), yearCursor.getMonth() + offset, 1);
     if (monthKey(nextCursor) < monthKey(minYearMonth)) return;
-    
-    const maxFuture = (maxFutureMonths && !Number.isNaN(maxFutureMonths)) ? maxFutureMonths : 0;
+
+    const maxFuture = maxFutureMonths && !Number.isNaN(maxFutureMonths) ? maxFutureMonths : 0;
     if (monthKey(nextCursor) > monthKey(currentMonthStart) + maxFuture) return;
-    
+
     yearCursor = nextCursor;
   }
 
   function handleYearKeyboardNav(event: KeyboardEvent) {
-    if (view !== "year") return;
+    if (view !== 'year') return;
     const target = event.target as HTMLElement | null;
     const tag = target?.tagName;
-    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target?.isContentEditable) return;
-    if (event.key === "ArrowLeft") { event.preventDefault(); shiftYearMonth(-1); }
-    else if (event.key === "ArrowRight") { event.preventDefault(); shiftYearMonth(1); }
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target?.isContentEditable)
+      return;
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      shiftYearMonth(-1);
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      shiftYearMonth(1);
+    }
   }
 
   function selectDay(iso: string) {
@@ -202,16 +218,22 @@
 <div class="activity" style="--ac: {color};">
   {#if !hideTabs}
     <div class="tabs">
-      <button class="tab" class:on={view === "week"} onclick={() => (view = "week")}>{$t('streakHeatmap.week')}</button>
-      <button class="tab" class:on={view === "month"} onclick={() => (view = "month")}>{$t('streakHeatmap.month')}</button>
-      <button class="tab" class:on={view === "year"} onclick={() => (view = "year")}>{$t('streakHeatmap.year')}</button>
+      <button class="tab" class:on={view === 'week'} onclick={() => (view = 'week')}
+        >{$t('streakHeatmap.week')}</button
+      >
+      <button class="tab" class:on={view === 'month'} onclick={() => (view = 'month')}
+        >{$t('streakHeatmap.month')}</button
+      >
+      <button class="tab" class:on={view === 'year'} onclick={() => (view = 'year')}
+        >{$t('streakHeatmap.year')}</button
+      >
     </div>
   {/if}
 
   <div class="view-title-row">
-    {#if view === "week"}
+    {#if view === 'week'}
       <span class="title">{$t('streakHeatmap.currentWeek')}</span>
-    {:else if view === "month"}
+    {:else if view === 'month'}
       <span class="title">{MONTH_LABEL}</span>
     {:else}
       <button
@@ -237,7 +259,7 @@
   </div>
 
   <div class="view-area">
-    {#if view === "week"}
+    {#if view === 'week'}
       <div class="week-wrap">
         <div class="mhdr">
           {#each DAY_NAMES as label}
@@ -257,19 +279,21 @@
               title={day.iso}
             >
               <div class="wd-num-wrap">
-                <span class="wd-num"
+                <span
+                  class="wd-num"
                   class:today-num={day.isToday}
                   class:checked-num={day.checked && !day.isToday}
                   class:failed-num={day.failed && !day.checked && !day.isToday}
                   class:target-num={day.isTarget}
                   class:selected-num={day.isSelected && !day.isToday && !day.checked && !day.failed}
-                >{day.dayNum}</span>
+                  >{day.dayNum}</span
+                >
               </div>
             </button>
           {/each}
         </div>
       </div>
-    {:else if view === "month"}
+    {:else if view === 'month'}
       <div class="month-wrap">
         <div class="mhdr">
           {#each DAY_NAMES as label}
@@ -292,7 +316,17 @@
                 disabled={!cell.inMonth}
               >
                 {#if cell.inMonth}
-                  <span class="mday" class:on={cell.checked && !cell.isToday} class:mtoday={cell.isToday} class:mfailed={cell.failed && !cell.checked && !cell.isToday} class:mtarget={cell.isTarget} class:mselected={cell.isSelected && !cell.isToday && !cell.checked && !cell.failed}>{cell.dayNum}</span>
+                  <span
+                    class="mday"
+                    class:on={cell.checked && !cell.isToday}
+                    class:mtoday={cell.isToday}
+                    class:mfailed={cell.failed && !cell.checked && !cell.isToday}
+                    class:mtarget={cell.isTarget}
+                    class:mselected={cell.isSelected &&
+                      !cell.isToday &&
+                      !cell.checked &&
+                      !cell.failed}>{cell.dayNum}</span
+                  >
                 {/if}
               </button>
             {/each}
@@ -323,7 +357,17 @@
                   disabled={!cell.inMonth}
                 >
                   {#if cell.inMonth}
-                    <span class="mday" class:on={cell.checked && !cell.isToday} class:mtoday={cell.isToday} class:mfailed={cell.failed && !cell.checked && !cell.isToday} class:mtarget={cell.isTarget} class:mselected={cell.isSelected && !cell.isToday && !cell.checked && !cell.failed}>{cell.dayNum}</span>
+                    <span
+                      class="mday"
+                      class:on={cell.checked && !cell.isToday}
+                      class:mtoday={cell.isToday}
+                      class:mfailed={cell.failed && !cell.checked && !cell.isToday}
+                      class:mtarget={cell.isTarget}
+                      class:mselected={cell.isSelected &&
+                        !cell.isToday &&
+                        !cell.checked &&
+                        !cell.failed}>{cell.dayNum}</span
+                    >
                   {/if}
                 </button>
               {/each}
@@ -368,7 +412,9 @@
     letter-spacing: 0.04em;
   }
 
-  .tab:hover { color: var(--text-muted); }
+  .tab:hover {
+    color: var(--text-muted);
+  }
 
   .tab.on {
     background: var(--surface);
@@ -395,6 +441,7 @@
     justify-content: center;
     gap: 16px;
     width: 100%;
+    margin-bottom: 8px;
   }
 
   .title {
@@ -449,14 +496,29 @@
     margin-left: -1px;
     margin-top: -1px;
     cursor: pointer;
-    transition: border-color 0.15s, background 0.15s;
+    transition:
+      border-color 0.15s,
+      background 0.15s;
     padding: 0;
   }
 
-  .week-col:first-child { margin-left: 0; }
-  .week-col:hover { border-color: var(--ac); z-index: var(--z-base); background: color-mix(in srgb, var(--ac) 8%, var(--surface)); }
-  .week-col.checked { border-color: var(--ac); z-index: var(--z-base); }
-  .week-col.selected { border-color: var(--ac); box-shadow: 0 0 0 2px var(--ac); z-index: 3; }
+  .week-col:first-child {
+    margin-left: 0;
+  }
+  .week-col:hover {
+    border-color: var(--ac);
+    z-index: var(--z-base);
+    background: color-mix(in srgb, var(--ac) 8%, var(--surface));
+  }
+  .week-col.checked {
+    border-color: var(--ac);
+    z-index: var(--z-base);
+  }
+  .week-col.selected {
+    border-color: var(--ac);
+    box-shadow: 0 0 0 2px var(--ac);
+    z-index: 3;
+  }
 
   /* ── Day number / emoji ── */
   .wd-num-wrap {
@@ -479,7 +541,8 @@
     transition: all 0.2s;
   }
 
-  .week-col.failed, .mcell.failed {
+  .week-col.failed,
+  .mcell.failed {
     border-color: var(--error);
     z-index: var(--z-base);
   }
@@ -516,22 +579,36 @@
     font-weight: 700;
   }
 
-  .wd-num.today-num, .mday.mtoday { font-weight: 700; }
-  .wd-num.checked-num, .mday.on { font-weight: 600; }
-  .wd-num.failed-num, .mday.mfailed { font-weight: 600; }
+  .wd-num.today-num,
+  .mday.mtoday {
+    font-weight: 700;
+  }
+  .wd-num.checked-num,
+  .mday.on {
+    font-weight: 600;
+  }
+  .wd-num.failed-num,
+  .mday.mfailed {
+    font-weight: 600;
+  }
 
   .wd-num.selected-num,
   .mday.mselected {
     box-shadow: 0 0 0 2px var(--ac);
   }
 
-  .wd-num.target-num, .mday.mtarget {
+  .wd-num.target-num,
+  .mday.mtarget {
     background: var(--target);
     color: #000;
     font-weight: 700;
   }
 
-  .week-col.target, .mcell.target { border-color: var(--target); z-index: 2; }
+  .week-col.target,
+  .mcell.target {
+    border-color: var(--target);
+    z-index: 2;
+  }
 
   /* ── Month grid ── */
   .mgrid {
@@ -554,7 +631,9 @@
     align-items: center;
     justify-content: center;
     background: var(--surface);
-    transition: box-shadow 0.15s, background 0.15s;
+    transition:
+      box-shadow 0.15s,
+      background 0.15s;
     cursor: pointer;
     border: none;
     padding: 0;
@@ -566,20 +645,36 @@
     z-index: var(--z-base);
   }
 
-  .mcell.checked { box-shadow: inset 0 0 0 1px var(--ac); z-index: var(--z-base); }
-  .mcell.failed:not(.checked) { box-shadow: inset 0 0 0 1px var(--error); }
-  .mcell.today { box-shadow: inset 0 0 0 1px var(--today); z-index: 4; }
-  .mcell.selected { box-shadow: inset 0 0 0 2px var(--ac); z-index: 3; }
-  .mcell.today.selected { box-shadow: inset 0 0 0 2px var(--today); z-index: 5; }
+  .mcell.checked {
+    box-shadow: inset 0 0 0 1px var(--ac);
+    z-index: var(--z-base);
+  }
+  .mcell.failed:not(.checked) {
+    box-shadow: inset 0 0 0 1px var(--error);
+  }
+  .mcell.today {
+    box-shadow: inset 0 0 0 1px var(--today);
+    z-index: 4;
+  }
+  .mcell.selected {
+    box-shadow: inset 0 0 0 2px var(--ac);
+    z-index: 3;
+  }
+  .mcell.today.selected {
+    box-shadow: inset 0 0 0 2px var(--today);
+    z-index: 5;
+  }
 
   .mcell.empty {
-    background: #000;
+    background: var(--elevated);
     opacity: 1;
     cursor: default;
     pointer-events: none;
   }
 
-  .mcell:disabled { cursor: default; }
+  .mcell:disabled {
+    cursor: default;
+  }
 
   .mday {
     width: 38px;
@@ -603,7 +698,9 @@
     margin: 0 auto;
   }
 
-  .year-wrap .month-wrap { max-width: 560px; }
+  .year-wrap .month-wrap {
+    max-width: 560px;
+  }
 
   .nav-btn {
     display: flex;
@@ -621,7 +718,11 @@
     transition: all 0.2s;
   }
 
-  .nav-btn:hover { color: var(--ac); border-color: var(--ac); background: var(--surface-hover); }
+  .nav-btn:hover {
+    color: var(--ac);
+    border-color: var(--ac);
+    background: var(--surface-hover);
+  }
 
   .nav-btn.disabled,
   .nav-btn:disabled {


### PR DESCRIPTION
## Summary

- Replace hardcoded `#000` background on empty calendar cells with `var(--elevated)` so it adapts to light/dark themes (#840)
- Add `margin-bottom: 8px` to `.view-title-row` to prevent the month title row (with navigation arrows) from overlapping with day-of-week headers in year view (#843)

## Changes

**#840 — Calendar hardcoded dark background:**
- `.mcell.empty` background: `#000` → `var(--elevated)` — empty cells now use the theme's elevated surface color instead of a hardcoded black

**#843 — Streaks year view overlap:**
- `.view-title-row` gets `margin-bottom: 8px` — ensures clear separation between the month/year title navigation row and the day-of-week header grid below

Closes #840, #843

#### Test plan

- [ ] `npm run check` passes
- [ ] Empty calendar cells render with correct theme-aware background in light mode (not black)
- [ ] Empty calendar cells render correctly in dark mode
- [ ] Year view: month title row (with ‹ › nav buttons) does not overlap with day-of-week headers
- [ ] Week and month views are not affected by the spacing change
- [ ] Layout is responsive on mobile

Generated with [Devin](https://devin.ai)