### PR TITLE
release: v1.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - _Nothing yet_
 
+## [1.0.0-beta.1] - 2026-08-24
+
+### Fixed
+
+- **CLI auto-bootstrap .env on first run** — AUR/system installs no longer fail with missing `POSTGRES_PASSWORD`; `.env` is auto-created in `~/.config/joidy/.env` with generated secrets (#873, #874)
+
+## [1.0.0-beta] - 2026-08-24
+
+### Added
+
+- Service power management UI in settings panel — hibernate, wake, and shutdown services from the web UI (#870, #871)
+- Podman compatibility in start scripts and Makefile (#810)
+- Infinite scroll for notes list (#809)
+- Assigned GitHub PRs and issues in the status bar (#792, #805)
+- Monthly calendar map and centered planning sort control (#783, #790, #804)
+- Goal settings 3-lists-at-once with folded description into note (#788, #789, #803)
+- GoalCard polish — borderless pin, state below title, square cards (#785, #786, #787, #801)
+- Professional responsive design across all pages and components (#732)
+- LAN IP display after `joidy up`/`restart`
+- Doctor command to detect root-owned `.svelte-kit` before `make dev` (#781, #782)
+- Auto-install joidy CLI into `~/.local/bin`
+- PowerShell installer and `--profile ai` handling in CLI/autostart (#848, #850, #858)
+- Self-hosted Geist fonts removing Google Fonts CDN dependency (#846, #859)
+- Disable AI service in production + harden API for stable release (#845)
+- Worker crash recovery with exponential backoff via supervisor (#818)
+- Alembic migration serialization across uvicorn workers via `pg_advisory_lock` (#817)
+- CI fork PR auto-approval policy documented (#811, #819)
+
+### Fixed
+
+- Streak timezone mismatch — counter showed 0 before check-in due to frontend/backend UTC offset (#864, #868)
+- Check-in layout shift — smooth transitions added, share button repositioned to corner (#862, #863, #867)
+- Progress track and module dots hardcoded to dark theme via `var(--border)` (#865, #866, #869)
+- Theme-aware disconnect buttons and settings panel colors (#844, #857)
+- Hardcoded dark colors in goals replaced with theme-aware CSS variables (#839, #842, #861)
+- StreakHeatmap theme-aware empty cells + year view spacing (#840, #843, #855)
+- Resize handle redesigned to be theme-aware and minimalist (#841, #856)
+- Goal pin icon now shows only on hover (#838, #854)
+- Google Calendar & Tasks hidden behind dev mode (#851, #853)
+
+### Security
+
+- AI service disabled in production by default (#845)
+- API hardened for stable release — internal secret validation, reduced attack surface (#845)
+
+### Changed
+
+- Infra audit fixes — parameterized Docker images, multi-stage builds, cache mounts (#812)
+- Dependabot updates: vitest, svelte, typescript-eslint, tiptap, uvicorn, openai, anthropic, cohere, pytest, sqlalchemy, and more
+
 ## [0.2.0] - 2026-08-16
 
 ### Added
@@ -145,6 +195,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Responsive base layout and mobile streak actions.
 - CI pipeline: API tests, frontend typecheck, Docker build smoke test.
 
-[unreleased]: https://github.com/Axel-DaMage/joidy/compare/v1.0.0-beta...HEAD
+[unreleased]: https://github.com/Axel-DaMage/joidy/compare/v1.0.0-beta.1...HEAD
+[1.0.0-beta.1]: https://github.com/Axel-DaMage/joidy/compare/v1.0.0-beta...v1.0.0-beta.1
+[1.0.0-beta]: https://github.com/Axel-DaMage/joidy/compare/v0.2.0...v1.0.0-beta
 [0.2.0]: https://github.com/Axel-DaMage/joidy/releases/tag/v0.2.0
 [0.1.0]: https://github.com/Axel-DaMage/joidy/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Responsive base layout and mobile streak actions.
 - CI pipeline: API tests, frontend typecheck, Docker build smoke test.
 
-[unreleased]: https://github.com/Axel-DaMage/joidy/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/Axel-DaMage/joidy/compare/v1.0.0-beta...HEAD
 [0.2.0]: https://github.com/Axel-DaMage/joidy/releases/tag/v0.2.0
 [0.1.0]: https://github.com/Axel-DaMage/joidy/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/JOIDY-v0.2.0-8B5CF6?style=for-the-badge" alt="Joidy">
+  <img src="https://img.shields.io/badge/JOIDY-v1.0.0-beta?style=for-the-badge" alt="Joidy">
 </p>
 
 <p align="center">

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -1,11 +1,11 @@
 pkgbase = joidy
 pkgdesc = Personal knowledge management with gamification
-pkgver = 0.2.0
+pkgver = 1.0.0-beta
 pkgrel = 1
 url = https://joidy-web.vercel.app
 arch = any
 license = GPL3
 depends = docker
-source = https://github.com/Axel-DaMage/joidy/archive/v0.2.0.tar.gz
+source = https://github.com/Axel-DaMage/joidy/archive/v1.0.0-beta.tar.gz
 sha256sums = SKIP
 pkgname = joidy

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -8,8 +8,10 @@ arch=('any')
 url="https://joidy-web.vercel.app"
 license=('GPL3')
 depends=('docker')
-source=("https://github.com/Axel-DaMage/joidy/archive/v${_tag}.tar.gz")
-sha256sums=('SKIP')
+install=joidy.install
+source=("https://github.com/Axel-DaMage/joidy/archive/v${_tag}.tar.gz"
+        "joidy.install")
+sha256sums=('SKIP' 'SKIP')
 
 package() {
   cd "${srcdir}/joidy-${_tag}"

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Joidy App <https://github.com/Axel-DaMage/joidy>
 pkgname=joidy
-pkgver=0.2.0
+pkgver=1.0.0-beta
 _tag=${pkgver}
 pkgrel=1
 pkgdesc="Personal knowledge management with gamification"

--- a/aur/joidy.install
+++ b/aur/joidy.install
@@ -1,0 +1,18 @@
+post_install() {
+  echo ""
+  echo "  Joidy installed to /usr/share/joidy/"
+  echo ""
+  echo "  On first 'joidy up', a .env file will be auto-created in"
+  echo "  ~/.config/joidy/.env with generated POSTGRES_PASSWORD and SECRET_KEY."
+  echo ""
+  echo "  Edit ~/.config/joidy/.env to add your credentials:"
+  echo "    - GEMINI_API_KEY:     https://aistudio.google.com/app/apikey"
+  echo "    - OBSIDIAN_VAULT_PATH: absolute path to your Obsidian vault"
+  echo ""
+  echo "  Then run: joidy up"
+  echo ""
+}
+
+post_upgrade() {
+  post_install
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 ```yaml
-version: 0.2.0
+version: 1.0.0-beta
 base_url: http://localhost:8000
 docs_url: http://localhost:8000/docs
 framework: FastAPI

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 ```yaml
 project: Joidy
 type: Sistema de Gestión del Conocimiento con Gamificación
-version: 0.2.0
+version: 1.0.0-beta
 framework: Monorepo Docker
 services: 4
 database: PostgreSQL 16 + pgvector

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 ```yaml
 project: Joidy
 type: Sistema de Gestión del Conocimiento con Gamificación
-version: 0.2.0
+version: 1.0.0-beta
 framework: Monorepo Docker
 docs_version: 2.0
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,8 +3,8 @@
 ## Metadata
 
 ```yaml
-last_updated: 2026-08-16
-version: 0.2.0
+last_updated: 2026-08-24
+version: 1.0.0-beta
 ```
 
 ---

--- a/scripts/joidy.ps1
+++ b/scripts/joidy.ps1
@@ -24,6 +24,11 @@ param(
   [string]$Service = ""
 )
 
+function Write-Status($msg) { Write-Host "[$(Get-Date -Format 'HH:mm:ss')] $msg" -ForegroundColor Blue }
+function Write-Ok($msg)     { Write-Host "✓ $msg" -ForegroundColor Green }
+function Write-Warn($msg)   { Write-Host "⚠ $msg" -ForegroundColor Yellow }
+function Write-Err($msg)    { Write-Host "✗ $msg" -ForegroundColor Red }
+
 # Resolve project directory.
 # Priority: JOIDY_DIR env var → ~/.config/joidy/path file → script location (../)
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
@@ -44,6 +49,89 @@ if (-not (Test-Path "$ProjectDir\docker-compose.yml")) {
 }
 
 Set-Location $ProjectDir
+
+# ─── .env bootstrap ───────────────────────────────────────────────
+# Resolve which .env file to use:
+# 1. $ProjectDir\.env           (git-clone install — writable)
+# 2. $env:USERPROFILE\.config\joidy\.env  (AUR/system install — project dir is read-only)
+# 3. Auto-create from .env.example with generated secrets
+$ConfigDirJoidy = Join-Path $env:USERPROFILE ".config\joidy"
+$EnvFile = ""
+$EnvFileArg = @()
+
+if (Test-Path "$ProjectDir\.env") {
+  $EnvFile = "$ProjectDir\.env"
+} elseif ((Test-Path "$ProjectDir\.env.example") -and -not (Test-Path "$ProjectDir\.env")) {
+  # Check if project dir is writable
+  $canWrite = $false
+  try {
+    $testFile = Join-Path $ProjectDir ".joidy_write_test"
+    [System.IO.File]::WriteAllText($testFile, "test")
+    Remove-Item $testFile -Force
+    $canWrite = $true
+  } catch {
+    $canWrite = $false
+  }
+
+  if ($canWrite) {
+    Copy-Item "$ProjectDir\.env.example" "$ProjectDir\.env"
+    $EnvFile = "$ProjectDir\.env"
+    Write-Status "Created .env from .env.example"
+  } else {
+    # Project dir is read-only — use user config dir
+    if (-not (Test-Path $ConfigDirJoidy)) {
+      New-Item -ItemType Directory -Path $ConfigDirJoidy -Force | Out-Null
+    }
+    $EnvFile = Join-Path $ConfigDirJoidy ".env"
+    if (-not (Test-Path $EnvFile)) {
+      Copy-Item "$ProjectDir\.env.example" $EnvFile
+      Write-Status "Created .env in $ConfigDirJoidy (project dir is read-only)"
+    }
+    $EnvFileArg = @("--env-file", $EnvFile)
+  }
+}
+
+# Auto-generate required secrets if empty or placeholder
+function Generate-Secret($Length) {
+  $bytes = New-Object byte[] $Length
+  (New-Object Security.Cryptography.RandomNumberGenerator).GetBytes($bytes)
+  return -join ($bytes | ForEach-Object { $_.ToString("x2") })
+}
+
+if ($EnvFile -and (Test-Path $EnvFile)) {
+  $envContent = Get-Content $EnvFile -Raw
+  $changed = $false
+
+  # POSTGRES_PASSWORD
+  if ($envContent -match '(?m)^POSTGRES_PASSWORD=\s*$') {
+    $newPw = Generate-Secret 24
+    $envContent = $envContent -replace '(?m)^POSTGRES_PASSWORD=.*', "POSTGRES_PASSWORD=$newPw"
+    Write-Ok "Generated POSTGRES_PASSWORD"
+    $changed = $true
+  }
+
+  # SECRET_KEY
+  if ($envContent -match '(?m)^SECRET_KEY=(\s*|change_this_to_a_random_secret_key)\s*$') {
+    $newSk = Generate-Secret 32
+    $envContent = $envContent -replace '(?m)^SECRET_KEY=.*', "SECRET_KEY=$newSk"
+    Write-Ok "Generated SECRET_KEY"
+    $changed = $true
+  }
+
+  # GRAFANA_ADMIN_PASSWORD
+  if ($envContent -match '(?m)^GRAFANA_ADMIN_PASSWORD=\s*$') {
+    $newGrafanaPw = Generate-Secret 24
+    $envContent = $envContent -replace '(?m)^GRAFANA_ADMIN_PASSWORD=.*', "GRAFANA_ADMIN_PASSWORD=$newGrafanaPw"
+    Write-Ok "Generated GRAFANA_ADMIN_PASSWORD"
+    $changed = $true
+  }
+
+  if ($changed) {
+    $envContent | Set-Content $EnvFile -NoNewline
+    Write-Warn "Auto-generated required secrets in $EnvFile"
+    Write-Warn "Edit $EnvFile to add: GEMINI_API_KEY, OBSIDIAN_VAULT_PATH, etc."
+  }
+}
 
 $HIBERNATE_SERVICES = @("ai-service", "worker")
 
@@ -87,11 +175,6 @@ function Invoke-ComposeCommand {
   }
 }
 
-function Write-Status($msg) { Write-Host "[$(Get-Date -Format 'HH:mm:ss')] $msg" -ForegroundColor Blue }
-function Write-Ok($msg)     { Write-Host "✓ $msg" -ForegroundColor Green }
-function Write-Warn($msg)   { Write-Host "⚠ $msg" -ForegroundColor Yellow }
-function Write-Err($msg)    { Write-Host "✗ $msg" -ForegroundColor Red }
-
 function Get-LanIp {
   # Try to get the first non-loopback IPv4 address
   $ip = "localhost"
@@ -124,9 +207,8 @@ function Write-AccessUrl {
 }
 
 function Get-AiProfileArgs {
-  $envFile = Join-Path $ProjectDir ".env"
-  if (Test-Path $envFile) {
-    $lines = Get-Content $envFile -ErrorAction SilentlyContinue
+  if ($EnvFile -and (Test-Path $EnvFile)) {
+    $lines = Get-Content $EnvFile -ErrorAction SilentlyContinue
     foreach ($line in $lines) {
       if ($line -match '^\s*AI_SERVICE_ENABLED\s*=\s*true\s*$') {
         return @("--profile", "ai")
@@ -140,9 +222,9 @@ function Invoke-Up {
   Write-Status "Starting Joidy services..."
   $profile = Get-AiProfileArgs
   if ($profile.Count -gt 0) {
-    Invoke-ComposeCommand @profile up -d
+    Invoke-ComposeCommand @EnvFileArg @profile up -d
   } else {
-    Invoke-ComposeCommand up -d
+    Invoke-ComposeCommand @EnvFileArg up -d
   }
   Write-Status "Waiting for services to stabilize..."
   Start-Sleep -Seconds 5
@@ -152,16 +234,16 @@ function Invoke-Up {
 
 function Invoke-Down {
   Write-Status "Stopping all Joidy services..."
-  Invoke-ComposeCommand down
+  Invoke-ComposeCommand @EnvFileArg down
   Write-Ok "All services stopped."
 }
 
 function Invoke-Sleep {
   Write-Status "Hibernating heavy services (ai-service, worker)..."
   foreach ($svc in $HIBERNATE_SERVICES) {
-    $running = Invoke-ComposeCommand ps $svc 2>$null
+    $running = Invoke-ComposeCommand @EnvFileArg ps $svc 2>$null
     if ($running -match $svc) {
-      Invoke-ComposeCommand stop $svc
+      Invoke-ComposeCommand @EnvFileArg stop $svc
       Write-Ok "Stopped $svc"
     } else {
       Write-Warn "$svc is already stopped"
@@ -176,13 +258,13 @@ function Invoke-Wake {
   Write-Status "Waking heavy services from hibernation..."
   $profile = Get-AiProfileArgs
   foreach ($svc in $HIBERNATE_SERVICES) {
-    $all = Invoke-ComposeCommand @profile ps -a $svc 2>$null
+    $all = Invoke-ComposeCommand @EnvFileArg @profile ps -a $svc 2>$null
     if ($all -match $svc) {
-      $running = Invoke-ComposeCommand @profile ps $svc 2>$null
+      $running = Invoke-ComposeCommand @EnvFileArg @profile ps $svc 2>$null
       if ($running -match $svc) {
         Write-Warn "$svc is already running"
       } else {
-        Invoke-ComposeCommand @profile start $svc
+        Invoke-ComposeCommand @EnvFileArg @profile start $svc
         Write-Ok "Started $svc"
       }
     } else {
@@ -197,9 +279,9 @@ function Invoke-Restart {
   Write-Status "Restarting all Joidy services..."
   $profile = Get-AiProfileArgs
   if ($profile.Count -gt 0) {
-    Invoke-ComposeCommand @profile restart
+    Invoke-ComposeCommand @EnvFileArg @profile restart
   } else {
-    Invoke-ComposeCommand restart
+    Invoke-ComposeCommand @EnvFileArg restart
   }
   Write-Ok "All services restarted."
   Write-AccessUrl
@@ -208,14 +290,14 @@ function Invoke-Restart {
 function Invoke-Status {
   Write-Status "Joidy service status:"
   Write-Host ""
-  Invoke-ComposeCommand ps
+  Invoke-ComposeCommand @EnvFileArg ps
 }
 
 function Invoke-Logs {
   if ($Service) {
-    Invoke-ComposeCommand logs -f $Service
+    Invoke-ComposeCommand @EnvFileArg logs -f $Service
   } else {
-    Invoke-ComposeCommand logs -f
+    Invoke-ComposeCommand @EnvFileArg logs -f
   }
 }
 
@@ -232,6 +314,11 @@ function Show-Help {
   Write-Host "  joidy logs       Tail logs (all services)"
   Write-Host "  joidy logs api   Tail logs for a specific service"
   Write-Host "  joidy help       Show this help message"
+  Write-Host ""
+  Write-Host "On first run, .env is auto-created from .env.example with generated"
+  Write-Host "POSTGRES_PASSWORD, SECRET_KEY, and GRAFANA_ADMIN_PASSWORD."
+  Write-Host "For system installs (read-only project dir), .env is stored in"
+  Write-Host "~/.config/joidy/.env. Edit it to add GEMINI_API_KEY, OBSIDIAN_VAULT_PATH, etc."
   Write-Host ""
   Write-Host "The project directory is auto-detected from the script location."
 }

--- a/scripts/joidy.sh
+++ b/scripts/joidy.sh
@@ -25,45 +25,6 @@
 
 set -e
 
-# Resolve project directory.
-# Priority: JOIDY_DIR env var → ~/.config/joidy/path (user) → /etc/joidy/path (system, e.g. AUR) → script location (../)
-SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
-
-if [ -n "$JOIDY_DIR" ] && [ -d "$JOIDY_DIR" ]; then
-  PROJECT_DIR="$JOIDY_DIR"
-elif [ -f "$HOME/.config/joidy/path" ]; then
-  PROJECT_DIR="$(cat "$HOME/.config/joidy/path")"
-elif [ -f "/etc/joidy/path" ]; then
-  PROJECT_DIR="$(cat "/etc/joidy/path")"
-else
-  PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-fi
-
-if [ ! -f "$PROJECT_DIR/docker-compose.yml" ]; then
-  echo "Error: docker-compose.yml not found in $PROJECT_DIR" >&2
-  echo "Set JOIDY_DIR env var or create ~/.config/joidy/path with the project path." >&2
-  exit 1
-fi
-
-cd "$PROJECT_DIR"
-
-# Services that are stopped during hibernation
-HIBERNATE_SERVICES="ai-service worker"
-
-# Detect container engine
-if command -v docker-compose &>/dev/null; then
-  DOCKER_CMD="docker-compose"
-elif command -v docker &>/dev/null; then
-  DOCKER_CMD="docker compose"
-elif command -v podman-compose &>/dev/null; then
-  DOCKER_CMD="podman-compose"
-elif command -v podman &>/dev/null; then
-  DOCKER_CMD="podman compose"
-else
-  echo -e "${RED}✗ Error: Neither docker nor podman was found in PATH.${NC}" >&2
-  exit 1
-fi
-
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -86,6 +47,115 @@ print_warn() {
 print_err() {
   echo -e "${RED}✗${NC} $1"
 }
+
+# Resolve project directory.
+# Priority: JOIDY_DIR env var → ~/.config/joidy/path (user) → /etc/joidy/path (system, e.g. AUR) → script location (../)
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+
+if [ -n "$JOIDY_DIR" ] && [ -d "$JOIDY_DIR" ]; then
+  PROJECT_DIR="$JOIDY_DIR"
+elif [ -f "$HOME/.config/joidy/path" ]; then
+  PROJECT_DIR="$(cat "$HOME/.config/joidy/path")"
+elif [ -f "/etc/joidy/path" ]; then
+  PROJECT_DIR="$(cat "/etc/joidy/path")"
+else
+  PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+if [ ! -f "$PROJECT_DIR/docker-compose.yml" ]; then
+  echo "Error: docker-compose.yml not found in $PROJECT_DIR" >&2
+  echo "Set JOIDY_DIR env var or create ~/.config/joidy/path with the project path." >&2
+  exit 1
+fi
+
+cd "$PROJECT_DIR"
+
+# ─── .env bootstrap ───────────────────────────────────────────────
+# Resolve which .env file to use:
+# 1. $PROJECT_DIR/.env          (git-clone install — writable)
+# 2. ~/.config/joidy/.env        (AUR/system install — project dir is read-only)
+# 3. Auto-create from .env.example with generated secrets
+ENV_FILE=""
+ENV_FILE_ARG=""
+CONFIG_DIR_JOIDY="$HOME/.config/joidy"
+
+if [ -f "$PROJECT_DIR/.env" ]; then
+  ENV_FILE="$PROJECT_DIR/.env"
+elif [ -w "$PROJECT_DIR" ] && [ -f "$PROJECT_DIR/.env.example" ]; then
+  # Project dir is writable (git clone) — create .env there
+  cp "$PROJECT_DIR/.env.example" "$PROJECT_DIR/.env"
+  ENV_FILE="$PROJECT_DIR/.env"
+  print_status "Created .env from .env.example"
+elif [ -f "$PROJECT_DIR/.env.example" ]; then
+  # Project dir is read-only (AUR install) — use user config dir
+  mkdir -p "$CONFIG_DIR_JOIDY"
+  ENV_FILE="$CONFIG_DIR_JOIDY/.env"
+  if [ ! -f "$ENV_FILE" ]; then
+    cp "$PROJECT_DIR/.env.example" "$ENV_FILE"
+    print_status "Created .env in $CONFIG_DIR_JOIDY (project dir is read-only)"
+  fi
+  ENV_FILE_ARG="--env-file $ENV_FILE"
+fi
+
+# Auto-generate required secrets if empty or placeholder
+generate_secret() {
+  local len="$1"
+  if command -v openssl &>/dev/null; then
+    openssl rand -hex "$len"
+  else
+    # Fallback: use /dev/urandom
+    head -c "$((len * 2))" /dev/urandom | od -An -tx1 | tr -d ' \n'
+  fi
+}
+
+if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
+  CHANGED=0
+  # POSTGRES_PASSWORD
+  PG_PW=$(grep -E '^POSTGRES_PASSWORD=' "$ENV_FILE" | cut -d'=' -f2-)
+  if [ -z "$PG_PW" ]; then
+    NEW_PW=$(generate_secret 24)
+    sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=${NEW_PW}|" "$ENV_FILE"
+    print_ok "Generated POSTGRES_PASSWORD"
+    CHANGED=1
+  fi
+  # SECRET_KEY
+  SK=$(grep -E '^SECRET_KEY=' "$ENV_FILE" | cut -d'=' -f2-)
+  if [ -z "$SK" ] || [ "$SK" = "change_this_to_a_random_secret_key" ]; then
+    NEW_SK=$(generate_secret 32)
+    sed -i "s|^SECRET_KEY=.*|SECRET_KEY=${NEW_SK}|" "$ENV_FILE"
+    print_ok "Generated SECRET_KEY"
+    CHANGED=1
+  fi
+  # GRAFANA_ADMIN_PASSWORD
+  GRAFANA_PW=$(grep -E '^GRAFANA_ADMIN_PASSWORD=' "$ENV_FILE" | cut -d'=' -f2-)
+  if [ -z "$GRAFANA_PW" ]; then
+    NEW_GRAFANA_PW=$(generate_secret 24)
+    sed -i "s|^GRAFANA_ADMIN_PASSWORD=.*|GRAFANA_ADMIN_PASSWORD=${NEW_GRAFANA_PW}|" "$ENV_FILE"
+    print_ok "Generated GRAFANA_ADMIN_PASSWORD"
+    CHANGED=1
+  fi
+  if [ "$CHANGED" = "1" ]; then
+    print_warn "Auto-generated required secrets in $ENV_FILE"
+    print_warn "Edit $ENV_FILE to add: GEMINI_API_KEY, OBSIDIAN_VAULT_PATH, etc."
+  fi
+fi
+
+# Services that are stopped during hibernation
+HIBERNATE_SERVICES="ai-service worker"
+
+# Detect container engine
+if command -v docker-compose &>/dev/null; then
+  DOCKER_CMD="docker-compose"
+elif command -v docker &>/dev/null; then
+  DOCKER_CMD="docker compose"
+elif command -v podman-compose &>/dev/null; then
+  DOCKER_CMD="podman-compose"
+elif command -v podman &>/dev/null; then
+  DOCKER_CMD="podman compose"
+else
+  echo -e "${RED}✗ Error: Neither docker nor podman was found in PATH.${NC}" >&2
+  exit 1
+fi
 
 # Detect the LAN IP address (exclude loopback, docker, virbr, etc.)
 get_lan_ip() {
@@ -120,7 +190,7 @@ print_access_url() {
 
 # Check whether the AI profile should be enabled by reading the .env file.
 ai_profile_args() {
-  if grep -q '^AI_SERVICE_ENABLED=true' "$PROJECT_DIR/.env" 2>/dev/null; then
+  if [ -n "$ENV_FILE" ] && grep -q '^AI_SERVICE_ENABLED=true' "$ENV_FILE" 2>/dev/null; then
     echo "--profile ai"
   fi
 }
@@ -130,9 +200,9 @@ cmd_up() {
   local profile
   profile="$(ai_profile_args)"
   if [ -n "$profile" ]; then
-    $DOCKER_CMD $profile up -d
+    $DOCKER_CMD $ENV_FILE_ARG $profile up -d
   else
-    $DOCKER_CMD up -d
+    $DOCKER_CMD $ENV_FILE_ARG up -d
   fi
   print_status "Waiting for services to stabilize..."
   sleep 5
@@ -142,7 +212,7 @@ cmd_up() {
 
 cmd_down() {
   print_status "Stopping all Joidy services..."
-  $DOCKER_CMD down
+  $DOCKER_CMD $ENV_FILE_ARG down
   print_ok "All services stopped."
 }
 
@@ -150,8 +220,8 @@ cmd_sleep() {
   print_status "Hibernating heavy services (ai-service, worker)..."
   for svc in $HIBERNATE_SERVICES; do
     # Check if the service is running by looking at docker compose ps output
-    if $DOCKER_CMD ps "$svc" 2>/dev/null | grep -q "$svc"; then
-      $DOCKER_CMD stop "$svc"
+    if $DOCKER_CMD $ENV_FILE_ARG ps "$svc" 2>/dev/null | grep -q "$svc"; then
+      $DOCKER_CMD $ENV_FILE_ARG stop "$svc"
       print_ok "Stopped $svc"
     else
       print_warn "$svc is already stopped"
@@ -168,11 +238,11 @@ cmd_wake() {
   profile="$(ai_profile_args)"
   for svc in $HIBERNATE_SERVICES; do
     # Check if the service is NOT running (use -a to include stopped containers)
-    if $DOCKER_CMD $profile ps -a "$svc" 2>/dev/null | grep -q "$svc"; then
-      if $DOCKER_CMD $profile ps "$svc" 2>/dev/null | grep -q "$svc"; then
+    if $DOCKER_CMD $ENV_FILE_ARG $profile ps -a "$svc" 2>/dev/null | grep -q "$svc"; then
+      if $DOCKER_CMD $ENV_FILE_ARG $profile ps "$svc" 2>/dev/null | grep -q "$svc"; then
         print_warn "$svc is already running"
       else
-        $DOCKER_CMD $profile start "$svc"
+        $DOCKER_CMD $ENV_FILE_ARG $profile start "$svc"
         print_ok "Started $svc"
       fi
     else
@@ -188,9 +258,9 @@ cmd_restart() {
   local profile
   profile="$(ai_profile_args)"
   if [ -n "$profile" ]; then
-    $DOCKER_CMD $profile restart
+    $DOCKER_CMD $ENV_FILE_ARG $profile restart
   else
-    $DOCKER_CMD restart
+    $DOCKER_CMD $ENV_FILE_ARG restart
   fi
   print_ok "All services restarted."
   print_access_url
@@ -199,15 +269,15 @@ cmd_restart() {
 cmd_status() {
   print_status "Joidy service status:"
   echo ""
-  $DOCKER_CMD ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || $DOCKER_CMD ps
+  $DOCKER_CMD $ENV_FILE_ARG ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || $DOCKER_CMD $ENV_FILE_ARG ps
 }
 
 cmd_logs() {
   local svc="${1:-}"
   if [ -n "$svc" ]; then
-    $DOCKER_CMD logs -f "$svc"
+    $DOCKER_CMD $ENV_FILE_ARG logs -f "$svc"
   else
-    $DOCKER_CMD logs -f
+    $DOCKER_CMD $ENV_FILE_ARG logs -f
   fi
 }
 
@@ -225,6 +295,11 @@ Usage:
   joidy logs       Tail logs (all services)
   joidy logs api   Tail logs for a specific service
   joidy help       Show this help message
+
+On first run, .env is auto-created from .env.example with generated
+POSTGRES_PASSWORD, SECRET_KEY, and GRAFANA_ADMIN_PASSWORD.
+For AUR installs (read-only /usr/share/joidy), .env is stored in
+~/.config/joidy/.env. Edit it to add GEMINI_API_KEY, OBSIDIAN_VAULT_PATH, etc.
 
 The project directory is auto-detected from the script location.
 HELP


### PR DESCRIPTION
## Summary

Hotfix release for v1.0.0-beta. Fixes the AUR install failure where `joidy up` crashed with missing `POSTGRES_PASSWORD`.

### Changes since v1.0.0-beta

- **CLI auto-bootstrap .env on first run** (#873, #874)
  - Auto-creates `.env` from `.env.example` with generated secrets
  - For AUR/system installs (read-only project dir), `.env` is stored in `~/.config/joidy/.env`
  - Auto-generates `POSTGRES_PASSWORD`, `SECRET_KEY`, `GRAFANA_ADMIN_PASSWORD`
  - PowerShell version (`joidy.ps1`) has the same behavior
  - Adds `joidy.install` with post_install hints for AUR users

### After merge

The `release.yml` workflow will be triggered manually via `workflow_dispatch` with version `v1.0.0-beta.1` and `prerelease=true`.

#### Test plan

- [x] CHANGELOG.md updated with [1.0.0-beta.1] section
- [x] PR #874 merged with green CI (5/5 checks)
- [ ] CI passes on this PR
- [ ] After merge: trigger release.yml with v1.0.0-beta.1

Generated with [Devin](https://devin.ai)