### PR TITLE
fix(vault): expand ~ in OBSIDIAN_VAULT_PATH and add UI examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,9 +29,10 @@ LLM_MODEL=gemini:gemini-2.0-flash
 EMBEDDING_MODEL=gemini:models/text-embedding-004
 
 # ── Obsidian Vault ────────────────────────────────
-# Absolute path to your Obsidian vault folder on the host
-# Example: /home/username/Documents/MyVault
-OBSIDIAN_VAULT_PATH=/path/to/your/obsidian/vault
+# Path to your Obsidian vault folder on the host.
+# Supports ~ for home-relative paths (expanded by `joidy up`).
+# Examples: ~/Documentos/notas/mi-vault  or  /home/username/Documents/MyVault
+OBSIDIAN_VAULT_PATH=~/Documentos/notas/mi-vault
 # Optional secret to validate /webhook/obsidian calls
 OBSIDIAN_WEBHOOK_SECRET=
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ setup: ## First-time setup: copy .env, create data directories
 		echo "$(YELLOW)Next steps:$(NC)"; \
 		echo "  1. Edit .env with your API keys"; \
 		echo "     - GEMINI_API_KEY: get free at https://aistudio.google.com/"; \
-		echo "     - OBSIDIAN_VAULT_PATH: absolute path to your vault"; \
+		echo "     - OBSIDIAN_VAULT_PATH: path to your vault (supports ~, e.g. ~/Documentos/notas/mi-vault)"; \
 		echo "  2. Run: make dev"; \
 	else \
 		echo "$(GREEN)✓$(NC) .env already exists"; \
@@ -64,23 +64,33 @@ setup: ## First-time setup: copy .env, create data directories
 dev: ## Start all services in development mode (with hot reload)
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
+	@. .env 2>/dev/null || true; \
+	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
 	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build
 
 dev-d: ## Start all services in development mode (detached)
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
+	@. .env 2>/dev/null || true; \
+	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
 	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build -d
 
 dev-reset: ## Recreate all services in development mode from scratch (one command)
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
+	@. .env 2>/dev/null || true; \
+	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
 	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai down --remove-orphans --volumes
+	@. .env 2>/dev/null || true; \
+	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
 	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build -d --force-recreate --remove-orphans --wait
 	@echo "✓ Services recreated. Use 'make logs' to follow output."
 
 prod: ## Start all services in production mode
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
+	@. .env 2>/dev/null || true; \
+	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
 	$(DOCKER_COMPOSE) up --build -d
 
 stop: ## Stop all services
@@ -241,12 +251,14 @@ doctor: ## Verify all prerequisites are met
 	else \
 		echo "$(GREEN)✓$(NC) GEMINI_API_KEY configured"; \
 	fi; \
-	if [ -z "$$OBSIDIAN_VAULT_PATH" ] || [ "$$OBSIDIAN_VAULT_PATH" = "/path/to/your/obsidian/vault" ]; then \
+	if [ -z "$$OBSIDIAN_VAULT_PATH" ] || [ "$$OBSIDIAN_VAULT_PATH" = "/path/to/your/obsidian/vault" ] || [ "$$OBSIDIAN_VAULT_PATH" = "~/Documentos/notas/mi-vault" ]; then \
 		echo "$(YELLOW)⚠$(NC) OBSIDIAN_VAULT_PATH not configured"; \
 		EXIT_CODE=1; \
 	else \
 		echo "$(GREEN)✓$(NC) OBSIDIAN_VAULT_PATH: $$OBSIDIAN_VAULT_PATH"; \
-		if [ -d "$$OBSIDIAN_VAULT_PATH" ]; then \
+		VAULT_CHECK="$$OBSIDIAN_VAULT_PATH"; \
+		case "$$VAULT_CHECK" in ~/*) VAULT_CHECK="$(HOME)/$${VAULT_CHECK#~/}";; ~) VAULT_CHECK="$(HOME)";; esac; \
+		if [ -d "$$VAULT_CHECK" ]; then \
 			echo "$(GREEN)  ✓ Vault directory exists$(NC)"; \
 		else \
 			echo "$(YELLOW)  ⚠ Vault directory does not exist yet$(NC)"; \
@@ -326,11 +338,11 @@ start: ## 🚀 Quick start: setup + start all services
 		fi; \
 	fi
 	@. .env 2>/dev/null || true; \
-	if [ -z "$$OBSIDIAN_VAULT_PATH" ] || [ "$$OBSIDIAN_VAULT_PATH" = "/path/to/your/obsidian/vault" ]; then \
+	if [ -z "$$OBSIDIAN_VAULT_PATH" ] || [ "$$OBSIDIAN_VAULT_PATH" = "/path/to/your/obsidian/vault" ] || [ "$$OBSIDIAN_VAULT_PATH" = "~/Documentos/notas/mi-vault" ]; then \
 		echo ""; \
 		echo "$(YELLOW)⚠ OBSIDIAN_VAULT_PATH not set in .env$(NC)"; \
-		echo "  Enter the absolute path to your Obsidian vault:"; \
-		echo "  (e.g., /home/username/Documents/Obsidian)"; \
+		echo "  Enter the path to your Obsidian vault (supports ~):"; \
+		echo "  (e.g., ~/Documentos/notas/mi-vault or /home/username/Documents/Obsidian)"; \
 		echo ""; \
 		echo -n "$(BLUE)Vault path (or press Enter to skip):$(NC) "; \
 		read -r VAULT_PATH; \
@@ -353,7 +365,9 @@ start: ## 🚀 Quick start: setup + start all services
 	fi
 	@echo ""
 	@echo "Step 2: Starting services..."
-	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml up --build -d
+	@. .env 2>/dev/null || true; \
+	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml up --build -d
 	@echo ""
 	@echo "── $(GREEN)Joidy is running!$(NC) ───────────────────────────────"
 	@echo ""

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -141,7 +141,7 @@ def get_available_keys():
 def get_key_description(key: str) -> str:
     descriptions = {
         "gemini_api_key": "API key for Google Gemini AI",
-        "obsidian_vault_path": "Absolute path to your Obsidian vault",
+        "obsidian_vault_path": "Path to your Obsidian vault (supports ~ for home-relative, expanded by `joidy up`)",
         "daily_notes_folder": "Relative folder inside your vault for daily notes",
         "github_token": "GitHub Personal Access Token",
         "github_username": "GitHub username",

--- a/aur/joidy.install
+++ b/aur/joidy.install
@@ -7,7 +7,7 @@ post_install() {
   echo ""
   echo "  Edit ~/.config/joidy/.env to add your credentials:"
   echo "    - GEMINI_API_KEY:     https://aistudio.google.com/app/apikey"
-  echo "    - OBSIDIAN_VAULT_PATH: absolute path to your Obsidian vault"
+  echo "    - OBSIDIAN_VAULT_PATH: path to your Obsidian vault (supports ~, e.g. ~/Documentos/notas/mi-vault)"
   echo ""
   echo "  Then run: joidy up"
   echo ""

--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -746,15 +746,19 @@
               style="display: flex; align-items: center; gap: 2px; padding: 0 10px; background: var(--elevated); border: 1px solid var(--border); border-radius: var(--r);"
               class="input-wrapper"
             >
-              <span class="mono" style="color: var(--text-disabled); font-size: 11px;">~</span>
               <input
                 type="text"
                 class="setting-input mono"
                 style="border: none; background: transparent; flex: 1; padding-left: 2px;"
-                placeholder="/Documentos/ObsidianVault"
+                placeholder="~/Documentos/notas/mi-vault"
                 bind:value={systemConfig.obsidian_vault_path}
               />
             </div>
+            <p class="hint">
+              Ruta a tu vault desde tu <code>home</code>. Ej:
+              <code>~/Documentos/notas/mi-vault</code>. Al guardar, <code>joidy up</code> expande
+              <code>~</code> automáticamente.
+            </p>
           </div>
           <div class="row" style="flex-direction: column; align-items: stretch; gap: 8px;">
             <div class="row-label">

--- a/frontend/src/lib/components/SetupWizard.svelte
+++ b/frontend/src/lib/components/SetupWizard.svelte
@@ -113,8 +113,11 @@
               type="text"
               bind:value={vaultPath}
               class="input mono"
-              placeholder="home/usuario/Documents/Vault"
+              placeholder="~/Documentos/notas/mi-vault"
             />
+            <span class="field-hint mono"
+              >Ej: ~/Documentos/notas/mi-vault — <code>joidy up</code> expande <code>~</code> automáticamente</span
+            >
           </div>
 
           <div class="actions">
@@ -239,6 +242,21 @@
     font-size: 12px;
     font-weight: 500;
     color: var(--text-secondary);
+  }
+
+  .field-hint {
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+
+  .field-hint code {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-secondary);
+    background: var(--elevated);
+    padding: 1px 4px;
+    border-radius: 3px;
   }
 
   .input {

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -481,8 +481,8 @@
     "back": "Back",
     "next": "Next",
     "vaultTitle": "Connect your Vault (Optional)",
-    "vaultDesc": "If you use Obsidian, enter the absolute path to your vault. Otherwise, leave it blank and Joidy will use its internal storage.",
-    "vaultPath": "Absolute Path (e.g. home/user/Documents/Vault)",
+    "vaultDesc": "If you use Obsidian, enter the path to your vault (e.g. ~/Documents/notes/my-vault). Otherwise, leave it blank and Joidy will use its internal storage.",
+    "vaultPath": "Vault Path (e.g. ~/Documents/notes/my-vault)",
     "doneDesc": "Your environment has been secured and configured successfully. Redirecting to the system..."
   },
   "folderPicker": {

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -481,8 +481,8 @@
     "back": "Atrás",
     "next": "Siguiente",
     "vaultTitle": "Conecta tu Vault (Opcional)",
-    "vaultDesc": "Si usas Obsidian, introduce la ruta absoluta a tu bóveda. Si no, déjalo en blanco y Joidy usará su almacenamiento interno.",
-    "vaultPath": "Ruta Absoluta (Ej. home/user/Documents/Vault)",
+    "vaultDesc": "Si usas Obsidian, introduce la ruta a tu bóveda (ej: ~/Documentos/notas/mi-vault). Si no, déjalo en blanco y Joidy usará su almacenamiento interno.",
+    "vaultPath": "Ruta del Vault (ej: ~/Documentos/notas/mi-vault)",
     "doneDesc": "Tu entorno ha sido asegurado y configurado con éxito. Redirigiendo al sistema..."
   },
   "folderPicker": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -116,7 +116,7 @@ echo ""
 echo -e "${YELLOW}Next steps:${NC}"
 echo "  1. Edit $DIR/.env with your credentials:"
 echo "     - GEMINI_API_KEY:    get free at https://aistudio.google.com/"
-echo "     - OBSIDIAN_VAULT_PATH: absolute path to your Obsidian vault"
+echo "     - OBSIDIAN_VAULT_PATH: path to your Obsidian vault (supports ~, e.g. ~/Documentos/notas/mi-vault)"
 echo "     - SECRET_KEY:        run: openssl rand -hex 32"
 echo ""
 if [ "$PATH_UPDATED" = "1" ]; then

--- a/scripts/joidy.ps1
+++ b/scripts/joidy.ps1
@@ -131,6 +131,24 @@ if ($EnvFile -and (Test-Path $EnvFile)) {
     Write-Warn "Auto-generated required secrets in $EnvFile"
     Write-Warn "Edit $EnvFile to add: GEMINI_API_KEY, OBSIDIAN_VAULT_PATH, etc."
   }
+
+  # Expand ~ in OBSIDIAN_VAULT_PATH — Docker bind mounts require absolute
+  # paths and do not expand `~`. The settings UI lets users enter home-relative
+  # paths (e.g. ~/Documentos/notas/mi-vault). Export the expanded value for
+  # this compose run; .env keeps the raw ~/... form so the UI stays clean.
+  if ($envContent -match '(?m)^OBSIDIAN_VAULT_PATH=(.+)$') {
+    $vaultRaw = $Matches[1].Trim()
+    $vaultExpanded = $vaultRaw
+    if ($vaultRaw -eq '~') {
+      $vaultExpanded = $HOME
+    } elseif ($vaultRaw -match '^~/(.*)') {
+      $vaultExpanded = Join-Path $HOME $Matches[1]
+    }
+    if ($vaultExpanded -ne $vaultRaw) {
+      Write-Ok "Expanded OBSIDIAN_VAULT_PATH: $vaultRaw -> $vaultExpanded"
+    }
+    $env:OBSIDIAN_VAULT_PATH = $vaultExpanded
+  }
 }
 
 $HIBERNATE_SERVICES = @("ai-service", "worker")

--- a/scripts/joidy.sh
+++ b/scripts/joidy.sh
@@ -194,6 +194,29 @@ if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
   fi
 fi
 
+# ─── Expand ~ in OBSIDIAN_VAULT_PATH ───────────────────────────────
+# Docker bind mounts do NOT expand `~` — they require absolute host paths.
+# The settings UI and Setup Wizard let users enter home-relative paths
+# (e.g. ~/Documentos/notas/mi-vault). Expand `~` to $HOME here and export it
+# so compose receives an absolute path. The raw value is kept in .env so the
+# UI always shows the clean ~/... form the user typed.
+if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
+  VAULT_RAW=$(grep -E '^OBSIDIAN_VAULT_PATH=' "$ENV_FILE" | head -1 | cut -d'=' -f2-)
+  if [ -n "$VAULT_RAW" ]; then
+    VAULT_EXPANDED="$VAULT_RAW"
+    # Expand leading ~/ or bare ~ to $HOME
+    case "$VAULT_RAW" in
+      \~/*) VAULT_EXPANDED="${HOME}/${VAULT_RAW#~/}" ;;
+      \~)   VAULT_EXPANDED="$HOME" ;;
+    esac
+    if [ "$VAULT_EXPANDED" != "$VAULT_RAW" ]; then
+      print_ok "Expanded OBSIDIAN_VAULT_PATH: ${VAULT_RAW} → ${VAULT_EXPANDED}"
+    fi
+    # Export so compose uses the expanded value (overrides .env for this run)
+    export OBSIDIAN_VAULT_PATH="$VAULT_EXPANDED"
+  fi
+fi
+
 # ─── Bind-mount sources ───────────────────────────────────────────
 # Compose resolves relative volumes against the compose file directory, which
 # is read-only on system installs (/usr/share/joidy). Mounting a non-existent

--- a/start.ps1
+++ b/start.ps1
@@ -166,9 +166,9 @@ if ([string]::IsNullOrEmpty($geminiKey) -or $geminiKey -eq "your_gemini_api_key_
 
 # Check OBSIDIAN_VAULT_PATH
 $vaultPath = $envVars["OBSIDIAN_VAULT_PATH"]
-if ([string]::IsNullOrEmpty($vaultPath) -or $vaultPath -eq "/path/to/your/obsidian/vault") {
+if ([string]::IsNullOrEmpty($vaultPath) -or $vaultPath -eq "/path/to/your/obsidian/vault" -or $vaultPath -eq "~/Documentos/notas/mi-vault") {
     Write-Warn "OBSIDIAN_VAULT_PATH not set"
-    Write-Host "  Enter the full path to your Obsidian vault (e.g., C:\Users\You\Documents\Obsidian):"
+    Write-Host "  Enter the path to your Obsidian vault (e.g., ~/Documents/notes/my-vault or C:\Users\You\Documents\Obsidian):"
     $newVaultPath = Read-Host "  Vault path (press Enter to skip)"
     if (-not [string]::IsNullOrEmpty($newVaultPath)) {
         $newVaultPath = $newVaultPath -replace '\\', '/'
@@ -178,7 +178,11 @@ if ([string]::IsNullOrEmpty($vaultPath) -or $vaultPath -eq "/path/to/your/obsidi
     }
 } else {
     Write-Success "OBSIDIAN_VAULT_PATH: $vaultPath"
-    if (Test-Path $vaultPath) {
+    # Expand ~ for the existence check
+    $checkPath = $vaultPath
+    if ($checkPath -eq '~') { $checkPath = $HOME }
+    elseif ($checkPath -match '^~/(.*)') { $checkPath = Join-Path $HOME $Matches[1] }
+    if (Test-Path $checkPath) {
         Write-Success "Vault directory exists"
     } else {
         Write-Warn "Vault directory does not exist yet"
@@ -206,6 +210,36 @@ if ([string]::IsNullOrEmpty($postgresPassword)) {
 # Step 3: Start services
 $script:step++
 Write-Step "Starting services..."
+
+# Expand ~ in OBSIDIAN_VAULT_PATH — Docker bind mounts do not expand `~`.
+# Export the expanded value so compose receives an absolute host path.
+if ($env:OBSIDIAN_VAULT_PATH) {
+    $vaultRaw = $env:OBSIDIAN_VAULT_PATH
+    if ($vaultRaw -eq '~') {
+        $env:OBSIDIAN_VAULT_PATH = $HOME
+    } elseif ($vaultRaw -match '^~/(.*)') {
+        $env:OBSIDIAN_VAULT_PATH = Join-Path $HOME $Matches[1]
+    }
+    if ($env:OBSIDIAN_VAULT_PATH -ne $vaultRaw) {
+        Write-Ok "Expanded OBSIDIAN_VAULT_PATH: $vaultRaw -> $env:OBSIDIAN_VAULT_PATH"
+    }
+} else {
+    # Read from .env if not already in the environment
+    $envContent = Get-Content ".env" -Raw
+    if ($envContent -match '(?m)^OBSIDIAN_VAULT_PATH=(.+)$') {
+        $vaultRaw = $Matches[1].Trim()
+        if ($vaultRaw -eq '~') {
+            $env:OBSIDIAN_VAULT_PATH = $HOME
+        } elseif ($vaultRaw -match '^~/(.*)') {
+            $env:OBSIDIAN_VAULT_PATH = Join-Path $HOME $Matches[1]
+        } else {
+            $env:OBSIDIAN_VAULT_PATH = $vaultRaw
+        }
+        if ($env:OBSIDIAN_VAULT_PATH -ne $vaultRaw) {
+            Write-Ok "Expanded OBSIDIAN_VAULT_PATH: $vaultRaw -> $env:OBSIDIAN_VAULT_PATH"
+        }
+    }
+}
 
 # Check if compose files exist
 if (-not (Test-Path "docker-compose.yml")) {

--- a/worker/README.md
+++ b/worker/README.md
@@ -37,7 +37,7 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up worker
 Key variables consumed by this service (see root [`.env.example`](../.env.example)
 for the full list — do not duplicate here):
 
-- `OBSIDIAN_VAULT_PATH` — absolute host path to the Obsidian vault
+- `OBSIDIAN_VAULT_PATH` — host path to the Obsidian vault (supports `~`, expanded by `joidy up`)
   (mounted read-only at `/vault` inside the container)
 - `DATABASE_URL` — shared PostgreSQL connection
 - `WORKER_PORT` — override the default 8001 (healthcheck only)


### PR DESCRIPTION
## Summary

- **Root cause:** Docker bind mounts do not expand `~`, so a vault path like `~/Documentos/notas/mi-vault` resolved to a broken relative path and the worker/api containers mounted the wrong directory. The settings UI also showed a decorative `~` prefix that was not part of the saved value, making the field misleading.
- **CLI expansion:** `joidy.sh`, `joidy.ps1`, and `start.ps1` now read `OBSIDIAN_VAULT_PATH` from `.env`, expand `~` to `$HOME`, and export the absolute path for compose. The raw `~/...` value is kept in `.env` so the UI always shows the clean form the user typed.
- **Makefile:** `dev`, `dev-d`, `dev-reset`, `prod`, and `start` targets now source `.env` and export the expanded path before invoking docker-compose.
- **UI examples:** `SettingsPanel.svelte` — removed the decorative `~` prefix, updated placeholder to `~/Documentos/notas/mi-vault`, added a hint with an example below the input. `SetupWizard.svelte` — updated placeholder and added an example hint.
- **Docs/messaging:** locales (es/en), `.env.example`, `install.sh`, `aur/joidy.install`, `worker/README.md`, Makefile hints, and the `/config/keys` API description updated for consistent `~` support messaging.

#### Test plan

- [ ] Set `OBSIDIAN_VAULT_PATH=~/Documentos/notas/mi-vault` in `.env`, run `joidy up`, confirm the bind mount resolves to the absolute home path (`docker inspect` / `make doctor`).
- [ ] Open Settings → Obsidian Vault, confirm the field shows the raw `~/...` value and the hint/example is visible.
- [ ] Run through the Setup Wizard, enter `~/Documentos/notas/mi-vault`, confirm it persists to `.env` as `~/...` (not expanded).
- [ ] `make dev` with a `~/...` path — confirm the vault mounts correctly.
- [ ] `npm run check` passes (0 errors).
- [ ] `python -m compileall api/routers/config.py` passes.

Generated with [Devin](https://devin.ai)