### PR TITLE
fix(cli): resolve_ports returns non-zero with set -e when no ports bumped

### DIFF
--- a/scripts/joidy.sh
+++ b/scripts/joidy.sh
@@ -411,6 +411,7 @@ resolve_ports() {
   [ "$ai" != "$ai_def" ] && print_warn "AI_SERVICE_PORT bumped ${ai_def}→${ai}"
   [ "$worker" != "$worker_def" ] && print_warn "WORKER_PORT bumped ${worker_def}→${worker}"
   [ "$frontend" != "$frontend_def" ] && print_warn "FRONTEND_PORT bumped ${frontend_def}→${frontend}"
+  return 0
 }
 
 cmd_up() {


### PR DESCRIPTION
## Summary

- `resolve_ports()` in `scripts/joidy.sh` ends with `[ "$frontend" != "$frontend_def" ] && print_warn ...`. When no ports are bumped, `[` returns 1, `&&` short-circuits, and the function returns 1. With `set -e`, this silently kills the script before `cmd_up` can invoke `docker compose up` — `joidy up` exits with code 1 and no error message.
- Fix: add `return 0` at the end of `resolve_ports()` so it always returns success when port resolution completed without aborting.

#### Test plan

- [ ] `bash -n scripts/joidy.sh` passes (syntax check)
- [ ] `joidy up` with all ports free — no bump, should proceed to `docker compose up` instead of exiting silently
- [ ] `joidy up` with a port conflict — should still bump and warn correctly

Generated with [Devin](https://devin.ai)