### PR TITLE
fix(frontend): redesign resize handle to be theme-aware and minimalist

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -8,67 +8,67 @@
 /* ── Custom Properties ──────────────────────────────────────────────────────── */
 :root {
   /* Base surfaces — AMOLED */
-  --bg:           #000000;
-  --surface:      #000000;
-  --elevated:     #000000;
-  --hover:        #0c0c0c;
-  --border:       #1a1a1a;
+  --bg: #000000;
+  --surface: #000000;
+  --elevated: #000000;
+  --hover: #0c0c0c;
+  --border: #1a1a1a;
   --border-light: #111111;
 
   /* Text — all white-range */
-  --text-primary:   #ffffff;
+  --text-primary: #ffffff;
   --text-secondary: #d0d0d0;
-  --text-muted:     #888888;
-  --text-disabled:  #444444;
+  --text-muted: #888888;
+  --text-disabled: #444444;
 
   /* Accents — used sparingly */
-  --accent:          #e0e0e0;   /* Primary interactive elements */
-  --xp:              #c8a96e;   /* Primary accent color (JS-overridden) */
-  --xp-2:            #9f8660;   /* Secondary accent color (JS-overridden) */
-  --xp-3:            #7e6a4d;   /* Tertiary accent color (JS-overridden) */
-  --xp-dark:         #9f8660;   /* Accent dark shade fallback */
-  --accent-gradient: #c8a96e;   /* Gradient or solid (JS-overridden) */
-  --plant:           #c8a96e;   /* Plant/module strokes — follows --xp */
+  --accent: #e0e0e0; /* Primary interactive elements */
+  --xp: #c8a96e; /* Primary accent color (JS-overridden) */
+  --xp-2: #9f8660; /* Secondary accent color (JS-overridden) */
+  --xp-3: #7e6a4d; /* Tertiary accent color (JS-overridden) */
+  --xp-dark: #9f8660; /* Accent dark shade fallback */
+  --accent-gradient: #c8a96e; /* Gradient or solid (JS-overridden) */
+  --plant: #c8a96e; /* Plant/module strokes — follows --xp */
   --plant-secondary: #9f8660;
-  --plant-tertiary:  #7e6a4d;
-  --plant-glow:      #9f8660;   /* Plant highlight */
-  --success:         #10b981;   /* Completions — emerald (matches streaks) */
-  --error:           #ef4444;   /* Failures — matches streaks red */
+  --plant-tertiary: #7e6a4d;
+  --plant-glow: #9f8660; /* Plant highlight */
+  --success: #10b981; /* Completions — emerald (matches streaks) */
+  --error: #ef4444; /* Failures — matches streaks red */
 
   /* Layout */
-  --sidebar-w:  48px;
-  --header-h:   48px;
+  --sidebar-w: 48px;
+  --header-h: 48px;
   --statusbar-h: 36px;
 
   /* Responsive breakpoints */
   --bp-mobile-s: 480px;
-  --bp-mobile:   768px;
-  --bp-tablet:   1024px;
-  --bp-desktop:  1440px;
+  --bp-mobile: 768px;
+  --bp-tablet: 1024px;
+  --bp-desktop: 1440px;
 
   /* Typography */
   --font-sans: 'Geist', 'Helvetica Neue', system-ui, sans-serif;
   --font-mono: 'Geist Mono', 'Fira Code', monospace;
 
   /* Sizing scale */
-  --s0_5:  2px;
-  --s1:    4px;
-  --s1_5:  6px;
-  --s2:    8px;
-  --s2_5:  10px;
-  --s3:    12px;
-  --s3_5:  14px;
-  --s4:    16px;
-  --s4_5:  20px;
-  --s5:    24px;
-  --s6:    32px;
-  --s7:    48px;
-  --s8:    64px;
+  --s0_5: 2px;
+  --s1: 4px;
+  --s1_5: 6px;
+  --s2: 8px;
+  --s2_5: 10px;
+  --s3: 12px;
+  --s3_5: 14px;
+  --s4: 16px;
+  --s4_5: 20px;
+  --s5: 24px;
+  --s6: 32px;
+  --s7: 48px;
+  --s8: 64px;
 
   /* Transitions */
-  --t-fast:   50ms ease-out;
+  --t-fast: 50ms ease-out;
   --t-normal: 80ms ease-out;
-  --t-slow:   120ms ease-out;
+  --t-slow: 120ms ease-out;
 
   /* Border radius */
   --r: 4px;
@@ -98,22 +98,29 @@
 }
 
 [data-theme='light'] {
-  --bg:           #ffffff;
-  --surface:      #ffffff;
-  --elevated:     #ffffff;
-  --hover:        #f0f0f0;
-  --border:       #000000;
+  --bg: #ffffff;
+  --surface: #ffffff;
+  --elevated: #ffffff;
+  --hover: #f0f0f0;
+  --border: #000000;
   --border-light: #cfcfcf;
-  --text-primary:   #000000;
+  --text-primary: #000000;
   --text-secondary: #222222;
-  --text-muted:     #666666;
-  --text-disabled:  #999999;
+  --text-muted: #666666;
+  --text-disabled: #999999;
 }
 
 /* ── Reset & Base ────────────────────────────────────────────────────────────── */
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
 
-html, body {
+html,
+body {
   height: 100%;
   background: var(--bg);
   color: var(--text-primary);
@@ -126,11 +133,14 @@ html, body {
   margin: 0;
   overflow: hidden;
   /* Smooth transitions for dynamic theme changes (#356) */
-  transition: background-color 2s ease, color 2s ease;
+  transition:
+    background-color 2s ease,
+    color 2s ease;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  html, body {
+  html,
+  body {
     transition: none;
   }
   .app-main {
@@ -138,17 +148,41 @@ html, body {
   }
 }
 
-#svelte { height: 100%; }
+#svelte {
+  height: 100%;
+}
 
 /* ── Typography ──────────────────────────────────────────────────────────────── */
-h1 { font-size: 28px; font-weight: 300; letter-spacing: -0.02em; }
-h2 { font-size: 20px; font-weight: 400; letter-spacing: -0.01em; }
-h3 { font-size: 16px; font-weight: 400; }
-h4 { font-size: 14px; font-weight: 500; }
+h1 {
+  font-size: 28px;
+  font-weight: 300;
+  letter-spacing: -0.02em;
+}
+h2 {
+  font-size: 20px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+}
+h3 {
+  font-size: 16px;
+  font-weight: 400;
+}
+h4 {
+  font-size: 14px;
+  font-weight: 500;
+}
 
-.mono { font-family: var(--font-mono); }
-.muted { color: var(--text-secondary); }
-.caption { font-size: 11px; color: var(--text-muted); letter-spacing: 0.03em; }
+.mono {
+  font-family: var(--font-mono);
+}
+.muted {
+  color: var(--text-secondary);
+}
+.caption {
+  font-size: 11px;
+  color: var(--text-muted);
+  letter-spacing: 0.03em;
+}
 .label {
   font-size: 10px;
   font-family: var(--font-mono);
@@ -163,9 +197,9 @@ h4 { font-size: 14px; font-weight: 500; }
   grid-template-columns: var(--sidebar-w) 1fr;
   grid-template-rows: var(--header-h) 1fr var(--statusbar-h);
   grid-template-areas:
-    "header header"
-    "sidebar main"
-    "statusbar statusbar";
+    'header header'
+    'sidebar main'
+    'statusbar statusbar';
   height: 100vh;
   margin: 0;
   overflow: hidden;
@@ -181,7 +215,7 @@ body.zen-mode-active .app-statusbar {
 body.zen-mode-active .app-shell {
   grid-template-columns: 1fr;
   grid-template-rows: 1fr;
-  grid-template-areas: "main";
+  grid-template-areas: 'main';
 }
 
 .app-header {
@@ -240,7 +274,9 @@ body.zen-mode-active .app-shell {
   border-radius: var(--r);
   color: var(--text-muted);
   cursor: pointer;
-  transition: background var(--t-normal), color var(--t-normal);
+  transition:
+    background var(--t-normal),
+    color var(--t-normal);
   text-decoration: none;
   border: 1px solid transparent;
   position: relative;
@@ -271,7 +307,9 @@ body.zen-mode-active .app-shell {
   pointer-events: none;
   opacity: 0;
   transform: translateX(-4px);
-  transition: opacity var(--t-normal), transform var(--t-normal);
+  transition:
+    opacity var(--t-normal),
+    transform var(--t-normal);
   z-index: var(--z-dropdown);
   color: var(--text-primary);
   font-family: var(--font-mono);
@@ -423,7 +461,9 @@ textarea.input {
   align-items: center;
 }
 
-.tag-chip button:hover { opacity: 1; }
+.tag-chip button:hover {
+  opacity: 1;
+}
 
 /* ── Progress bars ───────────────────────────────────────────────────────────── */
 .progress-track {
@@ -440,7 +480,9 @@ textarea.input {
   transition: width 600ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.progress-fill.success { background: var(--success); }
+.progress-fill.success {
+  background: var(--success);
+}
 
 /* ── Dividers ────────────────────────────────────────────────────────────────── */
 .divider {
@@ -482,17 +524,37 @@ textarea.input {
 }
 
 /* ── Scrollbar ───────────────────────────────────────────────────────────────── */
-::-webkit-scrollbar { width: 4px; height: 4px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
-::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
 
 /* ── XP Float Animation ──────────────────────────────────────────────────────── */
 @keyframes xp-float {
-  0%   { opacity: 0; transform: translateY(0px); }
-  15%  { opacity: 1; }
-  85%  { opacity: 1; }
-  100% { opacity: 0; transform: translateY(-32px); }
+  0% {
+    opacity: 0;
+    transform: translateY(0px);
+  }
+  15% {
+    opacity: 1;
+  }
+  85% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-32px);
+  }
 }
 
 .xp-float {
@@ -508,43 +570,102 @@ textarea.input {
 
 /* ── Plant breathing animation ───────────────────────────────────────────────── */
 @keyframes breathe {
-  0%, 100% { transform: scale(1) translateY(0); }
-  50%       { transform: scale(1.015) translateY(-2px); }
+  0%,
+  100% {
+    transform: scale(1) translateY(0);
+  }
+  50% {
+    transform: scale(1.015) translateY(-2px);
+  }
 }
 
 @keyframes wilt {
-  0%, 100% { transform: rotate(0deg) translateY(0); }
-  30%       { transform: rotate(-1.5deg) translateY(1px); }
-  70%       { transform: rotate(1deg) translateY(0.5px); }
+  0%,
+  100% {
+    transform: rotate(0deg) translateY(0);
+  }
+  30% {
+    transform: rotate(-1.5deg) translateY(1px);
+  }
+  70% {
+    transform: rotate(1deg) translateY(0.5px);
+  }
 }
 
 /* ── Fade transitions ────────────────────────────────────────────────────────── */
 @keyframes fadeIn {
-  from { opacity: 0; transform: translateY(4px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
-.fade-in { animation: fadeIn var(--t-slow) ease-out forwards; }
+.fade-in {
+  animation: fadeIn var(--t-slow) ease-out forwards;
+}
 
 /* ── Utility ─────────────────────────────────────────────────────────────────── */
-.flex { display: flex; }
-.flex-col { flex-direction: column; }
-.items-center { align-items: center; }
-.justify-between { justify-content: space-between; }
-.gap-1 { gap: var(--s1); }
-.gap-2 { gap: var(--s2); }
-.gap-3 { gap: var(--s3); }
-.gap-4 { gap: var(--s4); }
-.flex-1 { flex: 1; }
-.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.w-full { width: 100%; }
-.p-4 { padding: var(--s4); }
-.p-5 { padding: var(--s5); }
-.mt-2 { margin-top: var(--s2); }
-.mt-4 { margin-top: var(--s4); }
-.text-xp { color: var(--xp); font-family: var(--font-mono); }
-.text-success { color: var(--success); }
-.text-error { color: var(--error); }
+.flex {
+  display: flex;
+}
+.flex-col {
+  flex-direction: column;
+}
+.items-center {
+  align-items: center;
+}
+.justify-between {
+  justify-content: space-between;
+}
+.gap-1 {
+  gap: var(--s1);
+}
+.gap-2 {
+  gap: var(--s2);
+}
+.gap-3 {
+  gap: var(--s3);
+}
+.gap-4 {
+  gap: var(--s4);
+}
+.flex-1 {
+  flex: 1;
+}
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.w-full {
+  width: 100%;
+}
+.p-4 {
+  padding: var(--s4);
+}
+.p-5 {
+  padding: var(--s5);
+}
+.mt-2 {
+  margin-top: var(--s2);
+}
+.mt-4 {
+  margin-top: var(--s4);
+}
+.text-xp {
+  color: var(--xp);
+  font-family: var(--font-mono);
+}
+.text-success {
+  color: var(--success);
+}
+.text-error {
+  color: var(--error);
+}
 
 /* ── Responsive (mobile) ─────────────────────────────────────────────────────── */
 @media (max-width: 768px) {
@@ -552,9 +673,9 @@ textarea.input {
     grid-template-columns: 1fr;
     grid-template-rows: var(--header-h) 1fr auto;
     grid-template-areas:
-      "header"
-      "main"
-      "sidebar";
+      'header'
+      'main'
+      'sidebar';
   }
 
   .app-sidebar {
@@ -671,8 +792,8 @@ textarea.input {
     grid-template-columns: var(--sidebar-w) 1fr;
     grid-template-rows: var(--header-h) 1fr;
     grid-template-areas:
-      "header header"
-      "sidebar main";
+      'header header'
+      'sidebar main';
   }
   .app-sidebar {
     flex-direction: column;
@@ -689,14 +810,35 @@ textarea.input {
   background: transparent;
   border-left: 1px solid var(--border);
   cursor: col-resize;
-  transition: border-color var(--t-fast), background var(--t-fast);
+  transition:
+    border-color var(--t-fast),
+    background var(--t-fast);
   position: relative;
   z-index: var(--z-sticky);
 }
+.resize-handle::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 2px;
+  height: 24px;
+  border-radius: 2px;
+  background: var(--border);
+  transition:
+    background var(--t-fast),
+    height var(--t-fast);
+}
 .resize-handle:hover,
 .dragging .resize-handle {
-  border-left-color: var(--text-muted);
-  background: color-mix(in srgb, var(--text-muted) 10%, transparent);
+  border-left-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+}
+.resize-handle:hover::before,
+.dragging .resize-handle::before {
+  background: var(--accent);
+  height: 32px;
 }
 .resize-handle::after {
   content: '';
@@ -706,9 +848,15 @@ textarea.input {
 .resize-handle.static {
   cursor: default;
 }
+.resize-handle.static::before {
+  display: none;
+}
 .resize-handle.static:hover {
   background: transparent;
   border-left-color: var(--border);
+}
+.resize-handle.static:hover::before {
+  display: none;
 }
 
 /* Global Implicit Keyboard Navigation Focus */


### PR DESCRIPTION
## Summary

Redesign the global resize handle (`.resize-handle` in `app.css`) with a minimalist, theme-aware approach:

- **Default state**: subtle 1px border line with a centered 24px grip indicator pill (using `var(--border)`)
- **Hover/dragging state**: grip indicator grows to 32px and turns accent-colored, with a subtle accent-tinted background — provides clear affordance for dragging
- **Static handles**: grip indicator is hidden entirely (non-draggable dividers remain as plain lines)
- All colors use CSS variables (`--border`, `--accent`) that adapt to both light and dark themes

## Changes

- Added `::before` pseudo-element to `.resize-handle` for the grip indicator
- Hover/dragging state now uses `color-mix` with `--accent` instead of `--text-muted` for a more polished look
- `.resize-handle.static::before` and `.resize-handle.static:hover::before` hide the grip indicator on non-draggable dividers

Closes #841

#### Test plan

- [ ] `npm run check` passes
- [ ] Notes page: resize handle shows subtle grip indicator by default
- [ ] Notes page: grip indicator grows and turns accent-colored on hover
- [ ] Streaks page: static resize handle shows no grip indicator
- [ ] Works correctly in both light and dark themes
- [ ] Dragging functionality is not affected

Generated with [Devin](https://devin.ai)