### PR TITLE
fix(scripts): install CLI in PowerShell + handle --profile ai in CLI/autostart

### DIFF
--- a/scripts/install-autostart.ps1
+++ b/scripts/install-autostart.ps1
@@ -33,10 +33,23 @@ if ($PSVersionTable.Platform -ne "Win32NT" -and (-not $osEnv -or -not $osEnv.Con
   exit 1
 }
 
+# Detect whether the AI profile should be enabled by reading the .env file.
+$AiProfileArg = ""
+$EnvFile = Join-Path $ProjectDir ".env"
+if (Test-Path $EnvFile) {
+  $envLines = Get-Content $EnvFile -ErrorAction SilentlyContinue
+  foreach ($line in $envLines) {
+    if ($line -match '^\s*AI_SERVICE_ENABLED\s*=\s*true\s*$') {
+      $AiProfileArg = "--profile ai "
+      break
+    }
+  }
+}
+
 # Create the scheduled task action
 $Action = New-ScheduledTaskAction `
   -Execute "powershell.exe" `
-  -Argument "-NoProfile -WindowStyle Hidden -Command `"Set-Location '$ProjectDir'; docker compose up -d`""
+  -Argument "-NoProfile -WindowStyle Hidden -Command `"Set-Location '$ProjectDir'; docker compose ${AiProfileArg}up -d`""
 
 # Trigger at user logon
 $Trigger = New-ScheduledTaskTrigger -AtLogOn

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,12 +16,44 @@ git clone --depth 1 $Repo $Dir
 Set-Location $Dir
 Copy-Item .env.example .env
 
+# ─── Install `joidy` CLI into ~/.local/bin ────────────────────────
+$LocalBin = Join-Path $HOME ".local\bin"
+$ConfigDir = Join-Path $HOME ".config\joidy"
+$JoidyScript = Join-Path $Dir "scripts\joidy.ps1"
+
+New-Item -ItemType Directory -Force -Path $LocalBin | Out-Null
+New-Item -ItemType Directory -Force -Path $ConfigDir | Out-Null
+
+# Persist the project path so the CLI survives renames/moves of the install.
+Set-Content -Path (Join-Path $ConfigDir "path") -Value $Dir -NoNewline
+Write-Host "✓ Project path saved to $ConfigDir\path"
+
+# Copy the CLI script (overwrite any previous install).
+Copy-Item $JoidyScript (Join-Path $LocalBin "joidy.ps1") -Force
+Write-Host "✓ Installed 'joidy' CLI → $LocalBin\joidy.ps1"
+
+# Create a joidy.cmd shim so users can type `joidy` without the .ps1 extension.
+$CmdShim = Join-Path $LocalBin "joidy.cmd"
+$CmdContent = "@`"%~dp0joidy.ps1`" %*"
+Set-Content -Path $CmdShim -Value $CmdContent -Encoding ASCII
+Write-Host "✓ Created 'joidy.cmd' shim → $CmdShim"
+
+# ─── Ensure ~/.local/bin is in PATH ───────────────────────────────
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($UserPath -and ($UserPath.Split(";") -contains $LocalBin)) {
+  Write-Host "✓ $LocalBin already in user PATH"
+} else {
+  $NewPath = if ($UserPath) { "$UserPath;$LocalBin" } else { $LocalBin }
+  [Environment]::SetEnvironmentVariable("Path", $NewPath, "User")
+  Write-Host "✓ Added $LocalBin to user PATH (restart your shell to apply)"
+}
+
 Write-Host ""
 Write-Host "Done!"
 Write-Host ""
 Write-Host "Next steps:"
 Write-Host "  1. Edit $Dir\.env with your credentials"
-Write-Host "  2. Run: cd $Dir ; docker compose up -d"
+Write-Host "  2. Restart your shell (so 'joidy' is in PATH), then run: joidy up"
 Write-Host "  3. Open http://localhost:3000"
 Write-Host ""
-Write-Host "For updates: cd $Dir ; git pull ; docker compose pull ; docker compose up -d"
+Write-Host "For updates: cd $Dir ; git pull ; docker compose pull ; joidy up"

--- a/scripts/joidy.ps1
+++ b/scripts/joidy.ps1
@@ -123,9 +123,27 @@ function Write-AccessUrl {
   Write-Host "╚══════════════════════════════════════════════╝" -ForegroundColor Green
 }
 
+function Get-AiProfileArgs {
+  $envFile = Join-Path $ProjectDir ".env"
+  if (Test-Path $envFile) {
+    $lines = Get-Content $envFile -ErrorAction SilentlyContinue
+    foreach ($line in $lines) {
+      if ($line -match '^\s*AI_SERVICE_ENABLED\s*=\s*true\s*$') {
+        return @("--profile", "ai")
+      }
+    }
+  }
+  return @()
+}
+
 function Invoke-Up {
   Write-Status "Starting Joidy services..."
-  Invoke-ComposeCommand up -d
+  $profile = Get-AiProfileArgs
+  if ($profile.Count -gt 0) {
+    Invoke-ComposeCommand @profile up -d
+  } else {
+    Invoke-ComposeCommand up -d
+  }
   Write-Status "Waiting for services to stabilize..."
   Start-Sleep -Seconds 5
   Invoke-Status
@@ -156,14 +174,15 @@ function Invoke-Sleep {
 
 function Invoke-Wake {
   Write-Status "Waking heavy services from hibernation..."
+  $profile = Get-AiProfileArgs
   foreach ($svc in $HIBERNATE_SERVICES) {
-    $all = Invoke-ComposeCommand ps -a $svc 2>$null
+    $all = Invoke-ComposeCommand @profile ps -a $svc 2>$null
     if ($all -match $svc) {
-      $running = Invoke-ComposeCommand ps $svc 2>$null
+      $running = Invoke-ComposeCommand @profile ps $svc 2>$null
       if ($running -match $svc) {
         Write-Warn "$svc is already running"
       } else {
-        Invoke-ComposeCommand start $svc
+        Invoke-ComposeCommand @profile start $svc
         Write-Ok "Started $svc"
       }
     } else {
@@ -176,7 +195,12 @@ function Invoke-Wake {
 
 function Invoke-Restart {
   Write-Status "Restarting all Joidy services..."
-  Invoke-ComposeCommand restart
+  $profile = Get-AiProfileArgs
+  if ($profile.Count -gt 0) {
+    Invoke-ComposeCommand @profile restart
+  } else {
+    Invoke-ComposeCommand restart
+  }
   Write-Ok "All services restarted."
   Write-AccessUrl
 }

--- a/scripts/joidy.sh
+++ b/scripts/joidy.sh
@@ -118,9 +118,22 @@ print_access_url() {
   echo -e "${GREEN}╚══════════════════════════════════════════════╝${NC}"
 }
 
+# Check whether the AI profile should be enabled by reading the .env file.
+ai_profile_args() {
+  if grep -q '^AI_SERVICE_ENABLED=true' "$PROJECT_DIR/.env" 2>/dev/null; then
+    echo "--profile ai"
+  fi
+}
+
 cmd_up() {
   print_status "Starting Joidy services..."
-  $DOCKER_CMD up -d
+  local profile
+  profile="$(ai_profile_args)"
+  if [ -n "$profile" ]; then
+    $DOCKER_CMD $profile up -d
+  else
+    $DOCKER_CMD up -d
+  fi
   print_status "Waiting for services to stabilize..."
   sleep 5
   cmd_status
@@ -151,13 +164,15 @@ cmd_sleep() {
 
 cmd_wake() {
   print_status "Waking heavy services from hibernation..."
+  local profile
+  profile="$(ai_profile_args)"
   for svc in $HIBERNATE_SERVICES; do
     # Check if the service is NOT running (use -a to include stopped containers)
-    if $DOCKER_CMD ps -a "$svc" 2>/dev/null | grep -q "$svc"; then
-      if $DOCKER_CMD ps "$svc" 2>/dev/null | grep -q "$svc"; then
+    if $DOCKER_CMD $profile ps -a "$svc" 2>/dev/null | grep -q "$svc"; then
+      if $DOCKER_CMD $profile ps "$svc" 2>/dev/null | grep -q "$svc"; then
         print_warn "$svc is already running"
       else
-        $DOCKER_CMD start "$svc"
+        $DOCKER_CMD $profile start "$svc"
         print_ok "Started $svc"
       fi
     else
@@ -170,7 +185,13 @@ cmd_wake() {
 
 cmd_restart() {
   print_status "Restarting all Joidy services..."
-  $DOCKER_CMD restart
+  local profile
+  profile="$(ai_profile_args)"
+  if [ -n "$profile" ]; then
+    $DOCKER_CMD $profile restart
+  else
+    $DOCKER_CMD restart
+  fi
   print_ok "All services restarted."
   print_access_url
 }


### PR DESCRIPTION
## Summary

### #848 — PowerShell install.ps1 missing CLI install
- `install.ps1` now installs the `joidy` CLI to `~/.local/bin/` (matching the bash installer)
- Copies `scripts/joidy.ps1` as `joidy.ps1` and creates a `joidy.cmd` shim so users can type `joidy` without `.ps1`
- Saves project path to `~/.config/joidy/path` so the CLI survives repo renames/moves
- Adds `~/.local/bin` to user PATH (if not already present)
- Updated "Next steps" to use `joidy up` instead of `docker compose up -d`

### #850 — CLI/auto-start --profile ai
- `joidy.sh`, `joidy.ps1`, and `install-autostart.ps1` now detect `AI_SERVICE_ENABLED=true` in `.env` and automatically add `--profile ai` to `docker compose up/wake/restart`
- Default behavior (AI disabled) is preserved — 4 containers start without the profile flag
- When AI is enabled, the ai-service container starts correctly (5 containers)

## Changes

| File | Change |
|------|--------|
| `scripts/install.ps1` | Added CLI installation (copy joidy.ps1 + cmd shim, PATH update, config dir) |
| `scripts/joidy.sh` | Added `ai_profile_args()` helper, `up`/`wake`/`restart` use `--profile ai` when AI enabled |
| `scripts/joidy.ps1` | Added `Get-AiProfileArgs` function, `up`/`wake`/`restart` use profile args |
| `scripts/install-autostart.ps1` | Auto-start task detects AI enabled and adds `--profile ai` |

Closes #848, #850

#### Test plan

- [ ] `bash -n scripts/joidy.sh` passes (syntax check)
- [ ] Windows: `irm .../install.ps1 | iex` installs `joidy` CLI to PATH
- [ ] Windows: `joidy up` works from any directory after install
- [ ] `joidy up` with `AI_SERVICE_ENABLED=false` starts 4 containers (no AI)
- [ ] `joidy up` with `AI_SERVICE_ENABLED=true` starts 5 containers (with AI)
- [ ] `joidy wake` restarts ai-service if it was running before `joidy sleep`
- [ ] Auto-start scripts start ai-service on reboot when AI is enabled

Generated with [Devin](https://devin.ai)