### PR TITLE
fix(frontend): theme-aware disconnect buttons and settings panel colors

### DIFF
--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -720,10 +720,8 @@
             {:else if githubConnected}
               <div style="display:flex; align-items:center; gap:8px;">
                 <span class="mono" style="font-size:12px; color: var(--xp);">{githubUsername}</span>
-                <button
-                  class="link-btn"
-                  onclick={disconnectGithub}
-                  style="background:var(--border); color:var(--text-secondary);">Desconectar</button
+                <button class="link-btn disconnect-btn" onclick={disconnectGithub}
+                  >Desconectar</button
                 >
               </div>
             {:else}
@@ -772,10 +770,8 @@
                   >Conectando…</span
                 >
               {:else if googleConnected}
-                <button
-                  class="link-btn"
-                  onclick={disconnectGoogle}
-                  style="background:var(--border); color:var(--text-secondary);">Desconectar</button
+                <button class="link-btn disconnect-btn" onclick={disconnectGoogle}
+                  >Desconectar</button
                 >
               {:else}
                 <button class="link-btn" onclick={startGoogleAuth}>Enlazar</button>
@@ -904,7 +900,7 @@
   .backdrop {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.6);
+    background: color-mix(in srgb, var(--bg) 60%, transparent);
     z-index: var(--z-dropdown);
     display: flex;
     align-items: flex-start;
@@ -1100,6 +1096,17 @@
   }
   .link-btn.disabled:hover {
     opacity: 0.6;
+  }
+
+  .disconnect-btn {
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+  }
+  .disconnect-btn:hover {
+    background: var(--hover);
+    border-color: var(--text-muted);
+    color: var(--text-primary);
   }
 
   .row-label.disabled {
@@ -1313,7 +1320,7 @@
     background: var(--accent, var(--xp));
     border: none;
     border-radius: var(--r);
-    color: #fff;
+    color: var(--bg);
     font-size: 12px;
     font-family: var(--font-mono);
     cursor: pointer;


### PR DESCRIPTION
## Summary

- GitHub and Google "Desconectar" (disconnect) buttons used `style="background:var(--border)"` which is `#000000` in light mode — making the button text invisible against the black background
- Replaced inline styles with a new `.disconnect-btn` class: transparent background + themed border that adapts to both light and dark themes
- Fixed `.save-config-btn` `color: #fff` → `var(--bg)` (was invisible on light background)
- Fixed `.backdrop` `background: rgba(0,0,0,0.6)` → `color-mix(in srgb, var(--bg) 60%, transparent)` for theme-aware overlay

## Changes

| Element | Before | After |
|---------|--------|-------|
| Disconnect buttons | `style="background:var(--border); color:var(--text-secondary)"` | `.disconnect-btn` class (transparent + border) |
| Save config button text | `color: #fff` | `color: var(--bg)` |
| Settings backdrop | `rgba(0, 0, 0, 0.6)` | `color-mix(in srgb, var(--bg) 60%, transparent)` |

Closes #844

#### Test plan

- [ ] `npm run check` passes
- [ ] GitHub integration: "Desconectar" button is visible and readable in light mode
- [ ] GitHub integration: "Desconectar" button is visible and readable in dark mode
- [ ] Google integration (dev mode): "Desconectar" button renders correctly in both themes
- [ ] Save config button text is readable in both themes
- [ ] Settings panel backdrop overlay adapts to theme

Generated with [Devin](https://devin.ai)