### PR TITLE
feat(goals): quick delete X button on goal cards with confirmation modal (#913)

### DIFF
--- a/frontend/src/lib/components/GoalCard.svelte
+++ b/frontend/src/lib/components/GoalCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Pin, PinOff, Target, Clock, Tag, FileText, Settings, CheckCircle2, XCircle, Trash2 } from 'lucide-svelte';
+  import { Pin, PinOff, Target, Clock, Tag, FileText, Settings, CheckCircle2, XCircle, Trash2, X } from 'lucide-svelte';
   import StreakIcon from './StreakIcon.svelte';
   import ProgressBar from './ProgressBar.svelte';
   import { getGoalContext } from '$lib/stores/goalContext';
@@ -40,20 +40,6 @@
   // Build Maps for O(1) lookups instead of linear searches
   const tagsMap = new Map(tags.map((t) => [t.id, t]));
   const notesMap = new Map(notes.map((n) => [n.id, n]));
-
-  let deleteConfirming = false;
-  let deleteTimer: ReturnType<typeof setTimeout> | null = null;
-
-  function handleDeleteClick(id: number) {
-    if (!deleteConfirming) {
-      deleteConfirming = true;
-      deleteTimer = setTimeout(() => (deleteConfirming = false), 3000);
-      return;
-    }
-    if (deleteTimer) clearTimeout(deleteTimer);
-    deleteConfirming = false;
-    onDelete?.(id);
-  }
 </script>
 
 <div
@@ -175,12 +161,11 @@
     {#if onDelete}
       <button
         class="card-action-btn delete-btn"
-        class:confirming={deleteConfirming}
-        onclick={(e) => { e.stopPropagation(); handleDeleteClick(goal.id); }}
-        title={deleteConfirming ? 'Haz clic de nuevo para eliminar' : 'Eliminar objetivo'}
+        onclick={(e) => { e.stopPropagation(); onDelete?.(goal); }}
+        title="Eliminar objetivo"
         aria-label="Eliminar objetivo"
       >
-        <Trash2 size={14} />
+        <X size={14} />
       </button>
     {/if}
 
@@ -322,12 +307,6 @@
   .delete-btn:hover {
     color: #ef4444;
     border-color: #ef4444;
-  }
-
-  .delete-btn.confirming {
-    background: #ef4444;
-    border-color: #ef4444;
-    color: #ffffff;
   }
 
   .pin-btn.pinned {

--- a/frontend/src/lib/components/GoalList.svelte
+++ b/frontend/src/lib/components/GoalList.svelte
@@ -20,7 +20,7 @@
     onClick: (goal: Goal) => void;
     onComplete?: (id: number) => void;
     onFail?: (id: number) => void;
-    onDelete?: (id: number) => void;
+    onDelete?: (goal: Goal) => void;
   }
 
   let {

--- a/frontend/src/lib/stores/goalContext.ts
+++ b/frontend/src/lib/stores/goalContext.ts
@@ -17,7 +17,7 @@ export interface GoalContextValue {
   onClick: (goal: Goal) => void;
   onComplete?: (id: number) => void;
   onFail?: (id: number) => void;
-  onDelete?: (id: number) => void;
+  onDelete?: (goal: Goal) => void;
 }
 
 const KEY = Symbol('goal-context');

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -222,7 +222,9 @@
     "color": "Color",
     "keepManual": "Keep as manual progress",
     "cancelArchive": "Cancel (archive without penalty)",
-    "deletePermanent": "Delete permanently"
+    "deletePermanent": "Delete permanently",
+    "deleteGoalConfirmTitle": "Delete goal",
+    "deleteGoalConfirmMessage": "Are you sure you want to delete \"{title}\"? This action is permanent."
   },
   "notesPage": {
     "createNote": "Create note",

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -222,7 +222,9 @@
     "color": "Color",
     "keepManual": "Mantener como progreso manual",
     "cancelArchive": "Cancelar (archivar sin penalización)",
-    "deletePermanent": "Eliminar permanentemente"
+    "deletePermanent": "Eliminar permanentemente",
+    "deleteGoalConfirmTitle": "Eliminar objetivo",
+    "deleteGoalConfirmMessage": "¿Seguro que deseas eliminar \"{title}\"? Esta acción es permanente."
   },
   "notesPage": {
     "createNote": "Crear nota",

--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -276,6 +276,9 @@
   };
   const COLOR_PRESETS = GOALS_SPECIFIC_COLOR_PRESETS;
 
+  // Deletion confirmation modal state
+  let goalToDelete = $state<Goal | null>(null);
+
   // New goal form
   let newTitle = $state('');
   let newDescription = $state('');
@@ -510,6 +513,21 @@
       goals = goals.map((g) => (g.id === id ? result : g));
     } catch (e) {
       logger.error('Error al actualizar estado:', e);
+    }
+  }
+
+  function confirmDeleteGoal(goal: Goal) {
+    goalToDelete = goal;
+  }
+
+  async function handleConfirmDeleteGoal() {
+    if (!goalToDelete) return;
+    try {
+      await api.goals.delete(goalToDelete.id);
+      goals = goals.filter((g) => g.id !== goalToDelete!.id);
+      goalToDelete = null;
+    } catch (e) {
+      logger.error('Error al eliminar objetivo:', e);
     }
   }
 
@@ -2660,9 +2678,38 @@
         onClick={openGoalEditor}
         onComplete={completeGoal}
         onFail={failGoal}
-        onDelete={deleteGoal}
+        onDelete={confirmDeleteGoal}
       />
     </div>
+  {/if}
+
+  {#if goalToDelete}
+    <ModalDialog
+      open={true}
+      title={$t('goalsPage.deleteGoalConfirmTitle')}
+      size="sm"
+      onClose={() => (goalToDelete = null)}
+    >
+      <p style="margin: 0 0 16px; font-size: 14px; line-height: 1.5; color: var(--text-primary);">
+        {$t('goalsPage.deleteGoalConfirmMessage', { values: { title: goalToDelete.title } })}
+      </p>
+      {#snippet footer()}
+        <button
+          type="button"
+          class="btn btn-ghost"
+          onclick={() => (goalToDelete = null)}
+        >
+          {$t('goalsPage.cancel')}
+        </button>
+        <button
+          type="button"
+          class="btn btn-danger"
+          onclick={handleConfirmDeleteGoal}
+        >
+          {$t('goalsPage.delete')}
+        </button>
+      {/snippet}
+    </ModalDialog>
   {/if}
 </div>
 


### PR DESCRIPTION
Closes #913

### Summary
Adds quick deletion capability to goal cards in the Editor grid tab with a modal confirmation dialog:
- Replaces the trash icon with an `X` button (statically imported from `lucide-svelte` per #257) positioned in the card action bar.
- Clicking the `X` button opens a `ModalDialog` confirmation modal with title and message explaining that deletion is permanent.
- Clicking confirm in the modal calls `api.goals.delete(id)` and removes the goal from the local store.
- Adds i18n translation keys (`deleteGoalConfirmTitle`, `deleteGoalConfirmMessage`) in both `es` and `en` common locales.
- Updates `GoalContextValue` and `GoalList` to pass the goal object to `onDelete`.