### PR TITLE
fix(frontend): replace var(--border) with theme-aware color-mix in progress tracks and module dots

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -482,7 +482,7 @@ textarea.input {
 /* ── Progress bars ───────────────────────────────────────────────────────────── */
 .progress-track {
   height: 2px;
-  background: var(--border);
+  background: color-mix(in srgb, var(--text-primary) 10%, transparent);
   border-radius: 1px;
   overflow: hidden;
 }

--- a/frontend/src/lib/components/ProgressBar.svelte
+++ b/frontend/src/lib/components/ProgressBar.svelte
@@ -23,7 +23,7 @@
 
 <style>
   .progress-track {
-    background: var(--border);
+    background: color-mix(in srgb, var(--text-primary) 10%, transparent);
     overflow: hidden;
     position: relative;
   }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -593,14 +593,14 @@
     width: 5px;
     height: 5px;
     border-radius: 50%;
-    background: var(--border);
+    background: color-mix(in srgb, var(--text-primary) 20%, transparent);
     border: none;
     padding: 0;
     cursor: pointer;
     transition: all var(--t-fast);
   }
   .dot.active {
-    background: var(--text-muted);
+    background: var(--text-secondary);
     width: 14px;
     border-radius: 3px;
   }

--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -3566,7 +3566,7 @@
     margin-bottom: 6px;
   }
   .progress-track {
-    background: var(--border);
+    background: color-mix(in srgb, var(--text-primary) 10%, transparent);
     border-radius: 4px;
     overflow: hidden;
   }


### PR DESCRIPTION
## Summary

`.progress-track` and `.dot` elements used `var(--border)` as their background, which is `#000000` in light mode. This made progress bar tracks and carousel navigation dots appear as solid black in light theme instead of subtle low-contrast indicators.

## Changes

| File | Element | Before | After |
|------|---------|--------|-------|
| `frontend/src/app.css` | `.progress-track` (global) | `var(--border)` | `color-mix(in srgb, var(--text-primary) 10%, transparent)` |
| `frontend/src/lib/components/ProgressBar.svelte` | `.progress-track` (component) | `var(--border)` | `color-mix(in srgb, var(--text-primary) 10%, transparent)` |
| `frontend/src/routes/goals/+page.svelte` | `.progress-track` (local) | `var(--border)` | `color-mix(in srgb, var(--text-primary) 10%, transparent)` |
| `frontend/src/routes/+page.svelte` | `.dot` (inactive) | `var(--border)` | `color-mix(in srgb, var(--text-primary) 20%, transparent)` |
| `frontend/src/routes/+page.svelte` | `.dot.active` | `var(--text-muted)` | `var(--text-secondary)` |

`color-mix` with `var(--text-primary)` adapts to both themes:
- **Dark mode**: white at 10-20% opacity → subtle gray
- **Light mode**: black at 10-20% opacity → subtle gray

Closes #865, #866

#### Test plan

- [x] `npm run check` passes (0 errors, 132 pre-existing warnings)
- [ ] Progress bar track is subtle in dark mode (no regression)
- [ ] Progress bar track is subtle in light mode (not solid black)
- [ ] Progress fill is clearly visible against the track in both themes
- [ ] Module carousel dots are subtle in both themes
- [ ] Active dot is clearly distinguishable from inactive dots in both themes

Generated with [Devin](https://devin.ai)