### PR TITLE
fix(goals): prevent duplicate goal creation when adding objective

### DIFF
--- a/api/routers/goals.py
+++ b/api/routers/goals.py
@@ -233,7 +233,8 @@ def create_goal(data: GoalCreate, db: Session = Depends(get_db)):
             content=note_content,
             tags=[],
             source="joidy",
-            source_path=None
+            source_path=None,
+            sync_goals=False,
         )
         note_id = note.id
 

--- a/api/services/note_service.py
+++ b/api/services/note_service.py
@@ -115,6 +115,7 @@ def create_note(
     source_path: str | None,
     rebuild_derived_data: bool = True,
     from_vault: bool = False,
+    sync_goals: bool = True,
 ):
     title = sanitize_title(title)
     content = sanitize_content(content)
@@ -134,7 +135,8 @@ def create_note(
     gami = process_event(db, event, {"note_id": note.id})
 
     sync_note_links(db, note.id, content)
-    sync_goals_from_note(db, note.id, content)
+    if sync_goals:
+        sync_goals_from_note(db, note.id, content)
     if rebuild_derived_data:
         sync_tag_cooccurrences_for_tags(db, touched_tag_ids)
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -93,6 +93,7 @@ def db_session():
         with engine.connect() as conn:
             conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
             conn.commit()
+        import models  # noqa: F401
         Base.metadata.create_all(engine)
     else:
         engine = create_engine(

--- a/api/tests/test_goal_service.py
+++ b/api/tests/test_goal_service.py
@@ -245,5 +245,17 @@ class TestEvaluateONEOFFGoals(GoalServiceTestBase):
             self.assertIsNotNone(goal.completed_at)
 
 
+class TestGoalCreationNoDuplicates(GoalServiceTestBase):
+    def test_create_goal_does_not_duplicate_entries(self) -> None:
+        with self.Session() as db:
+            from routers.goals import create_goal, GoalCreate
+            data = GoalCreate(title="Single Goal Test", temporality=GoalTemporality.DAILY)
+            result = create_goal(data, db)
+            
+            goals = db.query(Goal).filter(Goal.title == "Single Goal Test").all()
+            self.assertEqual(len(goals), 1)
+            self.assertEqual(goals[0].id, result["id"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #916

## Summary
When creating a new goal (objective) via `POST /goals/`, `create_goal` creates a backing note with content `# Objetivo: <title>`. 

Previously, `create_note_service` triggered `sync_goals_from_note`, which parsed the header and inserted a `Goal` record. Then `create_goal` inserted a second `Goal` record, causing 2 duplicate entries in the database.

## Solution
- Added `sync_goals: bool = True` parameter to `create_note_service` in `api/services/note_service.py`.
- Passed `sync_goals=False` when `create_goal` in `api/routers/goals.py` creates the goal's backing note.
- Added unit test `test_create_goal_does_not_duplicate_entries` in `api/tests/test_goal_service.py`.