### PR TITLE
feat(frontend): add service power management section to settings panel

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -850,4 +850,26 @@ export const api = {
         server_time: string;
       }>('GET', '/sync/status'),
   },
+
+  power: {
+    status: () =>
+      req<{
+        docker_available: boolean;
+        services: {
+          name: string;
+          status: 'running' | 'stopped' | 'unknown';
+          healthy: boolean | null;
+        }[];
+        hibernating: boolean;
+      }>('GET', '/system/power/status'),
+    sleep: () =>
+      req<{ status: string; message: string; affected: string[] }>('POST', '/system/power/sleep'),
+    wake: () =>
+      req<{ status: string; message: string; affected: string[] }>('POST', '/system/power/wake'),
+    shutdown: () =>
+      req<{ status: string; message: string; affected: string[] }>(
+        'POST',
+        '/system/power/shutdown'
+      ),
+  },
 };

--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -67,6 +67,30 @@
 
   let configuredKeys: string[] = [];
 
+  // ── Power management state ────────────────────────────────────────────────
+  let powerStatus: {
+    docker_available: boolean;
+    services: {
+      name: string;
+      status: 'running' | 'stopped' | 'unknown';
+      healthy: boolean | null;
+    }[];
+    hibernating: boolean;
+  } | null = null;
+  let powerLoading = false;
+  let powerActionLoading: 'sleep' | 'wake' | 'shutdown' | null = null;
+  let powerError = '';
+  let powerMessage = '';
+  let shutdownConfirm = false;
+
+  const SERVICE_LABELS: Record<string, string> = {
+    postgres: 'PostgreSQL',
+    api: 'API',
+    'ai-service': 'AI Service',
+    worker: 'Worker',
+    frontend: 'Frontend',
+  };
+
   onMount(async () => {
     if (open) {
       await loadConfig();
@@ -112,9 +136,75 @@
       configLoaded = true;
       await checkGithubStatus();
       await checkGoogleStatus();
+      await loadPowerStatus();
     } catch (e) {
       logger.error('Failed to load config:', e);
       configLoaded = true;
+    }
+  }
+
+  async function loadPowerStatus() {
+    powerLoading = true;
+    powerError = '';
+    try {
+      powerStatus = await api.power.status();
+    } catch (e: any) {
+      powerStatus = null;
+      powerError = e.message || 'No se pudo obtener el estado de los servicios';
+    } finally {
+      powerLoading = false;
+    }
+  }
+
+  async function hibernateServices() {
+    powerActionLoading = 'sleep';
+    powerError = '';
+    powerMessage = '';
+    try {
+      const result = await api.power.sleep();
+      powerMessage = result.message;
+      showNotification(result.message, 'success');
+      await loadPowerStatus();
+    } catch (e: any) {
+      powerError = e.message || 'Error al hibernar servicios';
+      showNotification(powerError, 'error');
+    } finally {
+      powerActionLoading = null;
+    }
+  }
+
+  async function wakeServices() {
+    powerActionLoading = 'wake';
+    powerError = '';
+    powerMessage = '';
+    try {
+      const result = await api.power.wake();
+      powerMessage = result.message;
+      showNotification(result.message, 'success');
+      await loadPowerStatus();
+    } catch (e: any) {
+      powerError = e.message || 'Error al despertar servicios';
+      showNotification(powerError, 'error');
+    } finally {
+      powerActionLoading = null;
+    }
+  }
+
+  async function shutdownServices() {
+    powerActionLoading = 'shutdown';
+    powerError = '';
+    powerMessage = '';
+    try {
+      const result = await api.power.shutdown();
+      powerMessage = result.message;
+      showNotification(result.message, 'info');
+      await loadPowerStatus();
+    } catch (e: any) {
+      powerError = e.message || 'Error al apagar servicios';
+      showNotification(powerError, 'error');
+    } finally {
+      powerActionLoading = null;
+      shutdownConfirm = false;
     }
   }
 
@@ -833,6 +923,119 @@
           </section>
         {/if}
 
+        <!-- Servicios (Power Management) -->
+        <section class="section">
+          <div class="section-title" style="color: var(--xp, var(--accent));">
+            <DynamicIcon name="Power" size={12} /> Servicios
+          </div>
+
+          {#if powerLoading}
+            <p class="hint">Cargando estado de servicios…</p>
+          {:else if !powerStatus || !powerStatus.docker_available}
+            <p class="hint">
+              Docker no está disponible. Usa la CLI (<span class="mono">joidy down</span>) para
+              detener servicios.
+            </p>
+          {:else}
+            <!-- Service status list -->
+            <div class="power-service-list">
+              {#each powerStatus.services as svc}
+                <div class="power-service-row">
+                  <span class="power-service-name">{SERVICE_LABELS[svc.name] || svc.name}</span>
+                  <span
+                    class="power-service-badge"
+                    class:running={svc.status === 'running'}
+                    class:stopped={svc.status !== 'running'}
+                  >
+                    {#if svc.status === 'running'}
+                      {#if svc.healthy === false}
+                        ⚠ unhealthy
+                      {:else}
+                        ● running
+                      {/if}
+                    {:else}
+                      ○ stopped
+                    {/if}
+                  </span>
+                </div>
+              {/each}
+            </div>
+
+            {#if powerError}
+              <p class="hint" style="color: var(--error);">{powerError}</p>
+            {/if}
+            {#if powerMessage}
+              <p class="hint" style="color: var(--success);">{powerMessage}</p>
+            {/if}
+
+            <!-- Action buttons -->
+            <div class="power-actions">
+              {#if powerStatus.hibernating}
+                <button
+                  class="power-btn wake"
+                  onclick={wakeServices}
+                  disabled={powerActionLoading !== null}
+                >
+                  {#if powerActionLoading === 'wake'}
+                    <DynamicIcon name="LoaderCircle" size={12} /> Despertando…
+                  {:else}
+                    <DynamicIcon name="Sun" size={12} /> Despertar
+                  {/if}
+                </button>
+              {:else}
+                <button
+                  class="power-btn sleep"
+                  onclick={hibernateServices}
+                  disabled={powerActionLoading !== null}
+                  title="Detiene AI Service y Worker para ahorrar recursos"
+                >
+                  {#if powerActionLoading === 'sleep'}
+                    <DynamicIcon name="LoaderCircle" size={12} /> Hibernando…
+                  {:else}
+                    <DynamicIcon name="Moon" size={12} /> Hibernar
+                  {/if}
+                </button>
+              {/if}
+
+              {#if !shutdownConfirm}
+                <button
+                  class="power-btn shutdown"
+                  onclick={() => (shutdownConfirm = true)}
+                  disabled={powerActionLoading !== null}
+                  title="Detiene todos los servicios excepto la API y la base de datos"
+                >
+                  <DynamicIcon name="Power" size={12} /> Apagar
+                </button>
+              {:else}
+                <button
+                  class="power-btn shutdown-confirm"
+                  onclick={shutdownServices}
+                  disabled={powerActionLoading !== null}
+                >
+                  {#if powerActionLoading === 'shutdown'}
+                    <DynamicIcon name="LoaderCircle" size={12} /> Apagando…
+                  {:else}
+                    <DynamicIcon name="TriangleAlert" size={12} /> Confirmar apagado
+                  {/if}
+                </button>
+                <button
+                  class="power-btn cancel"
+                  onclick={() => (shutdownConfirm = false)}
+                  disabled={powerActionLoading !== null}
+                >
+                  Cancelar
+                </button>
+              {/if}
+            </div>
+
+            <p class="hint">
+              <strong>Hibernar</strong> detiene AI Service y Worker (la API y la base de datos
+              siguen disponibles). <strong>Apagar</strong> detiene todo excepto la API y la base de
+              datos — usa <span class="mono">joidy up</span> para reiniciar.
+            </p>
+          {/if}
+        </section>
+
         <!-- Repositorio -->
         <section class="section">
           <div class="row">
@@ -1408,5 +1611,111 @@
     .toggle {
       white-space: normal;
     }
+  }
+
+  /* ── Power management ──────────────────────────────────────────────────── */
+  .power-service-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 10px;
+  }
+
+  .power-service-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 8px;
+    border-radius: var(--r);
+    background: var(--surface);
+    font-size: 11px;
+  }
+
+  .power-service-name {
+    color: var(--text-secondary);
+    font-weight: 500;
+  }
+
+  .power-service-badge {
+    font-size: 10px;
+    font-family: var(--font-mono);
+    letter-spacing: 0.02em;
+  }
+
+  .power-service-badge.running {
+    color: var(--success);
+  }
+
+  .power-service-badge.stopped {
+    color: var(--text-disabled);
+  }
+
+  .power-actions {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+  }
+
+  .power-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--r);
+    background: var(--surface);
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-family: var(--font-sans);
+    cursor: pointer;
+    transition: all var(--t-fast);
+  }
+
+  .power-btn:hover:not(:disabled) {
+    background: var(--elevated);
+    border-color: var(--text-muted);
+    color: var(--text-primary);
+  }
+
+  .power-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .power-btn.sleep:hover:not(:disabled) {
+    border-color: var(--info, var(--accent));
+    color: var(--info, var(--accent));
+  }
+
+  .power-btn.wake:hover:not(:disabled) {
+    border-color: var(--success);
+    color: var(--success);
+  }
+
+  .power-btn.shutdown {
+    border-color: color-mix(in srgb, var(--error) 40%, var(--border));
+    color: var(--error);
+  }
+
+  .power-btn.shutdown:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--error) 10%, transparent);
+    border-color: var(--error);
+  }
+
+  .power-btn.shutdown-confirm {
+    background: var(--error);
+    border-color: var(--error);
+    color: white;
+    font-weight: 600;
+  }
+
+  .power-btn.shutdown-confirm:hover:not(:disabled) {
+    opacity: 0.9;
+  }
+
+  .power-btn.cancel {
+    font-size: 10px;
+    padding: 6px 10px;
   }
 </style>


### PR DESCRIPTION
## Summary

The backend already had `/system/power/*` endpoints (status, sleep, wake, shutdown) in `api/routers/system.py`, but the frontend had no UI to use them. Users had to rely on the CLI (`joidy down`) to stop services.

This PR adds a "Servicios" section to the SettingsPanel that exposes all power management controls.

## Changes

### `frontend/src/lib/api.ts`
- Added `api.power` client with `status()`, `sleep()`, `wake()`, `shutdown()` methods

### `frontend/src/lib/components/SettingsPanel.svelte`
- Added power management state (`powerStatus`, `powerLoading`, `powerActionLoading`, `shutdownConfirm`)
- Added `loadPowerStatus()`, `hibernateServices()`, `wakeServices()`, `shutdownServices()` functions
- Added "Servicios" section with:
  - Service status list (running/stopped/healthy badges for PostgreSQL, API, AI Service, Worker, Frontend)
  - **Hibernar** button — stops AI Service + Worker (saves resources, API/DB stay up)
  - **Despertar** button — restarts hibernated services (shown when hibernating)
  - **Apagar** button — full shutdown with two-step confirmation (stops everything except API + Postgres)
  - Graceful fallback message when Docker socket is not available
  - Loading states with spinner icons
  - Error/success notifications via `showNotification`
- Added CSS styles for `.power-service-list`, `.power-service-row`, `.power-service-badge`, `.power-actions`, `.power-btn` variants

Closes #870

#### Test plan

- [x] `npm run check` passes (0 errors, 132 pre-existing warnings)
- [ ] Settings panel shows "Servicios" section with service status
- [ ] Hibernate button stops AI Service and Worker
- [ ] Wake button restarts hibernated services
- [ ] Shutdown button shows confirmation, then stops all services except API + Postgres
- [ ] Status refreshes after each action
- [ ] Graceful fallback when Docker is not available (shows CLI hint)
- [ ] Works in both dark and light themes

Generated with [Devin](https://devin.ai)