### PR TITLE
fix(infra): run dev containers as host UID/GID so .svelte-kit never needs sudo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,7 @@ otherwise the API joins group 0, `/system/power/status` returns
 - AI features disabled without `GEMINI_API_KEY`; API still works
 - Database is shared across all services (single PostgreSQL database via `DATABASE_URL`)
 - Config via Pydantic `Settings` from `.env`; no hardcoded values
-- `svelte-kit sync` runs on `postinstall` — can fail if `.svelte-kit/` has root-owned files
+- `svelte-kit sync` runs on `postinstall` — can fail if `.svelte-kit/` has root-owned files (legacy only: since #886 the dev containers run as the host UID/GID via `docker-compose.dev.yml` build args + `user:`, so `make dev` never creates root-owned `.svelte-kit` and `make fix-permissions` no longer needs `sudo`).
 - Vite HMR in Docker: `server.hmr.clientPort: 3000` + `host: 127.0.0.1` (in `vite.config.ts`, overridable via `JOIDY_HMR_HOST`). Using `localhost` breaks on hosts where it resolves to `::1` (IPv6) and Docker's IPv6 forwarding hangs.
 
 ## Workflow

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ PLATFORM := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 # Portable sed in-place: GNU sed uses -i, BSD sed (macOS) needs -i ''
 SED_INPLACE := $(shell sed --version >/dev/null 2>&1 && echo "sed -i" || echo "sed -i ''")
 
+# Host UID/GID passed to the dev compose overlay so dev containers run as the
+# host user and bind-mounted artifacts (.svelte-kit, data/logs) never need sudo
+# to clean (#886). Resolved by make (not the shell) to avoid bash's readonly UID.
+HOST_UID := $(shell id -u)
+HOST_GID := $(shell id -g)
+
 RED := \033[0;31m
 GREEN := \033[0;32m
 YELLOW := \033[0;33m
@@ -66,24 +72,24 @@ dev: ## Start all services in development mode (with hot reload)
 	@mkdir -p data/db data/uploads data/vault
 	@. .env 2>/dev/null || true; \
 	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build
+	UID=$(HOST_UID) GID=$(HOST_GID) $(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build
 
 dev-d: ## Start all services in development mode (detached)
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
 	@. .env 2>/dev/null || true; \
 	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build -d
+	UID=$(HOST_UID) GID=$(HOST_GID) $(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build -d
 
 dev-reset: ## Recreate all services in development mode from scratch (one command)
 	@if [ ! -f .env ]; then echo "Run 'make setup' first"; exit 1; fi
 	@mkdir -p data/db data/uploads data/vault
 	@. .env 2>/dev/null || true; \
 	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai down --remove-orphans --volumes
+	UID=$(HOST_UID) GID=$(HOST_GID) $(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai down --remove-orphans --volumes
 	@. .env 2>/dev/null || true; \
 	case "$$OBSIDIAN_VAULT_PATH" in ~/*) export OBSIDIAN_VAULT_PATH="$(HOME)/$${OBSIDIAN_VAULT_PATH#~/}";; ~) export OBSIDIAN_VAULT_PATH="$(HOME)";; esac; \
-	$(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build -d --force-recreate --remove-orphans --wait
+	UID=$(HOST_UID) GID=$(HOST_GID) $(DOCKER_COMPOSE) -p $(COMPOSE_PROJECT) -f docker-compose.yml -f docker-compose.dev.yml --profile ai up --build -d --force-recreate --remove-orphans --wait
 	@echo "✓ Services recreated. Use 'make logs' to follow output."
 
 prod: ## Start all services in production mode
@@ -161,8 +167,8 @@ lint-api: ## Check syntax of all Python services via Docker (compileall)
 
 lint: lint-api ## Run all linters and code checkers
 
-fix-permissions: ## Fix project permissions (run once with sudo make fix-permissions)
-	sudo bash scripts/fix-permissions.sh
+fix-permissions: ## Clean Docker artifacts and fix project permissions (no sudo needed since #886)
+	bash scripts/fix-permissions.sh
 
 # ─────────────────────────────────────────────────
 # Quick Start Commands (Linux/Mac)
@@ -273,14 +279,15 @@ doctor: ## Verify all prerequisites are met
 	echo ""; \
 	if [ -d "frontend/.svelte-kit" ]; then \
 		if [ -e "frontend/.svelte-kit/env.d.ts" ] && [ ! -w "frontend/.svelte-kit/env.d.ts" ]; then \
-			echo "$(YELLOW)⚠$(NC) frontend/.svelte-kit/env.d.ts is not writable (likely root-owned)"; \
-			echo "  The frontend dev container (uid 1000) will crash on start with EACCES"; \
-			echo "  Run: sudo make fix-permissions"; \
+			echo "$(YELLOW)⚠$(NC) frontend/.svelte-kit/env.d.ts is not writable (legacy root-owned)"; \
+			echo "  The frontend dev container will crash on start with EACCES."; \
+			echo "  One-time cleanup (then never again, dev runs as your UID since #886):"; \
+			echo "    sudo chown -R \"\$$(id -u):\$$(id -g)\" frontend/.svelte-kit"; \
 			EXIT_CODE=1; \
 		elif [ ! -w "frontend/.svelte-kit" ]; then \
-			echo "$(YELLOW)⚠$(NC) frontend/.svelte-kit is not writable (likely root-owned)"; \
-			echo "  The frontend dev container (uid 1000) will crash on start with EACCES"; \
-			echo "  Run: sudo make fix-permissions"; \
+			echo "$(YELLOW)⚠$(NC) frontend/.svelte-kit is not writable (legacy root-owned)"; \
+			echo "  One-time cleanup (then never again, dev runs as your UID since #886):"; \
+			echo "    sudo chown -R \"\$$(id -u):\$$(id -g)\" frontend/.svelte-kit"; \
 			EXIT_CODE=1; \
 		else \
 			echo "$(GREEN)✓$(NC) frontend/.svelte-kit is writable"; \

--- a/ai-service/Dockerfile
+++ b/ai-service/Dockerfile
@@ -29,8 +29,12 @@ WORKDIR /app
 
 COPY --from=deps /install /usr/local
 
-# Create non-root user (uid 1000 matches typical host user for dev volume mounts)
-RUN addgroup --system --gid 1000 app && adduser --system --uid 1000 --ingroup app app
+# Create non-root user. Defaults to uid/gid 1000 (matches typical host user).
+# In development, docker-compose.dev.yml passes the host UID/GID as build args
+# so bind-mounted files are written as the host user and never need sudo (#886).
+ARG UID=1000
+ARG GID=1000
+RUN addgroup --system --gid ${GID} app && adduser --system --uid ${UID} --ingroup app app
 
 COPY --chown=app:app . .
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -37,8 +37,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=deps /install /usr/local
 
-# Create non-root user (uid 1000 matches typical host user for dev volume mounts)
-RUN addgroup --system --gid 1000 app && adduser --system --uid 1000 --ingroup app app
+# Create non-root user. Defaults to uid/gid 1000 (matches typical host user).
+# In development, docker-compose.dev.yml passes the host UID/GID as build args
+# so bind-mounted files are written as the host user and never need sudo (#886).
+ARG UID=1000
+ARG GID=1000
+RUN addgroup --system --gid ${GID} app && adduser --system --uid ${UID} --ingroup app app
 
 COPY --chown=app:app . .
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,9 +1,17 @@
 services:
+  # Dev containers run as the host UID/GID (exported by the Makefile dev
+  # targets, defaulting to 1000) so bind-mounted artifacts — frontend/.svelte-kit,
+  # api/data/logs, etc. — are owned by the host user and never need sudo to
+  # clean, even when the host UID is not 1000 (#886).
   frontend:
     build:
       context: ./frontend
       dockerfile: Dockerfile
       target: development
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    user: ${UID:-1000}:${GID:-1000}
     volumes:
       - ./frontend:/app
       - /app/node_modules
@@ -13,11 +21,10 @@ services:
       - VITE_API_URL=http://localhost:${API_PORT:-8000}
       - VITE_INTERNAL_API_URL=http://api:8000
     command: npm run dev -- --host 0.0.0.0 --port 3000
-    # The dev container runs as uid 1000 (node). When frontend/.svelte-kit is
-    # root-owned (e.g. after `sudo make fix-permissions`), svelte-kit sync
-    # crashes on EACCES before Vite starts. The healthcheck surfaces that
-    # crash-loop as "unhealthy" in `docker compose ps` so it is visible
-    # instead of a silently dead UI.
+    # The dev container runs as the host UID. A leftover root-owned .svelte-kit
+    # (e.g. from a previous `sudo make fix-permissions`) still crashes
+    # svelte-kit sync on EACCES; the healthcheck surfaces that crash-loop as
+    # "unhealthy" in `docker compose ps` instead of a silently dead UI.
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
       interval: 10s
@@ -29,6 +36,10 @@ services:
     build:
       context: ./api
       dockerfile: Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    user: ${UID:-1000}:${GID:-1000}
     volumes:
       - ./api:/app
       - ./data/db:/data/db
@@ -41,11 +52,10 @@ services:
       - VAULT_PATH=/vault
       - OBSIDIAN_VAULT_PATH=/vault
     # The ./api:/app bind mount shadows the image's pre-chowned /app/data/logs,
-    # so this mkdir runs against the host checkout and fails whenever the host
-    # UID differs from the container's app user (uid 1000) — e.g. in CI, where
-    # it crash-looped the container before uvicorn ever started (#622).
-    # Keep it best-effort: logging_config.py already creates the directory and
-    # degrades to console-only logging when it is not writable.
+    # so this mkdir runs against the host checkout. With the host UID/GID match
+    # above it now succeeds; keep it best-effort anyway so a stale root-owned
+    # checkout (pre-#886) still boots — logging_config.py degrades to
+    # console-only logging when the dir is not writable (#622).
     command: sh -c "mkdir -p /app/data/logs 2>/dev/null || true; exec uvicorn main:app --host 0.0.0.0 --port 8000 --reload --reload-include '*.py' --reload-exclude '__pycache__/*' --reload-exclude '*.pyc'"
 
   ai-service:
@@ -54,6 +64,10 @@ services:
     build:
       context: ./ai-service
       dockerfile: Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    user: ${UID:-1000}:${GID:-1000}
     volumes:
       - ./ai-service:/app
       - ./data/db:/data/db
@@ -64,6 +78,10 @@ services:
     build:
       context: ./worker
       dockerfile: Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    user: ${UID:-1000}:${GID:-1000}
     ports:
       - "${WORKER_PORT:-8001}:8001"
     volumes:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -306,11 +306,11 @@ npm run check
   ```
 - Nada parece roto si solo se revisa `make dev` (el contenedor reinicia en bucle).
 
-**Causa:** El contenedor de desarrollo del frontend corre como el usuario `node`
-(uid 1000). `frontend/.svelte-kit` es host-compilado por `svelte-kit` y, si se
-generó (o se tocó) con `sudo` —p. ej. tras `sudo make fix-permissions`—, queda
-propiedad de `root`. En el próximo arranque, `svelte-kit sync` no puede
-reescribir `env.d.ts` y Vite nunca llega a levantar.
+**Causa:** `frontend/.svelte-kit` quedó propiedad de `root` (o de otro UID) en el
+host, por lo que `svelte-kit sync` no puede reescribir `env.d.ts` y Vite nunca
+llega a levantar. Desde #886 los contenedores dev corren con el UID/GID del host,
+así que esto **ya no ocurre en arranques nuevos** — solo aparece en checkouts
+heredados de antes del fix o si se ejecutó `sudo` contra el árbol.
 
 **Solución:**
 
@@ -319,7 +319,8 @@ reescribir `env.d.ts` y Vite nunca llega a levantar.
    ls -la frontend/.svelte-kit | head
    ```
 
-2. Devolverle la propiedad a tu usuario (el healthcheck se apagará solo):
+2. Devolverle la propiedad a tu usuario (limpieza **única**, el healthcheck se
+   apagará solo):
    ```bash
    sudo chown -R "$(id -u):$(id -g)" frontend/.svelte-kit
    ```
@@ -335,8 +336,10 @@ reescribir `env.d.ts` y Vite nunca llega a levantar.
    docker compose logs frontend
    ```
 
-**Prevención:** `make doctor` ya detecta `.svelte-kit` con permisos ridículos
-(propiedad de root / no escribible) antes de levantar la pila.
+**Prevención:** Desde #886 `make dev` pasa tu UID/GID a los contenedores dev, así
+`frontend/.svelte-kit` se genera propiedad de tu usuario y **nunca más** hace falta
+`sudo`. `make fix-permissions` tampoco requiere `sudo`. `make doctor` sigue
+detectando un `.svelte-kit` no escribible (heredado) antes de levantar la pila.
 
 ---
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,8 +9,17 @@ RUN --mount=type=cache,target=/root/.npm npm ci
 RUN chown -R node:node /app
 
 FROM deps AS development
-COPY --chown=node:node . .
-USER node
+# Run the dev server as the host UID/GID (passed via docker-compose.dev.yml build
+# args, defaulting to 1000). With a bind-mounted ./frontend:/app this ensures
+# svelte-kit sync writes frontend/.svelte-kit/* owned by the host user, so no
+# sudo is ever needed to clean them — even when the host UID is not 1000 (#886).
+ARG UID=1000
+ARG GID=1000
+RUN getent group ${GID} >/dev/null || groupadd -g ${GID} appuser \
+ && id -u ${UID} >/dev/null 2>&1 || useradd -u ${UID} -g ${GID} -m -s /bin/bash appuser
+RUN chown -R ${UID}:${GID} /app
+COPY --chown=${UID}:${GID} . .
+USER ${UID}:${GID}
 EXPOSE 3000
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
 

--- a/scripts/fix-permissions.sh
+++ b/scripts/fix-permissions.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
-# Script to fix Joidy project permissions
-# Run this ONCE with: sudo bash scripts/fix-permissions.sh
+# Clean Docker-generated artifacts and fix project permissions.
+#
+# No sudo required: since #886 the dev containers run as the host UID/GID, so
+# bind-mounted artifacts (.svelte-kit, build, __pycache__, data/logs) are owned
+# by the host user and this script can remove them directly.
+#
+# Backward compatibility: if invoked via sudo (e.g. an old `sudo make
+# fix-permissions` muscle memory), it still chowns the tree back to the
+# invoking user — useful to clear legacy root-owned files from pre-#886 checkouts.
+#
+# Usage: bash scripts/fix-permissions.sh   (no sudo needed)
 
 set -e
 
@@ -8,60 +17,65 @@ PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 echo "Project root: $PROJECT_ROOT"
 cd "$PROJECT_ROOT"
 
-echo "Fixing permissions and cleaning Docker-generated artifacts for Joidy..."
-
-# Detect original user (not root)
-if [ -n "$SUDO_USER" ]; then
+# Detect the target user. When run via sudo, prefer the invoking user; otherwise
+# use the current (non-root) user.
+if [ -n "$SUDO_USER" ] && [ "$(id -u)" -eq 0 ]; then
     CURRENT_USER="$SUDO_USER"
+    RUNNING_AS_ROOT=1
 else
     CURRENT_USER=$(whoami)
+    RUNNING_AS_ROOT=0
 fi
+CURRENT_GROUP=$(id -gn "$CURRENT_USER" 2>/dev/null || echo "$CURRENT_USER")
+CURRENT_UID=$(id -u "$CURRENT_USER" 2>/dev/null || id -u)
+CURRENT_GID=$(id -g "$CURRENT_USER" 2>/dev/null || id -g)
 
-# If running as root, try to get the actual user
-if [ "$CURRENT_USER" = "root" ]; then
-    # Try to get the owner of a file in the project
-    CURRENT_USER=$(stat -c '%U' "$PROJECT_ROOT/frontend/package.json" 2>/dev/null) || CURRENT_USER="d4mag3"
-fi
+echo "Target user: $CURRENT_USER ($CURRENT_UID:$CURRENT_GROUP), running as $([ "$RUNNING_AS_ROOT" = 1 ] && echo root || echo non-root)"
 
-CURRENT_GROUP=$(id -gn "$CURRENT_USER" 2>/dev/null || echo "d4mag3")
-
-echo "Target user: $CURRENT_USER, group: $CURRENT_GROUP"
-
-# Remove Python caches that may have been generated as root by Docker containers
+# Remove Python caches (owned by the caller — no sudo needed).
 echo "Removing __pycache__ directories..."
 find "$PROJECT_ROOT" -type d -name "__pycache__" -prune -exec rm -rf {} + 2>/dev/null || true
-
-# Remove coverage data files
 echo "Removing coverage data..."
 find "$PROJECT_ROOT" -name ".coverage" -delete 2>/dev/null || true
 find "$PROJECT_ROOT" -type d -name ".pytest_cache" -prune -exec rm -rf {} + 2>/dev/null || true
 
-# Remove and recreate .svelte-kit directory with correct ownership
-if [ -d "$PROJECT_ROOT/frontend/.svelte-kit" ]; then
-    echo "Removing and recreating .svelte-kit..."
-    rm -rf "$PROJECT_ROOT/frontend/.svelte-kit"
-fi
-
-# Remove build directory
-if [ -d "$PROJECT_ROOT/frontend/build" ]; then
-    echo "Removing build directory..."
-    rm -rf "$PROJECT_ROOT/frontend/build"
-fi
-
-# Create fresh directories
-mkdir -p "$PROJECT_ROOT/frontend/.svelte-kit"
-
-# Fix ownership of project Python/Node directories that may have root-owned files
-echo "Setting ownership to $CURRENT_USER:$CURRENT_GROUP..."
-for dir in api worker ai-service frontend; do
+# Remove and recreate .svelte-kit / build (owned by the caller — no sudo needed).
+for dir in frontend/.svelte-kit frontend/build; do
     if [ -d "$PROJECT_ROOT/$dir" ]; then
-        chown -R $CURRENT_USER:$CURRENT_GROUP "$PROJECT_ROOT/$dir" 2>/dev/null || true
+        echo "Removing $dir..."
+        if [ -w "$PROJECT_ROOT/$dir" ]; then
+            rm -rf "$PROJECT_ROOT/$dir"
+        elif [ "$RUNNING_AS_ROOT" = 1 ]; then
+            rm -rf "$PROJECT_ROOT/$dir"
+        else
+            # Legacy root-owned dir from a pre-#886 checkout: a non-root caller
+            # cannot delete it. Report and let the one-time sudo path handle it.
+            echo "  ⚠ $dir is not writable by $CURRENT_USER (legacy root-owned)."
+            ROOT_OWNED=1
+        fi
     fi
 done
 
-# Set proper permissions for SvelteKit generated directory
+mkdir -p "$PROJECT_ROOT/frontend/.svelte-kit" 2>/dev/null || true
+
+# Fix ownership. As root (sudo) we can chown the whole tree; as a normal user we
+# only chown what we own (best-effort) — which is everything in a post-#886 dev
+# checkout. chown silently skips files the caller doesn't own.
+echo "Setting ownership to $CURRENT_USER:$CURRENT_GROUP..."
+for dir in api worker ai-service frontend; do
+    [ -d "$PROJECT_ROOT/$dir" ] && chown -R "$CURRENT_USER:$CURRENT_GROUP" "$PROJECT_ROOT/$dir" 2>/dev/null || true
+done
+
 chmod -R 755 "$PROJECT_ROOT/frontend/.svelte-kit" 2>/dev/null || true
 chmod -R 755 "$PROJECT_ROOT/frontend/build" 2>/dev/null || true
 
-echo "✓ Permissions and artifacts cleaned for user: $CURRENT_USER"
+if [ "${ROOT_OWNED:-0}" = 1 ]; then
+    echo ""
+    echo "⚠ Found legacy root-owned files (from a pre-#886 checkout)."
+    echo "  One-time cleanup (run once, then never again):"
+    echo "    sudo chown -R \"$CURRENT_UID:$CURRENT_GID\" frontend/.svelte-kit frontend/build"
+    echo "  Future 'make dev' runs will not create root-owned files (#886)."
+else
+    echo "✓ Permissions and artifacts cleaned for user: $CURRENT_USER"
+fi
 echo "Now run: make dev"

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -37,8 +37,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=deps /install /usr/local
 
-# Create non-root user (uid 1000 matches typical host user for dev volume mounts)
-RUN addgroup --system --gid 1000 app && adduser --system --uid 1000 --ingroup app app
+# Create non-root user. Defaults to uid/gid 1000 (matches typical host user).
+# In development, docker-compose.dev.yml passes the host UID/GID as build args
+# so bind-mounted files are written as the host user and never need sudo (#886).
+ARG UID=1000
+ARG GID=1000
+RUN addgroup --system --gid ${GID} app && adduser --system --uid ${UID} --ingroup app app
 
 COPY --chown=app:app . .
 


### PR DESCRIPTION
## Summary

Follow-up to #796 (which fixed only the **production** frontend image). The **development** workflow still hardcoded uid/gid 1000, so for host users with UID ≠ 1000 `svelte-kit sync` wrote `frontend/.svelte-kit/*` owned by uid 1000 and they had to run `sudo make fix-permissions` / `sudo chown` to clean it. The api dev command already had a best-effort `mkdir` workaround for the same UID mismatch (#622).

This makes the dev containers run as the host UID/GID so bind-mounted artifacts are always owned by the host user — **sudo is never needed again**.

### Changes
- `frontend/Dockerfile` (`development` target): `ARG UID/GID` (default 1000), create a matching user, `chown -R /app` (incl. `node_modules`) and `USER` that uid.
- `api/`, `worker/`, `ai-service/` `Dockerfile`: `ARG UID/GID` (default 1000) for the non-root user. **Production images unchanged** (default 1000; prebuilt `d4mag3/joidy-*:latest` are not rebuilt by dev).
- `docker-compose.dev.yml`: `UID`/`GID` build args + `user:` for all 4 services.
- `Makefile`: `HOST_UID`/`HOST_GID` via `$(shell id -u/id -g)` (avoids bash's readonly `UID`) and prefix the `dev`/`dev-d`/`dev-reset` compose commands with them.
- `scripts/fix-permissions.sh` + `make fix-permissions`: no longer require `sudo` (best-effort cleanup of the caller's own files; sudo path kept only for one-time legacy root-owned cleanup from pre-#886 checkouts).
- `make doctor`: stop telling users to `sudo make fix-permissions`; show a one-time `chown` only for legacy root-owned `.svelte-kit`.
- `docs/troubleshooting.md` §3.4 + `AGENTS.md`: document that sudo is no longer the fix.

#### Test plan
- [x] `make lint` passes
- [x] `cd frontend && npm run check` — 0 errors
- [x] Frontend dev image built with `UID=1500 GID=1500` runs as `uid=1500(appuser)`, `/app` and `/app/node_modules` owned by 1500, writable test passes
- [x] API image built with `UID=2000 GID=2000` runs as `uid=2000(app)`
- [x] `bash scripts/fix-permissions.sh` (no sudo) cleans `.svelte-kit` and reports success
- [x] `make doctor` svelte-kit block renders both the writable (green) and non-writable (legacy warning + one-time chown) branches correctly
- [ ] CI: API Lint & Typecheck, Frontend Typecheck, Docker Build, Worker Tests
- [ ] Reviewer: `make dev` on a host with UID ≠ 1000 confirms `frontend/.svelte-kit` is owned by the host user after first start

Closes #886

Generated with [Devin](https://devin.ai)