### PR TITLE
release: v1.0.0-beta.3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,9 +29,10 @@ LLM_MODEL=gemini:gemini-2.0-flash
 EMBEDDING_MODEL=gemini:models/text-embedding-004
 
 # ── Obsidian Vault ────────────────────────────────
-# Absolute path to your Obsidian vault folder on the host
-# Example: /home/username/Documents/MyVault
-OBSIDIAN_VAULT_PATH=/path/to/your/obsidian/vault
+# Path to your Obsidian vault folder on the host.
+# Supports ~ for home-relative paths (expanded by `joidy up`).
+# Examples: ~/Documentos/notas/mi-vault  or  /home/username/Documents/MyVault
+OBSIDIAN_VAULT_PATH=~/Documentos/notas/mi-vault
 # Optional secret to validate /webhook/obsidian calls
 OBSIDIAN_WEBHOOK_SECRET=
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - _Nothing yet_
 
+## [1.0.0-beta.3] - 2026-08-24
+
+### Added
+
+- **Port fallback for `joidy up`** — if a service's host port is already bound by a foreign process, the CLI tries up to 5 subsequent ports before aborting (no half-started stack). Ports held by joidy's own compose project are reused, so re-running `joidy up` is idempotent (#879)
+
+### Fixed
+
+- **`~` not expanded in `OBSIDIAN_VAULT_PATH`** — Docker bind mounts do not expand `~`, so a vault path like `~/Documentos/notas/mi-vault` resolved to a broken relative path and the worker/api containers mounted the wrong directory. The CLI (`joidy.sh`, `joidy.ps1`, `start.ps1`) and Makefile targets now expand `~` to `$HOME` and export the absolute path for compose. The settings UI and Setup Wizard show examples and hints about `~` support (#880)
+
 ## [1.0.0-beta.2] - 2026-08-24
 
 ### Added
@@ -169,7 +179,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Responsive base layout and mobile streak actions.
 - CI pipeline: API tests, frontend typecheck, Docker build smoke test.
 
-[unreleased]: https://github.com/Axel-DaMage/joidy/compare/v1.0.0-beta.2...HEAD
+[unreleased]: https://github.com/Axel-DaMage/joidy/compare/v1.0.0-beta.3...HEAD
+[1.0.0-beta.3]: https://github.com/Axel-DaMage/joidy/compare/v1.0.0-beta.2...v1.0.0-beta.3
 [1.0.0-beta.2]: https://github.com/Axel-DaMage/joidy/compare/v1.0.0-beta.1...v1.0.0-beta.2
 [0.2.0]: https://github.com/Axel-DaMage/joidy/releases/tag/v0.2.0
 [0.1.0]: https://github.com/Axel-DaMage/joidy/releases/tag/v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ setup: ## First-time setup: copy .env, create data directories
 		echo "$(YELLOW)Next steps:$(NC)"; \
 		echo "  1. Edit .env with your API keys"; \
 		echo "     - GEMINI_API_KEY: get free at https://aistudio.google.com/"; \
-		echo "     - OBSIDIAN_VAULT_PATH: absolute path to your vault"; \
+		echo "     - OBSIDIAN_VAULT_PATH: path to your vault (supports ~, e.g. ~/Documentos/notas/mi-vault)"; \
 		echo "  2. Run: make dev"; \
 	else \
 		echo "$(GREEN)✓$(NC) .env already exists"; \
@@ -64,23 +64,33 @@ setup: ## First-time setup: copy .env, create data directories
 dev: ## Start all services in development mode (with hot reload)
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
+	@. .env 2>/dev/null || true; \
+	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
 	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build
 
 dev-d: ## Start all services in development mode (detached)
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
+	@. .env 2>/dev/null || true; \
+	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
 	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build -d
 
 dev-reset: ## Recreate all services in development mode from scratch (one command)
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
+	@. .env 2>/dev/null || true; \
+	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
 	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai down --remove-orphans --volumes
+	@. .env 2>/dev/null || true; \
+	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
 	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build -d --force-recreate --remove-orphans --wait
 	@echo "✓ Services recreated. Use 'make logs' to follow output."
 
 prod: ## Start all services in production mode
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
+	@. .env 2>/dev/null || true; \
+	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
 	$(DOCKER_COMPOSE) up --build -d
 
 stop: ## Stop all services
@@ -241,12 +251,14 @@ doctor: ## Verify all prerequisites are met
 	else \
 		echo "$(GREEN)✓$(NC) GEMINI_API_KEY configured"; \
 	fi; \
-	if [ -z "$$OBSIDIAN_VAULT_PATH" ] || [ "$$OBSIDIAN_VAULT_PATH" = "/path/to/your/obsidian/vault" ]; then \
+	if [ -z "$$OBSIDIAN_VAULT_PATH" ] || [ "$$OBSIDIAN_VAULT_PATH" = "/path/to/your/obsidian/vault" ] || [ "$$OBSIDIAN_VAULT_PATH" = "~/Documentos/notas/mi-vault" ]; then \
 		echo "$(YELLOW)⚠$(NC) OBSIDIAN_VAULT_PATH not configured"; \
 		EXIT_CODE=1; \
 	else \
 		echo "$(GREEN)✓$(NC) OBSIDIAN_VAULT_PATH: $$OBSIDIAN_VAULT_PATH"; \
-		if [ -d "$$OBSIDIAN_VAULT_PATH" ]; then \
+		VAULT_CHECK="$$OBSIDIAN_VAULT_PATH"; \
+		case "$$VAULT_CHECK" in ~/*) VAULT_CHECK="$(HOME)/$${VAULT_CHECK#~/}";; ~) VAULT_CHECK="$(HOME)";; esac; \
+		if [ -d "$$VAULT_CHECK" ]; then \
 			echo "$(GREEN)  ✓ Vault directory exists$(NC)"; \
 		else \
 			echo "$(YELLOW)  ⚠ Vault directory does not exist yet$(NC)"; \
@@ -326,11 +338,11 @@ start: ## 🚀 Quick start: setup + start all services
 		fi; \
 	fi
 	@. .env 2>/dev/null || true; \
-	if [ -z "$$OBSIDIAN_VAULT_PATH" ] || [ "$$OBSIDIAN_VAULT_PATH" = "/path/to/your/obsidian/vault" ]; then \
+	if [ -z "$$OBSIDIAN_VAULT_PATH" ] || [ "$$OBSIDIAN_VAULT_PATH" = "/path/to/your/obsidian/vault" ] || [ "$$OBSIDIAN_VAULT_PATH" = "~/Documentos/notas/mi-vault" ]; then \
 		echo ""; \
 		echo "$(YELLOW)⚠ OBSIDIAN_VAULT_PATH not set in .env$(NC)"; \
-		echo "  Enter the absolute path to your Obsidian vault:"; \
-		echo "  (e.g., /home/username/Documents/Obsidian)"; \
+		echo "  Enter the path to your Obsidian vault (supports ~):"; \
+		echo "  (e.g., ~/Documentos/notas/mi-vault or /home/username/Documents/Obsidian)"; \
 		echo ""; \
 		echo -n "$(BLUE)Vault path (or press Enter to skip):$(NC) "; \
 		read -r VAULT_PATH; \
@@ -353,7 +365,9 @@ start: ## 🚀 Quick start: setup + start all services
 	fi
 	@echo ""
 	@echo "Step 2: Starting services..."
-	@$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml up --build -d
+	@. .env 2>/dev/null || true; \
+	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
+	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml up --build -d
 	@echo ""
 	@echo "── $(GREEN)Joidy is running!$(NC) ───────────────────────────────"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/JOIDY-v1.0.0-beta.2?style=for-the-badge" alt="Joidy">
+  <img src="https://img.shields.io/badge/JOIDY-v1.0.0-beta.3?style=for-the-badge" alt="Joidy">
 </p>
 
 <p align="center">

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -141,7 +141,7 @@ def get_available_keys():
 def get_key_description(key: str) -> str:
     descriptions = {
         "gemini_api_key": "API key for Google Gemini AI",
-        "obsidian_vault_path": "Absolute path to your Obsidian vault",
+        "obsidian_vault_path": "Path to your Obsidian vault (supports ~ for home-relative, expanded by `joidy up`)",
         "daily_notes_folder": "Relative folder inside your vault for daily notes",
         "github_token": "GitHub Personal Access Token",
         "github_username": "GitHub username",

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -1,11 +1,11 @@
 pkgbase = joidy
 pkgdesc = Personal knowledge management with gamification
-pkgver = 1.0.0-beta.2
+pkgver = 1.0.0-beta.3
 pkgrel = 1
 url = https://joidy-web.vercel.app
 arch = any
 license = GPL3
 depends = docker
-source = https://github.com/Axel-DaMage/joidy/archive/v1.0.0-beta.2.tar.gz
+source = https://github.com/Axel-DaMage/joidy/archive/v1.0.0-beta.3.tar.gz
 sha256sums = SKIP
 pkgname = joidy

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Joidy App <https://github.com/Axel-DaMage/joidy>
 pkgname=joidy
-pkgver=1.0.0-beta.2
+pkgver=1.0.0-beta.3
 _tag=${pkgver}
 pkgrel=1
 pkgdesc="Personal knowledge management with gamification"

--- a/aur/joidy.install
+++ b/aur/joidy.install
@@ -7,7 +7,7 @@ post_install() {
   echo ""
   echo "  Edit ~/.config/joidy/.env to add your credentials:"
   echo "    - GEMINI_API_KEY:     https://aistudio.google.com/app/apikey"
-  echo "    - OBSIDIAN_VAULT_PATH: absolute path to your Obsidian vault"
+  echo "    - OBSIDIAN_VAULT_PATH: path to your Obsidian vault (supports ~, e.g. ~/Documentos/notas/mi-vault)"
   echo ""
   echo "  Then run: joidy up"
   echo ""

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 ```yaml
-version: 1.0.0-beta.2
+version: 1.0.0-beta.3
 base_url: http://localhost:8000
 docs_url: http://localhost:8000/docs
 framework: FastAPI

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 ```yaml
 project: Joidy
 type: Sistema de Gestión del Conocimiento con Gamificación
-version: 1.0.0-beta.2
+version: 1.0.0-beta.3
 framework: Monorepo Docker
 services: 4
 database: PostgreSQL 16 + pgvector

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 ```yaml
 project: Joidy
 type: Sistema de Gestión del Conocimiento con Gamificación
-version: 1.0.0-beta.2
+version: 1.0.0-beta.3
 framework: Monorepo Docker
 docs_version: 2.0
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@
 
 ```yaml
 last_updated: 2026-08-24
-version: 1.0.0-beta.2
+version: 1.0.0-beta.3
 ```
 
 ---

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joidy-frontend",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "private": true,
   "engines": {
     "node": ">=22.19.0"

--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -746,15 +746,19 @@
               style="display: flex; align-items: center; gap: 2px; padding: 0 10px; background: var(--elevated); border: 1px solid var(--border); border-radius: var(--r);"
               class="input-wrapper"
             >
-              <span class="mono" style="color: var(--text-disabled); font-size: 11px;">~</span>
               <input
                 type="text"
                 class="setting-input mono"
                 style="border: none; background: transparent; flex: 1; padding-left: 2px;"
-                placeholder="/Documentos/ObsidianVault"
+                placeholder="~/Documentos/notas/mi-vault"
                 bind:value={systemConfig.obsidian_vault_path}
               />
             </div>
+            <p class="hint">
+              Ruta a tu vault desde tu <code>home</code>. Ej:
+              <code>~/Documentos/notas/mi-vault</code>. Al guardar, <code>joidy up</code> expande
+              <code>~</code> automáticamente.
+            </p>
           </div>
           <div class="row" style="flex-direction: column; align-items: stretch; gap: 8px;">
             <div class="row-label">

--- a/frontend/src/lib/components/SetupWizard.svelte
+++ b/frontend/src/lib/components/SetupWizard.svelte
@@ -113,8 +113,11 @@
               type="text"
               bind:value={vaultPath}
               class="input mono"
-              placeholder="home/usuario/Documents/Vault"
+              placeholder="~/Documentos/notas/mi-vault"
             />
+            <span class="field-hint mono"
+              >Ej: ~/Documentos/notas/mi-vault — <code>joidy up</code> expande <code>~</code> automáticamente</span
+            >
           </div>
 
           <div class="actions">
@@ -239,6 +242,21 @@
     font-size: 12px;
     font-weight: 500;
     color: var(--text-secondary);
+  }
+
+  .field-hint {
+    font-size: 11px;
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+
+  .field-hint code {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-secondary);
+    background: var(--elevated);
+    padding: 1px 4px;
+    border-radius: 3px;
   }
 
   .input {

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -481,8 +481,8 @@
     "back": "Back",
     "next": "Next",
     "vaultTitle": "Connect your Vault (Optional)",
-    "vaultDesc": "If you use Obsidian, enter the absolute path to your vault. Otherwise, leave it blank and Joidy will use its internal storage.",
-    "vaultPath": "Absolute Path (e.g. home/user/Documents/Vault)",
+    "vaultDesc": "If you use Obsidian, enter the path to your vault (e.g. ~/Documents/notes/my-vault). Otherwise, leave it blank and Joidy will use its internal storage.",
+    "vaultPath": "Vault Path (e.g. ~/Documents/notes/my-vault)",
     "doneDesc": "Your environment has been secured and configured successfully. Redirecting to the system..."
   },
   "folderPicker": {

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -481,8 +481,8 @@
     "back": "Atrás",
     "next": "Siguiente",
     "vaultTitle": "Conecta tu Vault (Opcional)",
-    "vaultDesc": "Si usas Obsidian, introduce la ruta absoluta a tu bóveda. Si no, déjalo en blanco y Joidy usará su almacenamiento interno.",
-    "vaultPath": "Ruta Absoluta (Ej. home/user/Documents/Vault)",
+    "vaultDesc": "Si usas Obsidian, introduce la ruta a tu bóveda (ej: ~/Documentos/notas/mi-vault). Si no, déjalo en blanco y Joidy usará su almacenamiento interno.",
+    "vaultPath": "Ruta del Vault (ej: ~/Documentos/notas/mi-vault)",
     "doneDesc": "Tu entorno ha sido asegurado y configurado con éxito. Redirigiendo al sistema..."
   },
   "folderPicker": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -116,7 +116,7 @@ echo ""
 echo -e "${YELLOW}Next steps:${NC}"
 echo "  1. Edit $DIR/.env with your credentials:"
 echo "     - GEMINI_API_KEY:    get free at https://aistudio.google.com/"
-echo "     - OBSIDIAN_VAULT_PATH: absolute path to your Obsidian vault"
+echo "     - OBSIDIAN_VAULT_PATH: path to your Obsidian vault (supports ~, e.g. ~/Documentos/notas/mi-vault)"
 echo "     - SECRET_KEY:        run: openssl rand -hex 32"
 echo ""
 if [ "$PATH_UPDATED" = "1" ]; then

--- a/scripts/joidy.ps1
+++ b/scripts/joidy.ps1
@@ -131,6 +131,24 @@ if ($EnvFile -and (Test-Path $EnvFile)) {
     Write-Warn "Auto-generated required secrets in $EnvFile"
     Write-Warn "Edit $EnvFile to add: GEMINI_API_KEY, OBSIDIAN_VAULT_PATH, etc."
   }
+
+  # Expand ~ in OBSIDIAN_VAULT_PATH — Docker bind mounts require absolute
+  # paths and do not expand `~`. The settings UI lets users enter home-relative
+  # paths (e.g. ~/Documentos/notas/mi-vault). Export the expanded value for
+  # this compose run; .env keeps the raw ~/... form so the UI stays clean.
+  if ($envContent -match '(?m)^OBSIDIAN_VAULT_PATH=(.+)$') {
+    $vaultRaw = $Matches[1].Trim()
+    $vaultExpanded = $vaultRaw
+    if ($vaultRaw -eq '~') {
+      $vaultExpanded = $HOME
+    } elseif ($vaultRaw -match '^~/(.*)') {
+      $vaultExpanded = Join-Path $HOME $Matches[1]
+    }
+    if ($vaultExpanded -ne $vaultRaw) {
+      Write-Ok "Expanded OBSIDIAN_VAULT_PATH: $vaultRaw -> $vaultExpanded"
+    }
+    $env:OBSIDIAN_VAULT_PATH = $vaultExpanded
+  }
 }
 
 $HIBERNATE_SERVICES = @("ai-service", "worker")

--- a/scripts/joidy.sh
+++ b/scripts/joidy.sh
@@ -194,6 +194,29 @@ if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
   fi
 fi
 
+# ─── Expand ~ in OBSIDIAN_VAULT_PATH ───────────────────────────────
+# Docker bind mounts do NOT expand `~` — they require absolute host paths.
+# The settings UI and Setup Wizard let users enter home-relative paths
+# (e.g. ~/Documentos/notas/mi-vault). Expand `~` to $HOME here and export it
+# so compose receives an absolute path. The raw value is kept in .env so the
+# UI always shows the clean ~/... form the user typed.
+if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
+  VAULT_RAW=$(grep -E '^OBSIDIAN_VAULT_PATH=' "$ENV_FILE" | head -1 | cut -d'=' -f2-)
+  if [ -n "$VAULT_RAW" ]; then
+    VAULT_EXPANDED="$VAULT_RAW"
+    # Expand leading ~/ or bare ~ to $HOME
+    case "$VAULT_RAW" in
+      \~/*) VAULT_EXPANDED="${HOME}/${VAULT_RAW#~/}" ;;
+      \~)   VAULT_EXPANDED="$HOME" ;;
+    esac
+    if [ "$VAULT_EXPANDED" != "$VAULT_RAW" ]; then
+      print_ok "Expanded OBSIDIAN_VAULT_PATH: ${VAULT_RAW} → ${VAULT_EXPANDED}"
+    fi
+    # Export so compose uses the expanded value (overrides .env for this run)
+    export OBSIDIAN_VAULT_PATH="$VAULT_EXPANDED"
+  fi
+fi
+
 # ─── Bind-mount sources ───────────────────────────────────────────
 # Compose resolves relative volumes against the compose file directory, which
 # is read-only on system installs (/usr/share/joidy). Mounting a non-existent

--- a/scripts/joidy.sh
+++ b/scripts/joidy.sh
@@ -22,6 +22,11 @@
 #   joidy logs     Tail logs (all services)
 #   joidy logs api Tail logs for a specific service
 #   joidy help     Show this help message
+#
+# Port fallback: if a service's host port is already bound by a foreign
+# process, `joidy up` tries up to 5 subsequent ports before aborting (so the
+# stack is never left half-started). Ports held by the joidy compose project's
+# own containers are reused (idempotent re-runs).
 
 set -e
 
@@ -67,6 +72,10 @@ if [ ! -f "$PROJECT_DIR/docker-compose.yml" ]; then
   echo "Set JOIDY_DIR env var or create ~/.config/joidy/path with the project path." >&2
   exit 1
 fi
+
+# Compose project name = lowercased basename of the project dir. Used to tell
+# our own containers apart from foreign ones holding a port we want to bind.
+COMPOSE_PROJECT="$(basename "$PROJECT_DIR" | tr '[:upper:]' '[:lower:]')"
 
 cd "$PROJECT_DIR"
 
@@ -270,8 +279,120 @@ ai_profile_args() {
   fi
 }
 
+# ─── Port fallback helpers ─────────────────────────────────────────
+# Before `joidy up`, resolve a free host port for each service. If the
+# configured port is busy by a foreign process, try up to 5 subsequent ports.
+# Ports held by our own compose project's containers are reused (idempotent).
+# If no free port is found, abort without running `compose up`.
+
+# Read a port setting: env var → .env file → default.
+read_port() {
+  local var="$1" default="$2" val=""
+  if [ -n "${!var:-}" ]; then
+    val="${!var}"
+  elif [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
+    val=$(grep -E "^${var}=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d'=' -f2-)
+  fi
+  [ -z "$val" ] && val="$default"
+  echo "$val"
+}
+
+# Is anything listening on $1 (TCP, any interface)?
+port_in_use() {
+  local port="$1"
+  if command -v ss &>/dev/null; then
+    ss -tlnH 2>/dev/null | awk '{print $4}' | grep -qE ":${port}$"
+  elif command -v netstat &>/dev/null; then
+    netstat -tlnH 2>/dev/null | awk '{print $4}' | grep -qE ":${port}$"
+  else
+    return 1 # cannot check — assume free
+  fi
+}
+
+# Is $1 held by a container of our own compose project? (Docker only)
+port_held_by_self() {
+  local port="$1"
+  [ "$CONTAINER_ENGINE" = "docker" ] || return 1
+  command -v docker &>/dev/null || return 1
+  docker ps --no-trunc \
+    --filter "label=com.docker.compose.project=${COMPOSE_PROJECT}" \
+    --format '{{.Ports}}' 2>/dev/null | grep -qE ":${port}->"
+}
+
+# Is $1 available for us to bind? (free, or already held by our own stack)
+port_available() {
+  local port="$1"
+  if ! port_in_use "$port"; then
+    return 0
+  fi
+  port_held_by_self "$port"
+}
+
+# Find a free port starting at $1, trying up to 5 subsequent ports (6 tries).
+# Skips ports already assigned to another joidy service in this run.
+# Echoes the chosen port; returns 1 if none free.
+find_free_port() {
+  local start="$1" port offset p
+  for offset in 0 1 2 3 4 5; do
+    port=$((start + offset))
+    # Skip ports already claimed by another joidy service this run
+    for p in "${RESOLVED_PORTS[@]:-}"; do
+      [ "$p" = "$port" ] && continue 2
+    done
+    if port_available "$port"; then
+      echo "$port"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Resolve free host ports for all 4 services and export them. Aborts (exit 1)
+# without invoking compose if any service cannot get a free port.
+resolve_ports() {
+  local api_def ai_def worker_def frontend_def
+  api_def=$(read_port API_PORT 8000)
+  ai_def=$(read_port AI_SERVICE_PORT 8002)
+  worker_def=$(read_port WORKER_PORT 8001)
+  frontend_def=$(read_port FRONTEND_PORT 3000)
+
+  RESOLVED_PORTS=()
+  local api ai worker frontend
+  api=$(find_free_port "$api_def") || {
+    print_err "No free port for api (tried ${api_def}..$((api_def + 5))) — aborting."
+    exit 1
+  }
+  RESOLVED_PORTS+=("$api")
+  ai=$(find_free_port "$ai_def") || {
+    print_err "No free port for ai-service (tried ${ai_def}..$((ai_def + 5))) — aborting."
+    exit 1
+  }
+  RESOLVED_PORTS+=("$ai")
+  worker=$(find_free_port "$worker_def") || {
+    print_err "No free port for worker (tried ${worker_def}..$((worker_def + 5))) — aborting."
+    exit 1
+  }
+  RESOLVED_PORTS+=("$worker")
+  frontend=$(find_free_port "$frontend_def") || {
+    print_err "No free port for frontend (tried ${frontend_def}..$((frontend_def + 5))) — aborting."
+    exit 1
+  }
+  RESOLVED_PORTS+=("$frontend")
+
+  export API_PORT="$api"
+  export AI_SERVICE_PORT="$ai"
+  export WORKER_PORT="$worker"
+  export FRONTEND_PORT="$frontend"
+
+  [ "$api" != "$api_def" ] && print_warn "API_PORT bumped ${api_def}→${api}"
+  [ "$ai" != "$ai_def" ] && print_warn "AI_SERVICE_PORT bumped ${ai_def}→${ai}"
+  [ "$worker" != "$worker_def" ] && print_warn "WORKER_PORT bumped ${worker_def}→${worker}"
+  [ "$frontend" != "$frontend_def" ] && print_warn "FRONTEND_PORT bumped ${frontend_def}→${frontend}"
+}
+
 cmd_up() {
   print_status "Starting Joidy services..."
+  resolve_ports
   local profile
   profile="$(ai_profile_args)"
   if [ -n "$profile" ]; then
@@ -377,6 +498,12 @@ For AUR installs (read-only /usr/share/joidy), .env is stored in
 ~/.config/joidy/.env. Edit it to add GEMINI_API_KEY, OBSIDIAN_VAULT_PATH, etc.
 
 The project directory is auto-detected from the script location.
+
+Port fallback: `joidy up` checks the host ports for api (8000), ai-service
+(8002), worker (8001) and frontend (3000). If a port is already bound by a
+foreign process, it tries up to 5 subsequent ports; if none are free, it
+aborts without starting any service (no half-started stack). Ports held by
+joidy's own containers are reused, so re-running `joidy up` is idempotent.
 HELP
 }
 

--- a/start.ps1
+++ b/start.ps1
@@ -166,9 +166,9 @@ if ([string]::IsNullOrEmpty($geminiKey) -or $geminiKey -eq "your_gemini_api_key_
 
 # Check OBSIDIAN_VAULT_PATH
 $vaultPath = $envVars["OBSIDIAN_VAULT_PATH"]
-if ([string]::IsNullOrEmpty($vaultPath) -or $vaultPath -eq "/path/to/your/obsidian/vault") {
+if ([string]::IsNullOrEmpty($vaultPath) -or $vaultPath -eq "/path/to/your/obsidian/vault" -or $vaultPath -eq "~/Documentos/notas/mi-vault") {
     Write-Warn "OBSIDIAN_VAULT_PATH not set"
-    Write-Host "  Enter the full path to your Obsidian vault (e.g., C:\Users\You\Documents\Obsidian):"
+    Write-Host "  Enter the path to your Obsidian vault (e.g., ~/Documents/notes/my-vault or C:\Users\You\Documents\Obsidian):"
     $newVaultPath = Read-Host "  Vault path (press Enter to skip)"
     if (-not [string]::IsNullOrEmpty($newVaultPath)) {
         $newVaultPath = $newVaultPath -replace '\\', '/'
@@ -178,7 +178,11 @@ if ([string]::IsNullOrEmpty($vaultPath) -or $vaultPath -eq "/path/to/your/obsidi
     }
 } else {
     Write-Success "OBSIDIAN_VAULT_PATH: $vaultPath"
-    if (Test-Path $vaultPath) {
+    # Expand ~ for the existence check
+    $checkPath = $vaultPath
+    if ($checkPath -eq '~') { $checkPath = $HOME }
+    elseif ($checkPath -match '^~/(.*)') { $checkPath = Join-Path $HOME $Matches[1] }
+    if (Test-Path $checkPath) {
         Write-Success "Vault directory exists"
     } else {
         Write-Warn "Vault directory does not exist yet"
@@ -206,6 +210,36 @@ if ([string]::IsNullOrEmpty($postgresPassword)) {
 # Step 3: Start services
 $script:step++
 Write-Step "Starting services..."
+
+# Expand ~ in OBSIDIAN_VAULT_PATH — Docker bind mounts do not expand `~`.
+# Export the expanded value so compose receives an absolute host path.
+if ($env:OBSIDIAN_VAULT_PATH) {
+    $vaultRaw = $env:OBSIDIAN_VAULT_PATH
+    if ($vaultRaw -eq '~') {
+        $env:OBSIDIAN_VAULT_PATH = $HOME
+    } elseif ($vaultRaw -match '^~/(.*)') {
+        $env:OBSIDIAN_VAULT_PATH = Join-Path $HOME $Matches[1]
+    }
+    if ($env:OBSIDIAN_VAULT_PATH -ne $vaultRaw) {
+        Write-Ok "Expanded OBSIDIAN_VAULT_PATH: $vaultRaw -> $env:OBSIDIAN_VAULT_PATH"
+    }
+} else {
+    # Read from .env if not already in the environment
+    $envContent = Get-Content ".env" -Raw
+    if ($envContent -match '(?m)^OBSIDIAN_VAULT_PATH=(.+)$') {
+        $vaultRaw = $Matches[1].Trim()
+        if ($vaultRaw -eq '~') {
+            $env:OBSIDIAN_VAULT_PATH = $HOME
+        } elseif ($vaultRaw -match '^~/(.*)') {
+            $env:OBSIDIAN_VAULT_PATH = Join-Path $HOME $Matches[1]
+        } else {
+            $env:OBSIDIAN_VAULT_PATH = $vaultRaw
+        }
+        if ($env:OBSIDIAN_VAULT_PATH -ne $vaultRaw) {
+            Write-Ok "Expanded OBSIDIAN_VAULT_PATH: $vaultRaw -> $env:OBSIDIAN_VAULT_PATH"
+        }
+    }
+}
 
 # Check if compose files exist
 if (-not (Test-Path "docker-compose.yml")) {

--- a/worker/README.md
+++ b/worker/README.md
@@ -37,7 +37,7 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml up worker
 Key variables consumed by this service (see root [`.env.example`](../.env.example)
 for the full list — do not duplicate here):
 
-- `OBSIDIAN_VAULT_PATH` — absolute host path to the Obsidian vault
+- `OBSIDIAN_VAULT_PATH` — host path to the Obsidian vault (supports `~`, expanded by `joidy up`)
   (mounted read-only at `/vault` inside the container)
 - `DATABASE_URL` — shared PostgreSQL connection
 - `WORKER_PORT` — override the default 8001 (healthcheck only)


### PR DESCRIPTION
## Summary

- Bump version strings to v1.0.0-beta.3 (package.json, PKGBUILD, .SRCINFO, README badge, docs metadata)
- Update CHANGELOG.md with the v1.0.0-beta.3 section and compare links

### Included since v1.0.0-beta.2

- **feat(cli): port fallback for `joidy up`** — tries up to 5 subsequent ports before aborting (#879)
- **fix(vault): expand `~` in `OBSIDIAN_VAULT_PATH`** — Docker bind mounts do not expand `~`; the CLI and Makefile now expand it to `$HOME` and export the absolute path for compose (#880)

#### Test plan

- [ ] CI passes (API Lint & Typecheck, Frontend Typecheck, Docker Build, Worker Tests)
- [ ] Version strings are consistent across all files (no stray `beta.2` references except CHANGELOG history)
- [ ] After merge, release workflow creates the tag and GitHub pre-release

Closes #879, #880

Generated with [Devin](https://devin.ai)