### PR TITLE
fix(goals): update syntax highlight immediately via rAF in GoalEditor (#936)

### DIFF
--- a/frontend/src/lib/components/GoalEditor.svelte
+++ b/frontend/src/lib/components/GoalEditor.svelte
@@ -67,6 +67,7 @@
   }
   onDestroy(() => {
     if (typeof document !== 'undefined') document.body.classList.remove('zen-mode-active');
+    if (highlightRaf !== null) cancelAnimationFrame(highlightRaf);
   });
 
   $: if (goal) {
@@ -79,7 +80,10 @@
   $: lineCount = Math.max(1, visibleContent.split('\n').length);
   $: lineNumbers = Array.from({ length: lineCount }, (_, i) => i + 1);
 
-  // Debounced content for expensive markdown rendering
+  // Debounced content for the expensive full markdown render (preview mode:
+  // marked + DOMPurify + highlight.js). The editor syntax highlight uses a
+  // faster rAF-based update (see editorHighlightedHtml) so typed text is styled
+  // immediately instead of lagging 300ms (#936).
   let debouncedContent = content;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   $: {
@@ -88,7 +92,6 @@
     debounceTimer = setTimeout(() => {
       debouncedContent = current;
       renderedHtml = renderMarkdown(current);
-      editorHighlightedHtml = highlightMarkdown(current);
     }, 300);
   }
   $: renderedHtml = renderMarkdown(debouncedContent);
@@ -169,7 +172,25 @@
     return html;
   }
 
-  $: editorHighlightedHtml = highlightMarkdown(debouncedContent);
+  // Editor syntax highlight: update on the next animation frame instead of the
+  // 300ms debounce. rAF coalesces multiple keystrokes into a single ~16ms
+  // render, so typed characters are styled immediately without re-running the
+  // regex highlighter more than once per frame (#703, #936).
+  let editorHighlightedHtml = highlightMarkdown(content);
+  let highlightRaf: ReturnType<typeof requestAnimationFrame> | null = null;
+
+  $: {
+    const current = visibleContent;
+    if (typeof requestAnimationFrame === 'function') {
+      if (highlightRaf !== null) cancelAnimationFrame(highlightRaf);
+      highlightRaf = requestAnimationFrame(() => {
+        editorHighlightedHtml = highlightMarkdown(current);
+        highlightRaf = null;
+      });
+    } else {
+      editorHighlightedHtml = highlightMarkdown(current);
+    }
+  }
 </script>
 
 <svelte:window onkeydown={onKeydown} />


### PR DESCRIPTION
Closes #936

### Summary
In `GoalEditor.svelte`, text in the textarea uses `color: transparent` and relies on the `.highlights` backdrop for syntax styling. Previously, `editorHighlightedHtml` was tied to `debouncedContent` with a 300ms timer, causing newly typed characters to appear unstyled or invisible until typing paused.

This brings the exact fix previously implemented in `NoteEditor.svelte` (#703, #708):
- Kept the 300ms debounce for the full expensive Markdown render (`renderedHtml` used in preview mode).
- Switched `editorHighlightedHtml` to update immediately on the next animation frame (`requestAnimationFrame`), coalescing keystrokes per frame (~16ms) without redundant regex runs.
- Cleaned up `highlightRaf` in `onDestroy`.