### PR TITLE
feat(goals): default untimed goals to ONEOFF (Indefinido) state

### DIFF
--- a/api/routers/goals.py
+++ b/api/routers/goals.py
@@ -40,7 +40,7 @@ class GoalCreate(BaseModel):
     """Schema for creating a new goal."""
     title: str
     description: str = ""
-    temporality: GoalTemporality = GoalTemporality.DAILY
+    temporality: GoalTemporality = GoalTemporality.ONEOFF
     measurement_type: GoalMeasurement = GoalMeasurement.COUNT
     target_value: float = 1.0
     state: GoalState = GoalState.ACTIVE
@@ -147,7 +147,7 @@ class GoalUpdate(BaseModel):
 class GoalContent(BaseModel):
     title: str
     content: str
-    temporality: GoalTemporality = GoalTemporality.DAILY
+    temporality: GoalTemporality = GoalTemporality.ONEOFF
     measurement_type: GoalMeasurement = GoalMeasurement.COUNT
     target_value: float = 1.0
     state: GoalState = GoalState.ACTIVE

--- a/api/services/goal_service.py
+++ b/api/services/goal_service.py
@@ -44,7 +44,7 @@ def validate_goal_parent(db: Session, goal_id: int | None, parent_id: int | None
 
 def _parse_temporality(text: str) -> GoalTemporality:
     if not text:
-        return GoalTemporality.DAILY
+        return GoalTemporality.ONEOFF
     text = text.lower()
     if text in ["diario", "daily"]:
         return GoalTemporality.DAILY
@@ -54,9 +54,9 @@ def _parse_temporality(text: str) -> GoalTemporality:
         return GoalTemporality.MONTHLY
     if text in ["anual", "annual"]:
         return GoalTemporality.ANNUAL
-    if text in ["oneoff", "one-off", "unica", "única", "once"]:
+    if text in ["oneoff", "one-off", "unica", "única", "once", "indefinido", "indefinida"]:
         return GoalTemporality.ONEOFF
-    return GoalTemporality.DAILY
+    return GoalTemporality.ONEOFF
 
 def _parse_fail_config(text: str) -> GoalFailConfig:
     if not text:

--- a/api/tests/test_goal_service.py
+++ b/api/tests/test_goal_service.py
@@ -93,7 +93,7 @@ Some other text here
         content = "# Objetivo: Hacer ejercicio"
         goals = parse_goals_from_content(content)
         self.assertEqual(len(goals), 1)
-        self.assertEqual(goals[0]["temporality"], GoalTemporality.DAILY)
+        self.assertEqual(goals[0]["temporality"], GoalTemporality.ONEOFF)
 
 
 class TestSyncGoalsFromNote(GoalServiceTestBase):

--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -259,13 +259,13 @@
     ])
   );
 
-  const TEMPORALITIES: Goal['temporality'][] = ['DAILY', 'WEEKLY', 'MONTHLY', 'ANNUAL', 'ONEOFF'];
+  const TEMPORALITIES: Goal['temporality'][] = ['ONEOFF', 'DAILY', 'WEEKLY', 'MONTHLY', 'ANNUAL'];
   const TEMPORALITY_LABELS: Record<string, string> = {
+    ONEOFF: 'Indefinido',
     DAILY: 'Diario',
     WEEKLY: 'Semanal',
     MONTHLY: 'Mensual',
     ANNUAL: 'Anual',
-    ONEOFF: 'Única',
   };
   const STATE_LABELS: Record<string, string> = {
     ACTIVE: 'Activo',
@@ -280,7 +280,7 @@
   let newTitle = $state('');
   let newDescription = $state('');
   let newTargetValue = $state(1);
-  let newTemporality = $state<Goal['temporality']>('DAILY');
+  let newTemporality = $state<Goal['temporality']>('ONEOFF');
   let newMeasurement = $state<Goal['measurement_type']>('COUNT');
   let newFailConfig = $state<Goal['fail_config']>('STATIC');
   let newFailEmoji = $state('🔴');


### PR DESCRIPTION
Closes #917

## Summary
Objectives created without an explicit calendar deadline previously defaulted to `DAILY` temporality and `ACTIVE` state, causing them to automatically transition to `FAILED` (red) as soon as the creation calendar day ended.

## Changes
- Updated `GoalCreate` and `GoalContent` schemas in `api/routers/goals.py` to default `temporality` to `GoalTemporality.ONEOFF` (Indefinido).
- Updated `_parse_temporality` fallback in `api/services/goal_service.py` to `GoalTemporality.ONEOFF` and added support for keywords `"indefinido"` and `"indefinida"`.
- Updated frontend goal creation state and labels in `frontend/src/routes/goals/+page.svelte` to default to `ONEOFF` ('Indefinido').
- Updated unit test assertions in `api/tests/test_goal_service.py`.