### PR TITLE
feat(goals): add archiving support, top-left action button, and hover-only card action buttons

### DIFF
--- a/frontend/src/lib/components/GoalCard.svelte
+++ b/frontend/src/lib/components/GoalCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Pin, PinOff, Target, Clock, Tag, FileText, Settings, CheckCircle2, XCircle, Trash2 } from 'lucide-svelte';
+  import { Pin, PinOff, Target, Clock, Tag, FileText, Settings, CheckCircle2, XCircle, Trash2, Archive, ArchiveRestore } from 'lucide-svelte';
   import StreakIcon from './StreakIcon.svelte';
   import ProgressBar from './ProgressBar.svelte';
   import { getGoalContext } from '$lib/stores/goalContext';
@@ -22,6 +22,7 @@
     onComplete: undefined,
     onFail: undefined,
     onDelete: undefined,
+    onArchive: undefined,
   };
   const {
     tags,
@@ -35,6 +36,7 @@
     onComplete,
     onFail,
     onDelete,
+    onArchive,
   } = ctx;
 
   // Build Maps for O(1) lookups instead of linear searches
@@ -61,8 +63,25 @@
   class:completed={goal.state === 'COMPLETED' || goal.is_completed}
   class:failed={goal.state === 'FAILED'}
   class:paused={goal.state === 'PAUSED'}
+  class:archived={goal.state === 'CANCELLED'}
   style="--goal-color: {getGoalColor(goal)}"
 >
+  <div class="card-top-left-actions">
+    <button
+      class="card-action-btn pin-btn"
+      class:pinned
+      onclick={(e) => { e.stopPropagation(); onTogglePin(goal.id); }}
+      title={pinned ? $t('goalCard.unpin') : $t('goalCard.pin')}
+      aria-label={pinned ? $t('goalCard.unpin') : $t('goalCard.pin')}
+    >
+      {#if pinned}
+        <Pin size={14} fill="currentColor" />
+      {:else}
+        <PinOff size={14} />
+      {/if}
+    </button>
+  </div>
+
   <button
     class="goal-card-main"
     onclick={() => onClick(goal)}
@@ -86,6 +105,7 @@
       class:completed={goal.state === 'COMPLETED' || goal.is_completed}
       class:paused={goal.state === 'PAUSED'}
       class:failed={goal.state === 'FAILED'}
+      class:archived={goal.state === 'CANCELLED'}
     >
       {STATE_LABELS[goal.state] || goal.state}
     </div>
@@ -153,8 +173,8 @@
         class="card-action-btn complete-btn"
         class:completed={goal.state === 'COMPLETED' || goal.is_completed}
         onclick={(e) => { e.stopPropagation(); onComplete?.(goal.id); }}
-        title={goal.state === 'COMPLETED' || goal.is_completed ? 'Marcar como pendiente' : 'Completar objetivo'}
-        aria-label="Completar objetivo"
+        title={goal.state === 'COMPLETED' || goal.is_completed ? $t('goalCard.markPending') : $t('goalCard.complete')}
+        aria-label={$t('goalCard.complete')}
       >
         <CheckCircle2 size={14} />
       </button>
@@ -165,10 +185,26 @@
         class="card-action-btn fail-btn"
         class:failed={goal.state === 'FAILED'}
         onclick={(e) => { e.stopPropagation(); onFail?.(goal.id); }}
-        title="Marcar como fallido"
-        aria-label="Marcar como fallido"
+        title={$t('goalCard.fail')}
+        aria-label={$t('goalCard.fail')}
       >
         <XCircle size={14} />
+      </button>
+    {/if}
+
+    {#if onArchive}
+      <button
+        class="card-action-btn archive-btn"
+        class:archived={goal.state === 'CANCELLED'}
+        onclick={(e) => { e.stopPropagation(); onArchive?.(goal.id); }}
+        title={goal.state === 'CANCELLED' ? $t('goalCard.unarchive') : $t('goalCard.archive')}
+        aria-label={goal.state === 'CANCELLED' ? $t('goalCard.unarchive') : $t('goalCard.archive')}
+      >
+        {#if goal.state === 'CANCELLED'}
+          <ArchiveRestore size={14} />
+        {:else}
+          <Archive size={14} />
+        {/if}
       </button>
     {/if}
 
@@ -177,26 +213,12 @@
         class="card-action-btn delete-btn"
         class:confirming={deleteConfirming}
         onclick={(e) => { e.stopPropagation(); handleDeleteClick(goal.id); }}
-        title={deleteConfirming ? 'Haz clic de nuevo para eliminar' : 'Eliminar objetivo'}
-        aria-label="Eliminar objetivo"
+        title={deleteConfirming ? $t('goalCard.deleteConfirm') : $t('goalCard.delete')}
+        aria-label={$t('goalCard.delete')}
       >
         <Trash2 size={14} />
       </button>
     {/if}
-
-    <button
-      class="card-action-btn pin-btn"
-      class:pinned
-      onclick={(e) => { e.stopPropagation(); onTogglePin(goal.id); }}
-      title={pinned ? 'Desfijar' : 'Fijar'}
-      aria-label={pinned ? 'Desfijar objetivo' : 'Fijar objetivo'}
-    >
-      {#if pinned}
-        <Pin size={14} fill="currentColor" />
-      {:else}
-        <PinOff size={14} />
-      {/if}
-    </button>
   </div>
 </div>
 
@@ -251,6 +273,25 @@
     opacity: 0.6;
   }
 
+  .goal-editor-card.archived {
+    border-style: dotted;
+    opacity: 0.55;
+    filter: grayscale(0.25);
+  }
+
+  .card-top-left-actions {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    z-index: 15;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+  }
+
   .card-header {
     display: flex;
     justify-content: center;
@@ -273,8 +314,17 @@
     align-items: center;
     gap: 4px;
     z-index: 15;
-    opacity: 1;
+    opacity: 0;
+    pointer-events: none;
     transition: opacity 0.2s ease;
+  }
+
+  .goal-editor-card:hover .card-actions-bar,
+  .goal-editor-card:hover .card-top-left-actions,
+  .goal-editor-card:focus-within .card-actions-bar,
+  .goal-editor-card:focus-within .card-top-left-actions {
+    opacity: 1;
+    pointer-events: auto;
   }
 
   .card-action-btn {
@@ -317,6 +367,16 @@
     background: var(--error, #ef4444);
     border-color: var(--error, #ef4444);
     color: #ffffff;
+  }
+
+  .archive-btn:hover {
+    color: var(--warning, #f59e0b);
+    border-color: var(--warning, #f59e0b);
+  }
+
+  .archive-btn.archived {
+    background: color-mix(in srgb, var(--warning, #f59e0b) 15%, transparent);
+    color: var(--warning, #f59e0b);
   }
 
   .delete-btn:hover {
@@ -376,6 +436,11 @@
   .goal-state-indicator.failed {
     background: color-mix(in srgb, var(--error) 15%, transparent);
     color: var(--error);
+  }
+
+  .goal-state-indicator.archived {
+    background: color-mix(in srgb, var(--text-muted) 15%, transparent);
+    color: var(--text-muted);
   }
 
   .card-title {

--- a/frontend/src/lib/components/GoalFilters.svelte
+++ b/frontend/src/lib/components/GoalFilters.svelte
@@ -42,9 +42,9 @@
       >{$t('goalFilters.completed')}</button>
       <button
         class="filter-btn"
-        class:active={filter === 'PAUSED'}
-        onclick={() => filter = 'PAUSED'}
-      >{$t('goalFilters.paused')}</button>
+        class:active={filter === 'CANCELLED'}
+        onclick={() => filter = 'CANCELLED'}
+      >{$t('goalFilters.archived')}</button>
       <button
         class="filter-btn"
         class:active={filter === 'FAILED'}

--- a/frontend/src/lib/components/GoalList.svelte
+++ b/frontend/src/lib/components/GoalList.svelte
@@ -21,6 +21,7 @@
     onComplete?: (id: number) => void;
     onFail?: (id: number) => void;
     onDelete?: (id: number) => void;
+    onArchive?: (id: number) => void;
   }
 
   let {
@@ -39,6 +40,7 @@
     onComplete,
     onFail,
     onDelete,
+    onArchive,
   }: Props = $props();
 
   // Set the shared context once so GoalCard can consume tags, notes, callbacks,
@@ -55,6 +57,7 @@
     onComplete,
     onFail,
     onDelete,
+    onArchive,
   });
 
   function filteredGoals(goals: Goal[], query: string, filter: string | null, pinned: Set<number>) {
@@ -74,6 +77,9 @@
       } else {
         result = result.filter(g => g.state === filter);
       }
+    } else {
+      // "Todos" filter (filter === null) excludes archived/cancelled goals
+      result = result.filter(g => g.state !== 'CANCELLED');
     }
     return [...result].sort((a, b) => {
       const aPinned = pinned.has(a.id) ? 0 : 1;

--- a/frontend/src/lib/stores/goalContext.ts
+++ b/frontend/src/lib/stores/goalContext.ts
@@ -18,6 +18,7 @@ export interface GoalContextValue {
   onComplete?: (id: number) => void;
   onFail?: (id: number) => void;
   onDelete?: (id: number) => void;
+  onArchive?: (id: number) => void;
 }
 
 const KEY = Symbol('goal-context');

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -370,7 +370,16 @@
   },
   "goalCard": {
     "openGoal": "Open goal: {title}",
-    "created": "Created: {date}"
+    "created": "Created: {date}",
+    "pin": "Pin",
+    "unpin": "Unpin",
+    "complete": "Complete goal",
+    "markPending": "Mark as pending",
+    "fail": "Mark as failed",
+    "delete": "Delete goal",
+    "deleteConfirm": "Click again to delete",
+    "archive": "Archive goal",
+    "unarchive": "Unarchive goal"
   },
   "deadLetter": {
     "loading": "Loading...",
@@ -445,7 +454,7 @@
     "pinned": "Pinned",
     "active": "Active",
     "completed": "Completed",
-    "paused": "Paused",
+    "archived": "Archived",
     "failed": "Failed"
   },
   "chat": {

--- a/frontend/src/locales/es/common.json
+++ b/frontend/src/locales/es/common.json
@@ -370,7 +370,16 @@
   },
   "goalCard": {
     "openGoal": "Abrir objetivo: {title}",
-    "created": "Creado: {date}"
+    "created": "Creado: {date}",
+    "pin": "Fijar",
+    "unpin": "Desfijar",
+    "complete": "Completar objetivo",
+    "markPending": "Marcar como pendiente",
+    "fail": "Marcar como fallido",
+    "delete": "Eliminar objetivo",
+    "deleteConfirm": "Haz clic de nuevo para eliminar",
+    "archive": "Archivar objetivo",
+    "unarchive": "Desarchivar objetivo"
   },
   "deadLetter": {
     "loading": "Cargando...",
@@ -445,7 +454,7 @@
     "pinned": "Fijados",
     "active": "Activos",
     "completed": "Completados",
-    "paused": "Pausados",
+    "archived": "Archivados",
     "failed": "Fallidos"
   },
   "chat": {

--- a/frontend/src/routes/goals/+page.svelte
+++ b/frontend/src/routes/goals/+page.svelte
@@ -2661,6 +2661,12 @@
         onComplete={completeGoal}
         onFail={failGoal}
         onDelete={deleteGoal}
+        onArchive={(id) => {
+          const target = goals.find((g) => g.id === id);
+          if (target) {
+            updateGoalState(id, target.state === 'CANCELLED' ? 'ACTIVE' : 'CANCELLED');
+          }
+        }}
       />
     </div>
   {/if}


### PR DESCRIPTION
Closes #932

### Changes
- **Archived Goals Filter Tab**: Replaced 'Pausados' filter tab in `GoalFilters` with 'Archivados' (`CANCELLED` state).
- **Hide Archived Goals from 'Todos'**: In `GoalList`, goals with `state === 'CANCELLED'` are filtered out when viewing 'Todos' (`filter === null`), only appearing when selecting the 'Archivados' tab.
- **Top-Left Action Button**: Moved pin control to the top-left corner (`card-top-left-actions`) on goal cards for balanced layout.
- **Hover-Only Action Buttons**: Goal card action bars (both top-left pin and top-right complete/fail/archive/delete buttons) are hidden by default (`opacity: 0; pointer-events: none;`) and smoothly fade in on `:hover` and `:focus-within`.
- **Archive/Unarchive Action**: Added archive/restore action button (`Archive` / `ArchiveRestore` icons) on goal cards, with context-level dispatch to toggle between `CANCELLED` and `ACTIVE` state.
- **Localization**: Added full Spanish and English strings for archived filters and goal card action tooltips.