### PR TITLE
feat(goals): support one-off tasks in goals

### DIFF
--- a/api/alembic/versions/d9a0fdaa6f90_add_oneoff_to_temporality.py
+++ b/api/alembic/versions/d9a0fdaa6f90_add_oneoff_to_temporality.py
@@ -1,0 +1,28 @@
+"""add_oneoff_to_temporality
+
+Revision ID: d9a0fdaa6f90
+Revises: a7b8c9d0e1f2
+Create Date: 2026-08-30 02:16:57.147789
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd9a0fdaa6f90'
+down_revision: Union[str, None] = 'a7b8c9d0e1f2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE goaltemporality ADD VALUE 'ONEOFF'")
+
+
+def downgrade() -> None:
+    # PostgreSQL doesn't support removing values from enum types,
+    # so we just pass.
+    pass

--- a/api/models/goal.py
+++ b/api/models/goal.py
@@ -22,6 +22,7 @@ class GoalTemporality(str, PyEnum):
     WEEKLY = "WEEKLY"
     MONTHLY = "MONTHLY"
     ANNUAL = "ANNUAL"
+    ONEOFF = "ONEOFF"
 
 
 class GoalMeasurement(str, PyEnum):

--- a/api/services/goal_service.py
+++ b/api/services/goal_service.py
@@ -54,6 +54,8 @@ def _parse_temporality(text: str) -> GoalTemporality:
         return GoalTemporality.MONTHLY
     if text in ["anual", "annual"]:
         return GoalTemporality.ANNUAL
+    if text in ["oneoff", "one-off", "unica", "única", "once"]:
+        return GoalTemporality.ONEOFF
     return GoalTemporality.DAILY
 
 def _parse_fail_config(text: str) -> GoalFailConfig:
@@ -241,6 +243,15 @@ def evaluate_active_goals(db: Session):
         elif goal.temporality == GoalTemporality.ANNUAL:
             if today.year != goal.created_at.year:
                 expired = True
+
+        if goal.temporality == GoalTemporality.ONEOFF:
+            progress = progress_by_goal.get(goal.id, 0.0)
+            if progress >= goal.target_value:
+                goal.state = GoalState.COMPLETED
+                goal.is_completed = True
+                goal.completed_at = now
+                goal.current_value = progress
+            continue
 
         if expired:
             _process_goal_failure(db, goal, now, progress_by_goal.get(goal.id))

--- a/api/tests/test_goal_service.py
+++ b/api/tests/test_goal_service.py
@@ -223,5 +223,27 @@ class TestGetGoalStreak(GoalServiceTestBase):
             self.assertEqual(result["best_streak"], 3)
 
 
+class TestEvaluateONEOFFGoals(GoalServiceTestBase):
+    def test_oneoff_goal_completion(self) -> None:
+        with self.Session() as db:
+            goal = Goal(
+                title="One-off Goal",
+                temporality=GoalTemporality.ONEOFF,
+                state=GoalState.ACTIVE,
+                target_value=5.0,
+                current_value=5.0,
+            )
+            db.add(goal)
+            db.commit()
+
+            from services.goal_service import evaluate_active_goals
+            evaluate_active_goals(db)
+            db.refresh(goal)
+
+            self.assertEqual(goal.state, GoalState.COMPLETED)
+            self.assertTrue(goal.is_completed)
+            self.assertIsNotNone(goal.completed_at)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -189,7 +189,7 @@ export interface Goal {
   title: string;
   description: string;
   source_path: string | null;
-  temporality: 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ANNUAL';
+  temporality: 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ANNUAL' | 'ONEOFF';
   measurement_type: 'COUNT' | 'BOOLEAN' | 'PERCENT';
   target_value: number;
   current_value: number;

--- a/frontend/src/lib/utils/goalColors.ts
+++ b/frontend/src/lib/utils/goalColors.ts
@@ -20,6 +20,8 @@ export const GOAL_COLOR_PRESETS: GoalColorPreset[] = [
   { name: 'Slate',     hex: '#64748b' },
 ];
 
+export const GOALS_SPECIFIC_COLOR_PRESETS = GOAL_COLOR_PRESETS.slice(0, 8);
+
 export const DEFAULT_GOAL_COLOR = '#c8a96e';
 
 /** Temporality color mapping — used by goal cards and editors. */
@@ -28,4 +30,5 @@ export const TEMPORALITY_COLORS: Record<string, string> = {
   'WEEKLY':  '#22d3d3',
   'MONTHLY': '#a78bfa',
   'ANNUAL':  '#f59e0b',
+  'ONEOFF':  '#ec4899',
 };

--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -49,7 +49,7 @@
   } from '$lib/utils/userSettings';
   import { logger } from '$lib/utils/logger';
   import {
-    GOAL_COLOR_PRESETS,
+    GOALS_SPECIFIC_COLOR_PRESETS,
     DEFAULT_GOAL_COLOR,
     TEMPORALITY_COLORS,
   } from '$lib/utils/goalColors';
@@ -259,12 +259,13 @@
     ])
   );
 
-  const TEMPORALITIES: Goal['temporality'][] = ['DAILY', 'WEEKLY', 'MONTHLY', 'ANNUAL'];
+  const TEMPORALITIES: Goal['temporality'][] = ['DAILY', 'WEEKLY', 'MONTHLY', 'ANNUAL', 'ONEOFF'];
   const TEMPORALITY_LABELS: Record<string, string> = {
     DAILY: 'Diario',
     WEEKLY: 'Semanal',
     MONTHLY: 'Mensual',
     ANNUAL: 'Anual',
+    ONEOFF: 'Única',
   };
   const STATE_LABELS: Record<string, string> = {
     ACTIVE: 'Activo',
@@ -273,7 +274,7 @@
     FAILED: 'Fallido',
     CANCELLED: 'Cancelado',
   };
-  const COLOR_PRESETS = GOAL_COLOR_PRESETS;
+  const COLOR_PRESETS = GOALS_SPECIFIC_COLOR_PRESETS;
 
   // New goal form
   let newTitle = $state('');

--- a/frontend/src/routes/goals/[id]/+page.svelte
+++ b/frontend/src/routes/goals/[id]/+page.svelte
@@ -6,7 +6,7 @@
   import { logger } from '$lib/utils/logger';
   import LazyIconPicker from '$lib/components/LazyIconPicker.svelte';
   import StreakIcon from '$lib/components/StreakIcon.svelte';
-  import { GOAL_COLOR_PRESETS, DEFAULT_GOAL_COLOR } from '$lib/utils/goalColors';
+  import { GOALS_SPECIFIC_COLOR_PRESETS, DEFAULT_GOAL_COLOR } from '$lib/utils/goalColors';
   import { t } from 'svelte-i18n';
 
   // Lazy-load the heavy GoalEditor (461 lines, pulls in marked, dompurify,
@@ -41,8 +41,8 @@
     '🥇','🥈','🥉','🏆','🎖️','🏅','⭐','🌟','✨','💫','🎊','🎉','🎁'
   ]));
 
-  const TEMPORALITIES: Goal['temporality'][] = ['DAILY', 'WEEKLY', 'MONTHLY', 'ANNUAL'];
-  const COLOR_PRESETS = GOAL_COLOR_PRESETS;
+  const TEMPORALITIES: Goal['temporality'][] = ['DAILY', 'WEEKLY', 'MONTHLY', 'ANNUAL', 'ONEOFF'];
+  const COLOR_PRESETS = GOALS_SPECIFIC_COLOR_PRESETS;
 
   let showSettings = false;
   let settingsSection: 'basics' | 'appearance' | 'advanced' = 'basics';


### PR DESCRIPTION
Closes #891. Adds ONEOFF temporality to goals so they don't expire and auto-complete once the target value is reached.