### PR TITLE
fix(ci): replace --notes-prepend with gh release edit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,12 @@ jobs:
           git push origin "$VERSION"
           ARGS=(--title "Joidy ${VERSION}" --generate-notes --verify-tag)
           if [ "$PRERELEASE" = "true" ]; then
-            PREPEND=$(printf '## ⚠️ Pre-Release — Non-Production Ready\n\nThis is a **pre-release**. Expect breaking changes, bugs, and incomplete features. Do **not** use in production.\n\n')
-            ARGS+=(--prerelease --notes-prepend "$PREPEND")
+            ARGS+=(--prerelease)
           fi
           gh release create "$VERSION" "${ARGS[@]}"
+          # Prepend pre-release warning (gh CLI on runners doesn't support --notes-prepend)
+          if [ "$PRERELEASE" = "true" ]; then
+            PREPEND=$(printf '## ⚠️ Pre-Release — Non-Production Ready\n\nThis is a **pre-release**. Expect breaking changes, bugs, and incomplete features. Do **not** use in production.\n\n')
+            BODY=$(gh release view "$VERSION" --json body -q .body)
+            gh release edit "$VERSION" --notes "${PREPEND}${BODY}"
+          fi


### PR DESCRIPTION
## Summary

- Replaces `gh release create --notes-prepend` (unsupported on runners) with a two-step approach: create release with `--generate-notes`, then `gh release edit --notes` to prepend the pre-release warning
- Fixes the release workflow failing at "Create tag and release" step on every pre-release

Closes #876

#### Test plan

- [x] `release.yml` no longer uses `--notes-prepend`
- [ ] CI passes
- [ ] Next release workflow completes end-to-end without manual intervention

Generated with [Devin](https://devin.ai)